### PR TITLE
Specify tolerance for partition size

### DIFF
--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -732,12 +732,16 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
     PedSector max_end;
     PedSector new_size = 0;
     gint status = 0;
+    PedSector tolerance = 0;
 
-    /* it should be possible to pass the whole drive size a partition size,
+    /* It should be possible to pass the whole drive size a partition size,
      * so -1 MiB for the first partition alignment,
      * -1 MiB for creating this here as a logial partition
-     * and -1 MiB for end alingment */
-    const PedSector tolerance = (PedSector) (4 MiB /  dev->sector_size);
+     * and -1 MiB for end alingment.
+     * But only if the caller doesn't request no alignment which also means
+     * they strictly care about precise numbers. */
+    if (align != BD_PART_ALIGN_NONE)
+        tolerance = (PedSector) (4 MiB /  dev->sector_size);
 
     constr = prepare_alignment_constraint (dev, disk, align, &orig_flag_state);
     start = part->geom.start;

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -729,8 +729,14 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
     gint orig_flag_state = 0;
     PedSector start;
     PedSector end;
+    PedSector max_end;
     PedSector new_size = 0;
     gint status = 0;
+    /* it should be possible to pass the whole drive size a partition size,
+     * so -1 MiB for the first partition alignment,
+     * -1 MiB for creating this here as a logial partition
+     * and -1 MiB for end alingment */
+    const PedSector tolerance = (PedSector) (4 MiB /  dev->sector_size);
 
     constr = prepare_alignment_constraint (dev, disk, align, &orig_flag_state);
     start = part->geom.start;
@@ -753,6 +759,7 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
         new_size = (size + dev->sector_size - 1) / dev->sector_size;
     }
 
+    max_end = geom->end;
     ped_geometry_destroy (geom);
     geom = ped_geometry_new (dev, start, new_size);
     if (!geom) {
@@ -763,12 +770,23 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
         return FALSE;
     }
 
-    if (size != 0)
+    if (size != 0) {
         end = ped_alignment_align_up (constr->end_align, constr->end_range, geom->end);
-    else
+        if (end > max_end && end < max_end + tolerance) {
+            end = max_end;
+        }
+    } else {
         end = geom->end;
-
+    }
     ped_constraint_destroy (constr);
+    if (!ped_geometry_set_end (geom, end)) {
+       set_parted_error (error, BD_PART_ERROR_FAIL);
+       g_prefix_error (error, "Failed to change geometry for partition on device '%s'", dev->path);
+       ped_constraint_destroy (constr);
+       ped_geometry_destroy (geom);
+       finish_alignment_constraint (disk, orig_flag_state);
+       return FALSE;
+    }
     constr = ped_constraint_exact (geom);
     status = ped_disk_set_partition_geom (disk, part, constr, start, end);
 
@@ -779,8 +797,14 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
         ped_constraint_destroy (constr);
         finish_alignment_constraint (disk, orig_flag_state);
         return FALSE;
-    } else if (part->geom.start != start || part->geom.length < new_size) {
-        g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_FAIL, "Failed to meet correct partition size on device '%s'", dev->path);
+    } else if (part->geom.start != start) {
+        g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_FAIL, "Failed to meet partition start on device '%s'", dev->path);
+        ped_geometry_destroy (geom);
+        ped_constraint_destroy (constr);
+        finish_alignment_constraint (disk, orig_flag_state);
+        return FALSE;
+    } else if (part->geom.length < new_size - tolerance) {
+        g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_FAIL, "Failed to meet partition size on device '%s'", dev->path);
         ped_geometry_destroy (geom);
         ped_constraint_destroy (constr);
         finish_alignment_constraint (disk, orig_flag_state);

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -825,8 +825,8 @@ static PedPartition* add_part_to_disk (PedDevice *dev, PedDisk *disk, BDPartType
         return NULL;
     }
 
-    ped_constraint_destroy (constr);
-    constr = ped_constraint_exact (geom);
+    if (!constr)
+        constr = ped_constraint_exact (geom);
 
     status = ped_disk_add_partition (disk, part, constr);
     if (status == 0) {

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -732,6 +732,7 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
     PedSector max_end;
     PedSector new_size = 0;
     gint status = 0;
+
     /* it should be possible to pass the whole drive size a partition size,
      * so -1 MiB for the first partition alignment,
      * -1 MiB for creating this here as a logial partition
@@ -758,6 +759,11 @@ static gboolean resize_part (PedPartition *part, PedDevice *dev, PedDisk *disk, 
     } else {
         new_size = (size + dev->sector_size - 1) / dev->sector_size;
     }
+
+    /* If the maximum partition geometry is smaller than the requested size, but
+       the difference is acceptable, just adapt the size. */
+    if (new_size > geom->length && (new_size - geom->length) < tolerance)
+        new_size = geom->length;
 
     max_end = geom->end;
     ped_geometry_destroy (geom);

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -212,6 +212,31 @@ class PartCreatePartCase(PartTestCase):
         self.assertEqual(ps.flags, ps3.flags)
 
 class PartCreatePartFullCase(PartTestCase):
+    def test_full_device_partition(self):
+        # we first need a partition table
+        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        self.assertTrue(succ)
+
+        # create partition spanning whole device even disregarding the partition table (loop_dev size)
+        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 0, 100 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        self.assertTrue(succ)
+
+        # same, but create a maximal partition automatically
+        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 0, 0, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        self.assertTrue(succ)
+
+        # start at byte 1 and create partition spanning whole device explicitly
+        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 1, 100 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        self.assertTrue(succ)
+
+        # start at byte 1 and create a maximal partition automatically
+        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 1, 0, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        self.assertTrue(succ)
+
     def test_create_part_all_primary(self):
         """Verify that partition creation works as expected with all primary parts"""
 


### PR DESCRIPTION
*Note: This PR was created as an extension of the PR #253 with two extra commits fixing the behavior on RHEL/CentOS7 and making things a bit more strict.*

If the caller of the partition creation and
resize functions is not aware of size reductions
due to alignment it should still be able to give
the theoretical free space as size argument.
This should be possible by a 3 MiB tolerance which
the final partition is allowed to be smaller.

This is to make it easier for an application that should rather use '0' to still be able to pass e.g. the device size to create one big partition.