### PR TITLE
Allow compiling libblockdev without libdmraid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,17 @@ AS_IF([test "x$with_escrow" != "xno"],
       [AC_DEFINE([WITH_BD_ESCROW], [], [Define if escrow is supported]) AC_SUBST([WITH_ESCROW], [1])],
       [])
 
+AC_ARG_WITH([dmraid],
+    AS_HELP_STRING([--with-dmraid], [support dmraid @<:@default=yes@:>@]),
+    [],
+    [with_dmraid=yes])
+
+AC_SUBST([WITH_DMRAID], [0])
+AM_CONDITIONAL(WITH_DMRAID, test "x$with_dmraid" != "xno")
+AS_IF([test "x$with_dmraid" != "xno"],
+      [AC_DEFINE([WITH_BD_DMRAID], [], [Define if dmraid is supported]) AC_SUBST([WITH_DMRAID], [1])],
+      [])
+
 LIBBLOCKDEV_PLUGIN([BTRFS], [btrfs])
 LIBBLOCKDEV_PLUGIN([CRYPTO], [crypto])
 LIBBLOCKDEV_PLUGIN([DM], [dm])
@@ -194,7 +205,7 @@ AS_IF([test "x$with_dm" != "xno" -o "x$with_lvm" != "xno" -o "x$with_lvm_dbus" !
       [LIBBLOCKDEV_PKG_CHECK_MODULES([DEVMAPPER], [devmapper >= 1.02.93])],
       [])
 
-AS_IF([test "x$with_dm" != "xno"],
+AS_IF([test "x$with_dm" != "xno" -a "x$with_dmraid" != "xno"],
       [LIBBLOCKDEV_CHECK_HEADER([dmraid/dmraid.h], [], [dmraid.h not available])],
       [])
 

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -17,6 +17,7 @@
 %define with_nvdimm @WITH_NVDIMM@
 %define with_gi @WITH_GI@
 %define with_escrow @WITH_ESCROW@
+%define with_dmraid @WITH_DMRAID@
 
 # python2 is not available on RHEL > 7 and not needed on Fedora > 28
 %if 0%{?rhel} > 7 || 0%{?fedora} > 28 || %{with_python2} == 0
@@ -54,6 +55,10 @@
 %endif
 %if %{with_dm} != 1
 %define dm_copts --without-dm
+%else
+%if %{with_dmraid} != 1
+%define dm_copts --without-dmraid
+%endif
 %endif
 %if %{with_loop} != 1
 %define loop_copts --without-loop
@@ -239,7 +244,9 @@ with the libblockdev-crypto plugin/library.
 %if %{with_dm}
 %package dm
 BuildRequires: device-mapper-devel
+%if %{with_dmraid}
 BuildRequires: dmraid-devel
+%endif
 BuildRequires: systemd-devel
 Summary:     The Device Mapper plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
@@ -256,7 +263,9 @@ Requires: %{name}-dm%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 Requires: device-mapper-devel
 Requires: systemd-devel
+%if %{with_dmraid}
 Requires: dmraid-devel
+%endif
 Requires: %{name}-utils-devel%{?_isa}
 
 %description dm-devel

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -83,12 +83,17 @@ libbd_crypto_la_SOURCES = crypto.c crypto.h
 endif
 
 if WITH_DM
-libbd_dm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) $(UDEV_CFLAGS) -Wall -Wextra -Werror
-libbd_dm_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) $(UDEV_LIBS) -ldmraid ${builddir}/../utils/libbd_utils.la
+libbd_dm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
+libbd_dm_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
 libbd_dm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
-# Dear author of libdmdraid, VERSION really is not a good name for an enum member!
-libbd_dm_la_CPPFLAGS = -I${builddir}/../../include/ -UVERSION
+libbd_dm_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_dm_la_SOURCES = dm.c dm.h check_deps.c check_deps.h
+if WITH_DMRAID
+libbd_dm_la_CFLAGS += $(UDEV_CFLAGS)
+libbd_dm_la_LIBADD += $(UDEV_LIBS) -ldmraid
+# Dear author of libdmdraid, VERSION really is not a good name for an enum member!
+libbd_dm_la_CPPFLAGS += -UVERSION
+endif
 endif
 
 if WITH_LOOP

--- a/src/plugins/dm.h
+++ b/src/plugins/dm.h
@@ -1,5 +1,4 @@
 #include <glib.h>
-#include <dmraid/dmraid.h>
 
 #ifndef BD_DM
 #define BD_DM


### PR DESCRIPTION
This allows compiling libblockdev dm plugin without dmraid support
using the "--without-dmraid" configure option ("BD_DM_TECH_RAID"
technology won't be available).

Fixes: #321