### PR TITLE
Use '=' instead of '==' to compare using 'test'

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -71,7 +71,7 @@ ${CC} -c [$2] $temp_file
 status=$?
 rm -f $temp_file
 rm -f $(basename ${temp_file%%.c}.o)
-if test $status == 0; then
+if test $status = 0; then
   echo yes
 else
   echo no


### PR DESCRIPTION
'=' is correct, '==' may work with some versions of 'test' (or
shells that don't actually use the utility).

Fixes: #333