### PR TITLE
Skip bcache tests on Rawhide

### DIFF
--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -294,6 +294,7 @@ class KbdBcacheTestCase(unittest.TestCase):
         else:
             BlockDev.reinit(cls.requested_plugins, True, None)
 
+    @skip_on(("fedora", "29"), reason="running bcache tests causes system to run out of kernel memory on rawhide")
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", 10 * 1024**3)


### PR DESCRIPTION
Running bcache tests on rawhide (kernel 4.17) causes system to
crash because it runs out of kernel memory.