### PR TITLE
lvm-dbus: Check returned job object for error

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -39,6 +39,7 @@ typedef enum {
     BD_LVM_ERROR_CACHE_INVAL,
     BD_LVM_ERROR_CACHE_NOCACHE,
     BD_LVM_ERROR_TECH_UNAVAIL,
+    BD_LVM_ERROR_FAIL,
 } BDLVMError;
 
 typedef enum {

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -43,6 +43,7 @@ typedef enum {
     BD_LVM_ERROR_CACHE_INVAL,
     BD_LVM_ERROR_CACHE_NOCACHE,
     BD_LVM_ERROR_TECH_UNAVAIL,
+    BD_LVM_ERROR_FAIL,
 } BDLVMError;
 
 typedef enum {


### PR DESCRIPTION
It is possible that calling a function won't return an error
immediately but will return a job object with 'GetError' property
set so we need to check it too.