### PR TITLE
More fixes for issues discovered by coverity

### DIFF
--- a/scripts/boilerplate_generator.py
+++ b/scripts/boilerplate_generator.py
@@ -191,12 +191,12 @@ def get_includes_str(includes):
     return ret
 
 def get_funcs_info(fn_infos, module_name):
-    ret = "static const gchar const * const {0}_functions[] = {{\n".format(module_name)
+    ret = "static const gchar* const {0}_functions[] = {{\n".format(module_name)
     for info in fn_infos:
         ret += '    "{0.name}",\n'.format(info)
     ret += "    NULL};\n\n"
 
-    ret += ("gchar const * const * get_{0}_functions (void) {{\n".format(module_name) +
+    ret += ("const gchar* const* get_{0}_functions (void) {{\n".format(module_name) +
             "    return {0}_functions;\n".format(module_name) +
             "}\n\n")
 

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -488,8 +488,8 @@ static gboolean raid_dev_matches_spec (struct raid_dev *raid_dev, const gchar *n
  * find_raid_sets_for_dev: (skip)
  */
 static void find_raid_sets_for_dev (const gchar *name, const gchar *uuid, gint major, gint minor, struct lib_context *lc, struct raid_set *rs, GPtrArray *ret_sets) {
-    struct raid_set *subset;
-    struct raid_dev *dev;
+    struct raid_set *subset = NULL;
+    struct raid_dev *dev = NULL;
 
     if (T_GROUP(rs) || !list_empty(&(rs->sets))) {
         for_each_subset (rs, subset)
@@ -582,8 +582,8 @@ static struct raid_set* rs_matches_name (struct raid_set *rs, gpointer *name_dat
 
 static gboolean change_set_by_name (const gchar *name, enum activate_type action, GError **error) {
     gint rc = 0;
-    struct lib_context *lc;
-    struct raid_set *iter_rs;
+    struct lib_context *lc = NULL;
+    struct raid_set *iter_rs = NULL;
     struct raid_set *match_rs = NULL;
 
     lc = init_dmraid_stack (error);
@@ -670,8 +670,8 @@ gboolean bd_dm_deactivate_raid_set (const gchar *name, GError **error) {
  * Tech category: %BD_DM_TECH_RAID-%BD_DM_TECH_QUERY
  */
 gchar* bd_dm_get_raid_set_type (const gchar *name, GError **error) {
-    struct lib_context *lc;
-    struct raid_set *iter_rs;
+    struct lib_context *lc = NULL;
+    struct raid_set *iter_rs = NULL;
     struct raid_set *match_rs = NULL;
     const gchar *type = NULL;
 

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -3204,9 +3204,9 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
     g_free (output);
     line_p = lines;
     /* find the beginning of the (data) section we are interested in */
-    while (*line_p && !g_str_has_prefix (*line_p, "bytes per volume"))
+    while (line_p && *line_p && !g_str_has_prefix (*line_p, "bytes per volume"))
         line_p++;
-    if (!line_p) {
+    if (!line_p || !(*line_p)) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NTFS file system information");
         g_strfreev (lines);
         bd_fs_ntfs_info_free (ret);
@@ -3218,9 +3218,9 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
     val_start++;
     ret->size = g_ascii_strtoull (val_start, NULL, 0);
 
-    while (*line_p && !g_str_has_prefix (*line_p, "bytes of free space"))
+    while (line_p && *line_p && !g_str_has_prefix (*line_p, "bytes of free space"))
         line_p++;
-    if (!line_p) {
+    if (!line_p || !(*line_p)) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NTFS file system information");
         g_strfreev (lines);
         bd_fs_ntfs_info_free (ret);

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -509,7 +509,13 @@ static void parse_unmount_error_new (struct libmnt_context *cxt, int rc, const g
                 g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
                              "%s", buf);
         }
-    }
+    } else
+        /* mnt_context_umount returned non-zero, but mnt_context_get_excode
+         * returned zero -- this should never happen, but just in case set error
+         * to something sane here
+         */
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Unknow error when unmounting %s", spec);
     return;
 }
 #endif

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1160,13 +1160,15 @@ guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n
     }
 
     ret = g_ascii_strtoull (output, NULL, 0);
-    g_free (output);
     if (ret == 0) {
         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_PARSE,
                      "Failed to parse number from thin_metadata_size's output: '%s'",
                      output);
+        g_free (output);
         return 0;
     }
+
+    g_free (output);
 
     return MAX (ret, BD_LVM_MIN_THPOOL_MD_SIZE);
 }
@@ -2153,16 +2155,22 @@ static gboolean filter_lvs_by_vg (const gchar **lvs, const gchar *vg_name, GSLis
             if (!lv_vg_name) {
                 g_free ((gchar *) *lv_p);
                 success = FALSE;
+                continue;
             }
-        }
-        if (!vg_name || g_strcmp0 (lv_vg_name, vg_name) == 0) {
+
+            if (g_strcmp0 (lv_vg_name, vg_name) == 0) {
+                *out = g_slist_prepend (*out, (gchar *) *lv_p);
+                (*n_lvs)++;
+            } else {
+                g_free ((gchar *) *lv_p);
+                *lv_p = NULL;
+            }
+
+            g_free (lv_vg_name);
+        } else {
             *out = g_slist_prepend (*out, (gchar *) *lv_p);
             (*n_lvs)++;
-        } else {
-            g_free ((gchar *) *lv_p);
-            *lv_p = NULL;
         }
-        g_free (lv_vg_name);
     }
     return success;
 }


### PR DESCRIPTION
Running `covscan` with `--profile=multi` (instead of `errata`) shows some more warnings.