### PR TITLE
Query functions for FS resize and repair support

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -428,6 +428,8 @@ bd_fs_mount
 bd_fs_unmount
 bd_fs_get_mountpoint
 bd_fs_resize
+bd_fs_repair
+bd_fs_check
 bd_fs_can_resize
 bd_fs_can_check
 bd_fs_can_repair

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -428,6 +428,9 @@ bd_fs_mount
 bd_fs_unmount
 bd_fs_get_mountpoint
 bd_fs_resize
+bd_fs_can_resize
+bd_fs_can_check
+bd_fs_can_repair
 bd_fs_ext2_check
 bd_fs_ext2_get_info
 bd_fs_ext2_info_copy

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -362,6 +362,63 @@ gchar* bd_fs_get_mountpoint (const gchar *device, GError **error);
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
 
 /**
+ * BDFsResizeFlags:
+ * Flags indicating whether a filesystem resize action supports growing and/or
+ * shrinking if mounted or unmounted.
+ */
+typedef enum {
+    BD_FS_OFFLINE_SHRINK = 1 << 1,
+    BD_FS_OFFLINE_GROW = 1 << 2,
+    BD_FS_ONLINE_SHRINK = 1 << 3,
+    BD_FS_ONLINE_GROW = 1 << 4
+} BDFsResizeFlags;
+
+/**
+ * bd_fs_can_resize:
+ * @type: the filesystem type to be tested for installed resize support
+ * @mode: (out): flags for allowed resizing (i.e. growing/shrinking support for online/offline)
+ * @required_utility: (out) (transfer full): the utility binary which is required for resizing (if missing i.e. returns FALSE but no error)
+ * @error: (out): place to store error (if any)
+ *
+ * Searches for the required utility to resize the given filesystem and returns whether
+ * it is installed. The mode flags indicate if growing and/or shrinking resize is available if
+ * mounted/unmounted.
+ * Unknown filesystems or filesystems which do not support resizing result in errors.
+ *
+ * Returns: whether filesystem resize is available
+ */
+gboolean bd_fs_can_resize (const gchar *type, BDFsResizeFlags *mode, gchar **required_utility, GError **error);
+
+/**
+ * bd_fs_can_check:
+ * @type: the filesystem type to be tested for installed consistency check support
+ * @required_utility: (out) (transfer full): the utility binary which is required for checking (if missing i.e. returns FALSE but no error)
+ * @error: (out): place to store error (if any)
+ *
+ * Searches for the required utility to check the given filesystem and returns whether
+ * it is installed.
+ * Unknown filesystems or filesystems which do not support checking result in errors.
+ *
+ * Returns: whether filesystem check is available
+ */
+gboolean bd_fs_can_check (const gchar *type, gchar **required_utility, GError **error);
+
+/**
+ * bd_fs_can_repair:
+ * @type: the filesystem type to be tested for installed repair support
+ * @required_utility: (out) (transfer full): the utility binary which is required for repairing (if missing i.e. return FALSE but no error)
+ * @error: (out): place to store error (if any)
+ *
+ * Searches for the required utility to repair the given filesystem and returns whether
+ * it is installed.
+ * Unknown filesystems or filesystems which do not support reparing result in errors.
+ *
+ * Returns: whether filesystem repair is available
+ */
+gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError **error);
+
+
+/**
  * bd_fs_ext2_mkfs:
  * @device: the device to create a new ext2 fs on
  * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -361,6 +361,32 @@ gchar* bd_fs_get_mountpoint (const gchar *device, GError **error);
  */
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
 
