### PR TITLE
Fix off-by-one error when counting TCRYPT keyfiles

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -1072,9 +1072,8 @@ gboolean bd_crypto_tc_open_full (const gchar *device, const gchar *name, const g
     g_free (msg);
 
     if (keyfiles) {
-        for (i=0; *(keyfiles + i); i++) {
-            keyfiles_count = i;
-        }
+        for (i=0; *(keyfiles + i); i++);
+        keyfiles_count = i;
     }
 
     if ((data_len == 0) && (keyfiles_count == 0)) {


### PR DESCRIPTION
When opening a TCRYPT volume, the keyfiles count is off by one.