### PR TITLE
Add partition resize function

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -389,6 +389,7 @@ BDPartDiskSpec
 bd_part_create_table
 bd_part_create_part
 bd_part_delete_part
+bd_part_resize_part
 bd_part_get_disk_parts
 bd_part_get_part_spec
 bd_part_set_part_flag

--- a/src/lib/plugin_apis/part.api
+++ b/src/lib/plugin_apis/part.api
@@ -284,6 +284,20 @@ BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 
 gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **error);
 
 /**
+ * bd_part_resize_part:
+ * @disk: disk containing the paritition
+ * @part: partition to resize
+ * @size: new partition size, 0 for maximal size
+ * @align: alignment to use for the partition end
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @part partition was successfully resized on @disk to @size
+ *
+ * NOTE: The resulting partition may be slightly bigger than requested due to alignment.
+ */
+gboolean bd_part_resize_part (const gchar *disk, const gchar *part, guint64 size, BDPartAlign align, GError **error);
+
+/**
  * bd_part_set_part_flag:
  * @disk: disk the partition belongs to
  * @part: partition to set the flag on

--- a/src/plugins/part.h
+++ b/src/plugins/part.h
@@ -117,6 +117,7 @@ BDPartSpec* bd_part_get_best_free_region (const gchar *disk, BDPartType type, gu
 
 BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error);
 gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **error);
+gboolean bd_part_resize_part (const gchar *disk, const gchar *part, guint64 size, BDPartAlign align, GError **error);
 
 gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag flag, gboolean state, GError **error);
 gboolean bd_part_set_disk_flag (const gchar *disk, BDPartDiskFlag flag, gboolean state, GError **error);


### PR DESCRIPTION
The new function bd_part_resize_part allows to
change the size of a partition and guarantees
that it does not move and has at least the requested
size allocated. It also supports resizing to maximum.

Should I write tests as well or is it anyway better if they are not written by the one writing the code?