### PR TITLE
Add a way to disable runtime dependency checks

### DIFF
--- a/scripts/boilerplate_generator.py
+++ b/scripts/boilerplate_generator.py
@@ -226,7 +226,7 @@ def get_loading_func(fn_infos, module_name):
     ret += '    * (void**) (&check_fn) = dlsym(handle, "bd_{0}_check_deps");\n'.format(MOD_FNAME_OVERRIDES.get(module_name, module_name))
     ret += '    if ((error = dlerror()) != NULL)\n'
     ret += '        g_debug("failed to load the check() function for {0}: %s", error);\n'.format(module_name)
-    ret += '    if (check_fn && !check_fn()) {\n'
+    ret += '    if (!g_getenv ("LIBBLOCKDEV_SKIP_DEP_CHECKS") && check_fn && !check_fn()) {\n'
     ret += '        dlclose(handle);\n'
     ret += '        return NULL;\n'
     ret += '    }'

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -358,3 +358,18 @@ class LibraryOpsTestCase(unittest.TestCase):
         else:
             del os.environ["LANG"]
         self.assertTrue(BlockDev.reinit(None, True, None))
+
+    def test_dep_checks_disabled(self):
+        """Verify that disabling runtime dep checks works"""
+
+        with fake_path(all_but="mkswap"):
+            # should fail because of 'mkswap' missing
+            with self.assertRaises(GLib.GError):
+                BlockDev.reinit(None, True, None)
+
+        os.environ["LIBBLOCKDEV_SKIP_DEP_CHECKS"] = ""
+        self.addCleanup(os.environ.pop, "LIBBLOCKDEV_SKIP_DEP_CHECKS")
+
+        with fake_path(all_but="mkswap"):
+            # should load just fine, skipping the runtime dep checks
+            self.assertTrue(BlockDev.reinit(None, True, None))


### PR DESCRIPTION
Sometimes it's undesirable to do strict dependency checks, especially right at the beginning when the library is being initialized. The dependencies may for example be installed later, right before or after the functionality requiring them is used for the first time.

Resolves: #248 

*Note: this includes a patch from #259 as it makes the ``fake_path()`` context manager more versatile and we are making use of it here*