### PR TITLE
Use system values in KbdTestBcacheStatusTest

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -192,7 +192,7 @@ AS_IF([test "x$with_fs" != "xno"],
               AC_SUBST([PARTED_FS_CFLAGS], [])])],
       [])
 
-AS_IF([test "x$with_btrfs" != "xno" -o "x$with_mdraid" != "xno"],
+AS_IF([test "x$with_btrfs" != "xno" -o "x$with_mdraid" != "xno" -o "x$with_kbd" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([BYTESIZE], [bytesize >= 0.1])],
       [])
 

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -255,6 +255,7 @@ with the libblockdev-fs plugin/library.
 %if %{with_kbd}
 %package kbd
 BuildRequires: kmod-devel
+BuildRequires: libbytesize-devel
 Summary:     The KBD plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
 %if %{with_bcache}

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -132,8 +132,8 @@ libbd_swap_la_SOURCES = swap.c swap.h check_deps.c check_deps.h
 endif
 
 if WITH_KBD
-libbd_kbd_la_CFLAGS = $(GLIB_CFLAGS) $(KMOD_CFLAGS) -Wall -Wextra -Werror
-libbd_kbd_la_LIBADD = $(GLIB_LIBS) $(KMOD_LIBS) ${builddir}/../utils/libbd_utils.la
+libbd_kbd_la_CFLAGS = $(GLIB_CFLAGS) $(KMOD_CFLAGS) $(BYTESIZE_CFLAGS) -Wall -Wextra -Werror
+libbd_kbd_la_LIBADD = $(GLIB_LIBS) $(KMOD_LIBS) $(BYTESIZE_LIBS) ${builddir}/../utils/libbd_utils.la
 libbd_kbd_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_kbd_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_kbd_la_SOURCES = kbd.c kbd.h check_deps.c check_deps.h


### PR DESCRIPTION
Bcache stats in sysfs are sometimes wrong or take long time to
get updatedi after bcache creation. This test shouldn't fail just
because bcache is broken -- so instead of comparing stats returned
by "kbd_bcache_status" with some "expected" values, just compare
them from stats we read from sysfs. It isn't our problem if bcache
is broken.