### PR TITLE
Make sure the device is opened for libparted

### DIFF
--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -196,6 +196,14 @@ static gboolean disk_commit (PedDisk *disk, const gchar *path, GError **error) {
        chance things will just work. If not, an error will be reported
        anyway with no harm. */
 
+    /* XXX: Sometimes it happens that when we try to commit the partition table
+       to disk below, libparted kills the process due to the
+       assert(disk->dev->open_count > 0). This looks like a bug to me, but we
+       have no reproducer for it. Let's just try to (re)open the device in such
+       cases. It is later closed by the ped_device_destroy() call. */
+    if (disk->dev->open_count <= 0)
+        ped_device_open (disk->dev);
+
     ret = ped_disk_commit_to_dev (disk);
     if (ret == 0) {
         set_parted_error (error, BD_PART_ERROR_FAIL);


### PR DESCRIPTION
Sometimes it magically happens that libparted kills the whole
process trying to create a partition due to the

  assert(disk->dev->open_count > 0)

Which should obviously never happen because we are never opening
or closing the device explicitly just by means of
ped_device_get() and ped_device_destroy(). So this is probably a
bug in libparted, but we have no reproducer for it.

Let's just try to make sure the device is opened while we are
trying to commit the new partition table to it.