### PR TITLE
Use xfs_repair instead of xfs_db in bd_fs_xfs_check()

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -890,8 +890,8 @@ gboolean bd_fs_xfs_wipe (const gchar *device, GError **error);
  *
  * Returns: whether an xfs file system on the @device is clean or not
  *
- * Note: if the file system is mounted it may be reported as unclean even if
- *       everything is okay and there are just some pending/in-progress writes
+ * Note: If the file system is mounted RW, it will always be reported as not
+ *       clean!
  *
  * Tech category: %BD_FS_TECH_XFS-%BD_FS_TECH_MODE_CHECK
  */

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -145,8 +145,8 @@ gboolean bd_fs_xfs_wipe (const gchar *device, GError **error) {
  *
  * Returns: whether an xfs file system on the @device is clean or not
  *
- * Note: if the file system is mounted it may be reported as unclean even if
- *       everything is okay and there are just some pending/in-progress writes
+ * Note: If the file system is mounted RW, it will always be reported as not
+ *       clean!
  *
  * Tech category: %BD_FS_TECH_XFS-%BD_FS_TECH_MODE_CHECK
  */

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -151,10 +151,10 @@ gboolean bd_fs_xfs_wipe (const gchar *device, GError **error) {
  * Tech category: %BD_FS_TECH_XFS-%BD_FS_TECH_MODE_CHECK
  */
 gboolean bd_fs_xfs_check (const gchar *device, GError **error) {
-    const gchar *args[6] = {"xfs_db", "-r", "-c", "check", device, NULL};
+    const gchar *args[4] = {"xfs_repair", "-n", device, NULL};
     gboolean ret = FALSE;
 
-    if (!check_deps (&avail_deps, DEPS_XFS_DB_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+    if (!check_deps (&avail_deps, DEPS_XFS_REPAIR_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
 
     ret = bd_utils_exec_and_report_error (args, NULL, error);

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -24,8 +24,8 @@ def check_output(args, ignore_retcode=True):
             raise
 
 @contextmanager
-def mounted(device, where):
-    mount(device, where)
+def mounted(device, where, ro=False):
+    mount(device, where, ro)
     yield
     umount(where)
 
@@ -560,9 +560,9 @@ class XfsTestCheck(FSTestCase):
         succ = BlockDev.fs_xfs_check(self.loop_dev)
         self.assertTrue(succ)
 
-        # mounted, but can be checked and nothing happened in/to the file
-        # system, so it should be just reported as clean
-        with mounted(self.loop_dev, self.mount_dir):
+        # mounted RO, can be checked and nothing happened in/to the file system,
+        # so it should be just reported as clean
+        with mounted(self.loop_dev, self.mount_dir, ro=True):
             succ = BlockDev.fs_xfs_check(self.loop_dev)
             self.assertTrue(succ)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -350,11 +350,13 @@ def run(cmd_string):
     return subprocess.call(cmd_string, close_fds=True, shell=True)
 
 
-def mount(device, where):
+def mount(device, where, ro=False):
     if not os.path.isdir(where):
         os.makedirs(where)
-    os.system("mount %s %s" % (device, where))
-
+    if ro:
+        os.system("mount -oro %s %s" % (device, where))
+    else:
+        os.system("mount %s %s" % (device, where))
 
 def umount(what, retry=True):
     try:


### PR DESCRIPTION
As described in the issue, xfs_db's check command does not scale
for large filesystems, and is not really a debug tool in xfs_db,
not something for general use.

Fixes: GH-344