### PR TITLE
Mark unstable tests as such

### DIFF
--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 from contextlib import contextmanager
 import utils
-from utils import run, create_sparse_tempfile, mount, umount
+from utils import run, create_sparse_tempfile, mount, umount, unstable_test
 import six
 import overrides_hack
 
@@ -1264,6 +1264,7 @@ class GenericResize(FSTestCase):
                                   fs_info_func=info_prepare,
                                   info_size_func=expected_size)
 
+    @unstable_test
     def test_vfat_generic_resize(self):
         """Test generic resize function with a vfat file system"""
         self._test_generic_resize(mkfs_function=BlockDev.fs_vfat_mkfs)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import re
 import glob
@@ -6,6 +8,7 @@ import tempfile
 import dbus
 import unittest
 import time
+import sys
 from contextlib import contextmanager
 from itertools import chain
 
@@ -313,6 +316,30 @@ def requires_locales(locales):
         return decorated
 
     return decorator
+
+
+# taken from udisks2/src/tests/dbus-tests/udiskstestcase.py
+def unstable_test(test):
+    """Decorator for unstable tests
+
+    Failures of tests decorated with this decorator are silently ignored unless
+    the ``UNSTABLE_TESTS_FATAL`` environment variable is defined.
+    """
+
+    def decorated_test(*args):
+        try:
+            test(*args)
+        except unittest.SkipTest:
+            # make sure skipped tests are just skipped as usual
+            raise
+        except:
+            # and swallow everything else, just report a failure of an unstable
+            # test, unless told otherwise
+            if "UNSTABLE_TESTS_FATAL" in os.environ:
+                raise
+            print("unstable-fail...", end="", file=sys.stderr)
+
+    return decorated_test
 
 
 def run(cmd_string):


### PR DESCRIPTION
So that they are not making results of our tests hard to work
with.