### PR TITLE
Progress for e2fsck

### DIFF
--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -728,6 +728,15 @@ gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **e
 }
 
 /**
+ * bd_utils_prog_reporting_initialized:
+ *
+ * Returns: TRUE if progress reporting has been initialized.
+ */
+gboolean bd_utils_prog_reporting_initialized () {
+    return prog_func != NULL;
+}
+
+/**
  * bd_utils_report_started:
  * @msg: message describing the started task/action
  *

--- a/src/utils/exec.h
+++ b/src/utils/exec.h
@@ -60,6 +60,7 @@ gint bd_utils_version_cmp (const gchar *ver_string1, const gchar *ver_string2, G
 gboolean bd_utils_check_util_version (const gchar *util, const gchar *version, const gchar *version_arg, const gchar *version_regexp, GError **error);
 
 gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **error);
+gboolean bd_utils_prog_reporting_initialized ();
 guint64 bd_utils_report_started (gchar *msg);
 void bd_utils_report_progress (guint64 task_id, guint64 completion, gchar *msg);
 void bd_utils_report_finished (guint64 task_id, gchar *msg);

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -18,6 +18,32 @@ class UtilsTestCase(unittest.TestCase):
         else:
             BlockDev.reinit(cls.requested_plugins, True, None)
 
+class UtilsExecProgressTest(UtilsTestCase):
+    log = []
+
+    def my_progress_func(self, task, status, completion, msg):
+        self.assertTrue(isinstance(completion, int))
+        self.log.append(completion)
+
+    def test_initialization(self):
+        """ Verify that progress report can (de)initialized"""
+
+        succ = BlockDev.utils_prog_reporting_initialized()
+        self.assertFalse(succ)
+
+        succ = BlockDev.utils_init_prog_reporting(self.my_progress_func)
+        self.assertTrue(succ)
+
+        succ = BlockDev.utils_prog_reporting_initialized()
+        self.assertTrue(succ)
+
+        succ = BlockDev.utils_init_prog_reporting(None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.utils_prog_reporting_initialized()
+        self.assertFalse(succ)
+
+
 class UtilsExecLoggingTest(UtilsTestCase):
     log = ""
 


### PR DESCRIPTION
These two commits add a progress reporting capabilities for check/repair of ext2/3/4 fs. It utilizes the existing infrastructure including `bd_utils_init_prog_reporting()`. An example of usage is here: https://github.com/jtulak/fd-issue, but it is the same as for any other of the few operations that currently support progress report.