### PR TITLE
Allow non-source directory builds and no-plugin builds

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,16 @@
 #!/bin/bash -e
-[ -d m4 ] || mkdir m4
-libtoolize --copy --force
-aclocal -I m4
-autoconf
-automake --foreign --add-missing --copy
-rm -rf autom4te.cache
+test -n "$srcdir" || srcdir=`dirname "$0"`
+test -n "$srcdir" || srcdir=.
+
+pushd $srcdir
+
+(test -f configure.ac) || {
+        echo "*** ERROR: Directory "\`$srcdir\'" does not look like the top-level project directory ***"
+        exit 1
+}
+
+PKG_NAME=`autoconf --trace 'AC_INIT:$1' configure.ac`
+
+aclocal --install || exit 1
+autoreconf --verbose --force --install -Wno-portability || exit 1
+popd

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -3,8 +3,8 @@
 SUBDIRS = plugin_apis
 
 lib_LTLIBRARIES = libblockdev.la
-libblockdev_la_CFLAGS = $(GLIB_CFLAGS)
-libblockdev_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la -ldl
+libblockdev_la_CFLAGS = $(GLIB_CFLAGS) $(GOBJECT_CFLAGS)
+libblockdev_la_LIBADD = $(GLIB_LIBS) $(GOBJECT_LIBS) ${builddir}/../utils/libbd_utils.la -ldl
 
 if WITH_BTRFS
 libblockdev_la_CFLAGS += $(GOBJECT_CFLAGS)


### PR DESCRIPTION
Hello,

what do you think about that?
This enables to build with e.g. jhbuild/gnome-continuous. The autogen.sh comes from GNOME Disks and could be improved I guess(?). I also ran into a linking error if all plugins were disabled.

Best regards,
Kai