### PR TITLE
Use new libmount function to get (un)mount error message

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,10 +152,9 @@ AS_IF([test "x$with_part" != "xno" -o "x$with_fs" != "xno"],
 
 AS_IF([test "x$with_fs" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([MOUNT], [mount >= 2.23.0])
-       # new versions of libmount behave differently -- do RO mount in case of
-       # RW mount fails by default
+       # new versions of libmount has some new functions we can use
        AS_IF([$PKG_CONFIG --atleast-version=2.30.0 mount],
-             [AC_DEFINE([LIBMOUNT_RO_FALLBACK])], [])
+             [AC_DEFINE([LIBMOUNT_NEW_ERR_API])], [])
 
        LIBBLOCKDEV_PKG_CHECK_MODULES([BLKID], [blkid >= 2.23.0])
        # older versions of libblkid don't support BLKID_SUBLKS_BADCSUM so let's just


### PR DESCRIPTION
We can use a new function "mnt_context_get_excode" to get error
code and error message when (un)mounting a device. This is
available since libmount 2.30