### PR TITLE
Compile everything with the C99 standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,5 +178,7 @@ AS_IF([test "x$with_btrfs" != "xno" -o "x$with_mdraid" != "xno"],
 AC_SUBST([skip_patterns], [$skip_patterns])
 AC_SUBST([MAJOR_VER], [\"2\"])
 
+CFLAGS="$CFLAGS -std=gnu99"
+
 AC_OUTPUT
 LIBBLOCKDEV_FAILURES

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -550,7 +550,6 @@ gint bd_utils_version_cmp (const gchar *ver_string1, const gchar *ver_string2, G
     guint64 v2_value = 0;
     GRegex *regex = NULL;
     gboolean success = FALSE;
-    guint i = 0;
     gint ret = -2;
 
     regex = g_regex_new ("^(\\d+)(\\.\\d+)*(-\\d)?$", 0, 0, error);
@@ -578,7 +577,7 @@ gint bd_utils_version_cmp (const gchar *ver_string1, const gchar *ver_string2, G
     v1_fields_len = g_strv_length (v1_fields);
     v2_fields_len = g_strv_length (v2_fields);
 
-    for (i=0; (i < v1_fields_len) && (i < v2_fields_len) && ret == -2; i++) {
+    for (guint i=0; (i < v1_fields_len) && (i < v2_fields_len) && ret == -2; i++) {
         v1_value = g_ascii_strtoull (v1_fields[i], NULL, 0);
         v2_value = g_ascii_strtoull (v2_fields[i], NULL, 0);
         if (v1_value < v2_value)


### PR DESCRIPTION
It supports some nice extra features like declaring variables for
'for' cycles just in/for the cycles. Let's check the change works
by doing exactly that at least in one place (and all future
code).

Please note that '-std=c99' doesn't work for us because we are
obviously using some GNU extensions. So we must use '-std=gnu99'.