### PR TITLE
Keep most utilities available for tests

### DIFF
--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -580,7 +580,7 @@ class BTRFSUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="btrfs"):
             # no btrfs tool available, the BTRFS plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)

--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -109,7 +109,7 @@ class DMUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="dmsetup"):
             # no dmsetup available, the DM plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -515,7 +515,7 @@ class KbdUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="make-bcache"):
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)
 

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1280,7 +1280,7 @@ class LVMUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="lvm"):
             # no lvm tool available, the LVM plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -635,8 +635,8 @@ class MDUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
-            # no mdsetup available, the MD plugin should fail to load
+        with fake_path(all_but="mdadm"):
+            # no mdadm available, the MD plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)
 

--- a/tests/mpath_test.py
+++ b/tests/mpath_test.py
@@ -61,7 +61,7 @@ class MpathUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="multipath"):
             # no multipath available, the mpath plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)
@@ -78,7 +78,7 @@ class MpathUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path("tests/mpath_no_mpathconf", keep_utils=["cat"]):
+        with fake_path(all_but="mpathconf"):
             # no mpathconf available, the mpath plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)

--- a/tests/s390_test.py
+++ b/tests/s390_test.py
@@ -79,7 +79,7 @@ class S390UnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="dasdfmt"):
             # dasdfmt is not available, so the s390 plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -110,7 +110,7 @@ class SwapUnloadTest(unittest.TestCase):
         # unload all plugins first
         self.assertTrue(BlockDev.reinit([], True, None))
 
-        with fake_path():
+        with fake_path(all_but="mkswap"):
             # no mkswap available, the swap plugin should fail to load
             with self.assertRaises(GLib.GError):
                 BlockDev.reinit(None, True, None)


### PR DESCRIPTION
We only need to make sure specific utilities are not available in
the tests that require so. Otherwise we are getting many warnings
for missing utilities in the tests.

Resolves: #203