+ /**
+ * bd_fs_repair:
+ * @device: the device the file system of which to repair
+ * @error: (out): place to store error (if any)
+ *
+ * Repair filesystem on @device. This calls other fs repair functions from this
+ * plugin based on detected filesystem (e.g. bd_fs_xfs_repair for XFS). This
+ * function will return an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether the file system on @device was successfully repaired or not
+ */
+gboolean bd_fs_repair (const gchar *device, GError **error);
+
+/**
+ * bd_fs_check:
+ * @device: the device the file system of which to check
+ * @error: (out): place to store error (if any)
+ *
+ * Check filesystem on @device. This calls other fs check functions from this
+ * plugin based on detected filesystem (e.g. bd_fs_xfs_check for XFS). This
+ * function will return an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether the file system on @device passed the consistency check or not
+ */
+gboolean bd_fs_check (const gchar *device, GError **error);
+
 /**
  * BDFsResizeFlags:
  * Flags indicating whether a filesystem resize action supports growing and/or

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -82,6 +82,8 @@ gboolean bd_fs_mount (const gchar *device, const gchar *mountpoint, const gchar 
 gchar* bd_fs_get_mountpoint (const gchar *device, GError **error);
 
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
+gboolean bd_fs_repair (const gchar *device, GError **error);
+gboolean bd_fs_check (const gchar *device, GError **error);
 
 typedef enum {
     BD_FS_OFFLINE_SHRINK = 1 << 1,

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -83,6 +83,17 @@ gchar* bd_fs_get_mountpoint (const gchar *device, GError **error);
 
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
 
+typedef enum {
+    BD_FS_OFFLINE_SHRINK = 1 << 1,
+    BD_FS_OFFLINE_GROW = 1 << 2,
+    BD_FS_ONLINE_SHRINK = 1 << 3,
+    BD_FS_ONLINE_GROW = 1 << 4
+} BDFsResizeFlags;
+
+gboolean bd_fs_can_resize (const gchar *type, BDFsResizeFlags *mode, gchar **required_utility, GError **error);
+gboolean bd_fs_can_check (const gchar *type, gchar **required_utility, GError **error);
+gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError **error);
+
 gboolean bd_fs_ext2_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext2_wipe (const gchar *device, GError **error);
 gboolean bd_fs_ext2_check (const gchar *device, const BDExtraArg **extra, GError **error);

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1097,6 +1097,45 @@ class MountTest(FSTestCase):
             BlockDev.fs_unmount(self.loop_dev, run_as_uid=uid, run_as_gid=gid)
         self.assertTrue(os.path.ismount(tmp))
 
+class GenericCheck(FSTestCase):
+    def _test_generic_check(self, mkfs_function):
+        # clean the device
+        succ = BlockDev.fs_clean(self.loop_dev)
+
+        succ = mkfs_function(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        # check for consistency (expected to be ok)
+        succ = BlockDev.fs_check(self.loop_dev)
+        self.assertTrue(succ)
+
+    def test_ext4_generic_check(self):
+        """Test generic check function with an ext4 file system"""
+        self._test_generic_check(mkfs_function=BlockDev.fs_ext4_mkfs)
+
+    def test_xfs_generic_check(self):
+        """Test generic check function with an ext4 file system"""
+        self._test_generic_check(mkfs_function=BlockDev.fs_xfs_mkfs)
+
+class GenericRepair(FSTestCase):
+    def _test_generic_repair(self, mkfs_function):
+        # clean the device
+        succ = BlockDev.fs_clean(self.loop_dev)
+
+        succ = mkfs_function(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        # repair (expected to succeed)
+        succ = BlockDev.fs_repair(self.loop_dev)
+        self.assertTrue(succ)
+
+    def test_ext4_generic_repair(self):
+        """Test generic repair function with an ext4 file system"""
+        self._test_generic_repair(mkfs_function=BlockDev.fs_ext4_mkfs)
+
+    def test_xfs_generic_repair(self):
+        """Test generic repair function with an xfs file system"""
+        self._test_generic_repair(mkfs_function=BlockDev.fs_xfs_mkfs)
 
 class GenericResize(FSTestCase):
     def _test_generic_resize(self, mkfs_function):

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -844,6 +844,69 @@ class VfatResize(FSTestCase):
         succ = BlockDev.fs_vfat_resize(self.loop_dev, 0)
         self.assertTrue(succ)
 
+class CanResizeRepairCheck(FSTestCase):
+    def test_can_resize(self):
+        """Verify that tooling query works for resize"""
+
+        avail, mode, util = BlockDev.fs_can_resize("ext4")
+        self.assertTrue(avail)
+        self.assertEqual(util, None)
+
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = ""
+        avail, mode, util = BlockDev.fs_can_resize("ext4")
+        os.environ["PATH"] = old_path
+        self.assertFalse(avail)
+        self.assertEqual(util, "resize2fs")
+        self.assertEqual(mode, BlockDev.FsResizeFlags.ONLINE_GROW |
+                               BlockDev.FsResizeFlags.OFFLINE_GROW |
+                               BlockDev.FsResizeFlags.OFFLINE_SHRINK)
+
+        avail = BlockDev.fs_can_resize("vfat")
+        self.assertTrue(avail)
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_can_resize("nilfs2")
+
+    def test_can_repair(self):
+        """Verify that tooling query works for repair"""
+
+        avail, util = BlockDev.fs_can_repair("xfs")
+        self.assertTrue(avail)
+        self.assertEqual(util, None)
+
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = ""
+        avail, util = BlockDev.fs_can_repair("xfs")
+        os.environ["PATH"] = old_path
+        self.assertFalse(avail)
+        self.assertEqual(util, "xfs_repair")
+
+        avail = BlockDev.fs_can_repair("vfat")
+        self.assertTrue(avail)
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_can_repair("nilfs2")
+
+    def test_can_check(self):
+        """Verify that tooling query works for consistency check"""
+
+        avail, util = BlockDev.fs_can_check("xfs")
+        self.assertTrue(avail)
+        self.assertEqual(util, None)
+
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = ""
+        avail, util = BlockDev.fs_can_check("xfs")
+        os.environ["PATH"] = old_path
+        self.assertFalse(avail)
+        self.assertEqual(util, "xfs_db")
+
+        avail = BlockDev.fs_can_check("vfat")
+        self.assertTrue(avail)
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_can_check("nilfs2")
 
 class MountTest(FSTestCase):
 


### PR DESCRIPTION
The FS plugin functions bd_fs_can_resize/check/repair
can be used to test for installed utility and FS support
before starting the action or exposing it in an UI.

Maybe you can give me feedback on this - I intend to use it in UDisks. It already has a value e.g. because it could be called to see if resize is supported by the generic resize method.

But to make it more meaningful the check_deps() would need to not already fail if e.g. xfs_db is missing. Currently this requires UDisks to depend on xfsprogs and if other filesystems like ntfs would be supported in FS plugin they all would need to be dependencies if check_deps() will remain strict. Through these functions the caller could query for support and there is no need for a hard dependency. But this would be another PR.