### PR TITLE
fix a clang compiling issue

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -881,7 +881,7 @@ gboolean bd_crypto_tc_open (const gchar *device, const gchar *name, const guint8
     gint ret = 0;
     guint64 progress_id = 0;
     gchar *msg = NULL;
-    struct crypt_params_tcrypt params = {0};
+    struct crypt_params_tcrypt params = {NULL,0,NULL,0,NULL,NULL,NULL,0,0};
 
     msg = g_strdup_printf ("Started opening '%s' TrueCrypt/VeraCrypt device", device);
     progress_id = bd_utils_report_started (msg);
@@ -999,7 +999,7 @@ static gchar *replace_char (gchar *str, gchar orig, gchar new) {
     return str;
 }
 
-static gboolean write_escrow_data_file (struct libvk_volume *volume, struct libvk_ui *ui, enum libvk_packet_format format, const gchar *out_path,
+static gboolean write_escrow_data_file (struct libvk_volume *volume, struct libvk_ui *ui, enum libvk_secret secret_type, const gchar *out_path,
                                         CERTCertificate *cert, GError **error) {
     gpointer packet_data = NULL;
     gsize packet_data_size = 0;
@@ -1008,7 +1008,7 @@ static gboolean write_escrow_data_file (struct libvk_volume *volume, struct libv
     gsize bytes_written = 0;
     GError *tmp_error = NULL;
 
-    packet_data = libvk_volume_create_packet_asymmetric_with_format (volume, &packet_data_size, format, cert,
+    packet_data = libvk_volume_create_packet_asymmetric_with_format (volume, &packet_data_size, secret_type, cert,
                                                                      ui, LIBVK_PACKET_FORMAT_ASYMMETRIC_WRAP_SECRET_ONLY, error);
 
     if (!packet_data) {

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -2614,8 +2614,8 @@ BDFSVfatInfo* bd_fs_vfat_get_info (const gchar *device, GError **error) {
  */
 gboolean bd_fs_vfat_resize (const gchar *device, guint64 new_size, GError **error) {
     PedDevice *ped_dev = NULL;
-    PedGeometry geom = {0};
-    PedGeometry new_geom = {0};
+    PedGeometry geom = {NULL, 0, 0, 0};
+    PedGeometry new_geom = {NULL, 0, 0, 0};
     PedFileSystem *fs = NULL;
     PedSector start = 0;
     PedSector length = 0;

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -849,7 +849,7 @@ static PedPartition* add_part_to_disk (PedDevice *dev, PedDisk *disk, BDPartType
         return NULL;
     }
 
-    part = ped_partition_new (disk, type, NULL, geom->start, geom->end);
+    part = ped_partition_new (disk, (PedPartitionType)type, NULL, geom->start, geom->end);
     if (!part) {
         set_parted_error (error, BD_PART_ERROR_FAIL);
         g_prefix_error (error, "Failed to create new partition on device '%s'", dev->path);
@@ -1427,7 +1427,7 @@ gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 f
     PedPartition *ped_part = NULL;
     const gchar *part_num_str = NULL;
     gint part_num = 0;
-    guint64 i = 0;
+    int i = 0;
     gint status = 0;
     gboolean ret = FALSE;
     guint64 progress_id = 0;

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -354,7 +354,7 @@ gboolean bd_utils_exec_and_report_progress (const gchar **argv, const BDExtraArg
     GIOStatus io_status = G_IO_STATUS_NORMAL;
     guint i = 0;
     guint8 completion = 0;
-    GPollFD fds[2] = {{0}, {0}};
+    GPollFD fds[2] = {{0,0,0}, {0,0,0}};
     gboolean out_done = FALSE;
     gboolean err_done = FALSE;
     GString *stdout_data = g_string_new (NULL);


### PR DESCRIPTION
[snip]
../../../git/src/plugins/fs.c:2617:26: error: missing field 'start'
initializer [-Werror,-Wmissing-field-initializers]
    PedGeometry geom = {0};
                         ^
../../../git/src/plugins/fs.c:2618:30: error: missing field 'start'
initializer [-Werror,-Wmissing-field-initializers]
    PedGeometry new_geom = {0};
[snip]

Fix typo s/enum libvk_packet_format format/enum libvk_secret secret_type/

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>