### PR TITLE
Require at least libndctl 58.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,7 +199,7 @@ AS_IF([test "x$with_btrfs" != "xno" -o "x$with_mdraid" != "xno" -o "x$with_kbd" 
 
 AS_IF([test "x$with_nvdimm" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([UUID], [uuid])
-       LIBBLOCKDEV_PKG_CHECK_MODULES([NDCTL], [libndctl])]
+       LIBBLOCKDEV_PKG_CHECK_MODULES([NDCTL], [libndctl >= 58.4])]
       [])
 
 AC_SUBST([skip_patterns], [$skip_patterns])


### PR DESCRIPTION
We are using some functions that are not available in older
versions.