### PR TITLE
Query setting FS label support and generic relabeling

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -430,9 +430,11 @@ bd_fs_get_mountpoint
 bd_fs_resize
 bd_fs_repair
 bd_fs_check
+bd_fs_set_label
 bd_fs_can_resize
 bd_fs_can_check
 bd_fs_can_repair
+bd_fs_can_set_label
 bd_fs_ext2_check
 bd_fs_ext2_get_info
 bd_fs_ext2_info_copy

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -388,6 +388,19 @@ gboolean bd_fs_repair (const gchar *device, GError **error);
 gboolean bd_fs_check (const gchar *device, GError **error);
 
 /**
+ * bd_fs_set_label:
+ * @device: the device with file system to set the label for
+ * @error: (out): place to store error (if any)
+ *
+ * Set label for filesystem on @device. This calls other fs label functions from this
+ * plugin based on detected filesystem (e.g. bd_fs_xfs_set_label for XFS). This
+ * function will return an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether the file system on @device was successfully relabled or not
+ */
+gboolean bd_fs_set_label (const gchar *device, const gchar *label, GError **error);
+
+/**
  * BDFsResizeFlags:
  * Flags indicating whether a filesystem resize action supports growing and/or
  * shrinking if mounted or unmounted.
@@ -443,6 +456,19 @@ gboolean bd_fs_can_check (const gchar *type, gchar **required_utility, GError **
  */
 gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError **error);
 
+/**
+ * bd_fs_can_set_label:
+ * @type: the filesystem type to be tested for installed label support
+ * @required_utility: (out) (transfer full): the utility binary which is required for relabeling (if missing i.e. return FALSE but no error)
+ * @error: (out): place to store error (if any)
+ *
+ * Searches for the required utility to set the label of the given filesystem and returns whether
+ * it is installed.
+ * Unknown filesystems or filesystems which do not support setting the label result in errors.
+ *
+ * Returns: whether setting filesystem label is available
+ */
+gboolean bd_fs_can_set_label (const gchar *type, gchar **required_utility, GError **error);
 
 /**
  * bd_fs_ext2_mkfs:

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -84,6 +84,7 @@ gchar* bd_fs_get_mountpoint (const gchar *device, GError **error);
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
 gboolean bd_fs_repair (const gchar *device, GError **error);
 gboolean bd_fs_check (const gchar *device, GError **error);
+gboolean bd_fs_set_label (const gchar *device, const gchar *label, GError **error);
 
 typedef enum {
     BD_FS_OFFLINE_SHRINK = 1 << 1,
@@ -95,6 +96,7 @@ typedef enum {
 gboolean bd_fs_can_resize (const gchar *type, BDFsResizeFlags *mode, gchar **required_utility, GError **error);
 gboolean bd_fs_can_check (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError **error);
+gboolean bd_fs_can_set_label (const gchar *type, gchar **required_utility, GError **error);
 
 gboolean bd_fs_ext2_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext2_wipe (const gchar *device, GError **error);


### PR DESCRIPTION
Introduces bd_fs_can_set_label to query for installed
tooling. Adds the generic function bd_fs_set_label to
set the filesystem label of a device.

The test case for XFS fails if a space is contained like "new label" - what's wrong there?