### PR TITLE
Fixes in the s390 plugin

### DIFF
--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -353,13 +353,8 @@ gboolean bd_s390_dasd_is_ldl (const gchar *dasd, GError **error) {
         return FALSE;
     }
 
-    /* check dasd volume label; "VOL1" is a CDL formatted DASD, won't require formatting */
-    if (dasd_info.format == DASD_FORMAT_CDL) {
-        return FALSE;
-    }
-    else {
-        return TRUE;
-    }
+    /* check dasd format */
+    return dasd_info.format == DASD_FORMAT_LDL;
 }
 
 /**

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -154,15 +154,15 @@ gboolean bd_s390_is_tech_avail (BDS390Tech tech, guint64 mode, GError **error) {
  */
 gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error) {
     gboolean rc = FALSE;
-    gchar *dev = NULL;
-    const gchar *argv[8] = {"/sbin/dasdfmt", "-y", "-d", "cdl", "-b", "4096", dev, NULL};
+    const gchar *argv[8] = {"/sbin/dasdfmt", "-y", "-d", "cdl", "-b", "4096", NULL, NULL};
 
     if (!check_deps (&avail_deps, DEPS_DASDFMT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
 
-    dev = g_strdup_printf ("/dev/%s", dasd);
+    argv[6] = g_strdup_printf ("/dev/%s", dasd);
+
     rc = bd_utils_exec_and_report_error (argv, extra, error);
-    g_free (dev);
+    g_free ((gchar *) argv[6]);
     return rc;
 }
 


### PR DESCRIPTION
**bd_s390_dasd_is_ldl should be true only for LDL DADSs:**
The format of DASD can be unformatted, CDL or LDL. We should check
only if the format is LDL, otherwise we could detect also unformatted
DASDs as LDL DASDs.

**Fix bd_s390_dasd_format:** 
We need to set argv to point at the device name, otherwise it is NULL.