### PR TITLE
Allow compiling libblockdev crypto plugin without escrow support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,17 @@ AS_IF([test "x$with_bcache" != "xno"],
       [AC_DEFINE([WITH_BD_BCACHE], [], [Define if bcache is supported]) AC_SUBST([WITH_BCACHE], [1])],
       [])
 
+AC_ARG_WITH([escrow],
+    AS_HELP_STRING([--with-escrow], [support escrow @<:@default=yes@:>@]),
+    [],
+    [with_escrow=yes])
+
+AC_SUBST([WITH_ESCROW], [0])
+AM_CONDITIONAL(WITH_ESCROW, test "x$with_escrow" != "xno")
+AS_IF([test "x$with_escrow" != "xno"],
+      [AC_DEFINE([WITH_BD_ESCROW], [], [Define if escrow is supported]) AC_SUBST([WITH_ESCROW], [1])],
+      [])
+
 LIBBLOCKDEV_PLUGIN([BTRFS], [btrfs])
 LIBBLOCKDEV_PLUGIN([CRYPTO], [crypto])
 LIBBLOCKDEV_PLUGIN([DM], [dm])
@@ -156,8 +167,10 @@ AS_IF([test "x$with_crypto" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([CRYPTSETUP], [libcryptsetup >= 1.6.7])
       AS_IF([$PKG_CONFIG --atleast-version=2.0 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_PIM_SUPPORT])], [])
-       LIBBLOCKDEV_PKG_CHECK_MODULES([NSS], [nss >= 3.18.0])
-       LIBBLOCKDEV_CHECK_HEADER([volume_key/libvolume_key.h], [$GLIB_CFLAGS $NSS_CFLAGS], [libvolume_key.h not available])
+      AS_IF([test "x$with_escrow" != "xno"],
+            [LIBBLOCKDEV_PKG_CHECK_MODULES([NSS], [nss >= 3.18.0])
+             LIBBLOCKDEV_CHECK_HEADER([volume_key/libvolume_key.h], [$GLIB_CFLAGS $NSS_CFLAGS], [libvolume_key.h not available])],
+            [])
       ],
       [])
 

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -15,6 +15,7 @@
 %define with_fs @WITH_FS@
 %define with_nvdimm @WITH_NVDIMM@
 %define with_gi @WITH_GI@
+%define with_escrow @WITH_ESCROW@
 
 # python3 is not available on older RHEL
 %if ! 0%{?fedora} && 0%{?rhel} <= 7
@@ -29,6 +30,10 @@
 %endif
 %if %{with_crypto} != 1
 %define crypto_copts --without-crypto
+%else
+%if %{with_escrow} != 1
+%define crypto_copts --without-escrow
+%endif
 %endif
 %if %{with_dm} != 1
 %define dm_copts --without-dm
@@ -187,8 +192,12 @@ with the libblockdev-btrfs plugin/library.
 %if %{with_crypto}
 %package crypto
 BuildRequires: cryptsetup-devel
+
+%if %{with_escrow}
 BuildRequires: volume_key-devel >= 0.3.9-7
 BuildRequires: nss-devel
+%endif
+
 Summary:     The crypto plugin for the libblockdev library
 
 %description crypto

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -70,8 +70,13 @@ libbd_btrfs_la_SOURCES = btrfs.c btrfs.h check_deps.c check_deps.h
 endif
 
 if WITH_CRYPTO
+if WITH_ESCROW
 libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(NSS_CFLAGS) -Wall -Wextra -Werror
 libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
+else
+libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) -Wall -Wextra -Werror
+libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) ${builddir}/../utils/libbd_utils.la
+endif
 libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_crypto_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_crypto_la_SOURCES = crypto.c crypto.h


### PR DESCRIPTION
This allows compiling libblockdev without volume_key and nss
dependencies using the "--without-escrow" configure option
("BD_CRYPTO_TECH_ESCROW" technology won't be available).

Fixes #322 