### PR TITLE
Add functions for opening/closing TrueCrypt/VeraCrypt volumes

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -77,6 +77,8 @@ bd_crypto_luks_remove_key_blob
 bd_crypto_luks_change_key
 bd_crypto_luks_change_key_blob
 bd_crypto_luks_resize
+bd_crypto_tc_open
+bd_crypto_tc_close
 bd_crypto_escrow_device
 </SECTION>
 

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -239,6 +239,28 @@ gboolean bd_crypto_luks_change_key_blob (const gchar *device, const guint8 *pass
 gboolean bd_crypto_luks_resize (const gchar *luks_device, guint64 size, GError **error);
 
 /**
+ * bd_crypto_tc_open:
+ * @device: the device to open
+ * @name: name for the TrueCrypt/VeraCrypt device
+ * @pass_data: (array length=data_len): a passphrase for the TrueCrypt/VeraCrypt volume (may contain arbitrary binary data)
+ * @data_len: length of the @pass_data buffer
+ * @read_only: whether to open as read-only or not (meaning read-write)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully opened or not
+ */
+gboolean bd_crypto_tc_open (const gchar *device, const gchar *name, const guint8* pass_data, gsize data_len, gboolean read_only, GError **error);
+
+/**
+ * bd_crypto_tc_close:
+ * @tc_device: TrueCrypt/VeraCrypt device to close
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the given @tc_device was successfully closed or not
+ */
+gboolean bd_crypto_tc_close (const gchar *tc_device, GError **error);
+
+/**
  * bd_crypto_escrow_device:
  * @device: path of the device to create escrow data for
  * @passphrase: passphrase used for the device

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -61,6 +61,10 @@ gboolean bd_crypto_luks_remove_key_blob (const gchar *device, const guint8 *pass
 gboolean bd_crypto_luks_change_key (const gchar *device, const gchar *pass, const gchar *npass, GError **error);
 gboolean bd_crypto_luks_change_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, const guint8 *npass_data, gsize ndata_len, GError **error);
 gboolean bd_crypto_luks_resize (const gchar *device, guint64 size, GError **error);
+
+gboolean bd_crypto_tc_open (const gchar *device, const gchar *name, const guint8* pass_data, gsize data_len, gboolean read_only, GError **error);
+gboolean bd_crypto_tc_close (const gchar *tc_device, GError **error);
+
 gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, const gchar *cert_data, const gchar *directory, const gchar *backup_passphrase, GError **error);
 
 #endif  /* BD_CRYPTO */


### PR DESCRIPTION
So that people can use libblockdev to work with their encrypted
devices using TrueCrypt/VeraCrypt.

Resolves: #200 

note: I have only manually tested the functionality because it's practically impossible to create a TrueCrypt/VeraCrypt volume for tests.