### PR TITLE
RFC - crypto: Add bd_crypto_luks_get_policies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,8 @@ LIBBLOCKDEV_PKG_CHECK_MODULES([KMOD], [libkmod >= 19])
 
 AS_IF([test "x$with_crypto" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([CRYPTSETUP], [libcryptsetup >= 1.6.7])
+      LIBBLOCKDEV_PKG_CHECK_MODULES([LUKSMETA], [luksmeta])
+      LIBBLOCKDEV_PKG_CHECK_MODULES([JSON_C], [json-c])
       AS_IF([$PKG_CONFIG --atleast-version=2.0 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_2])], [])
       AS_IF([test "x$with_escrow" != "xno"],

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -314,6 +314,18 @@ gchar* bd_crypto_luks_uuid (const gchar *device, GError **error);
 guint64 bd_crypto_luks_get_metadata_size (const gchar *device, GError **error);
 
 /**
+ * bd_crypto_luks_get_policies
+ * @device: the queried device
+ * @include_secrets:
+ * @error: (out): place to store error (if any)
+ *
+ * Returns:
+ *
+ * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_QUERY
+ */
+gchar *bd_crypto_luks_get_policies (const gchar *device, gboolean include_secrets, GError **error);
+
+/**
  * bd_crypto_luks_status:
  * @luks_device: the queried LUKS device
  * @error: (out): place to store error (if any)

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -75,11 +75,11 @@ endif
 
 if WITH_CRYPTO
 if WITH_ESCROW
-libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(NSS_CFLAGS) -Wall -Wextra -Werror
-libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
+libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(LUKSMETA_CFLAGS) $(JSON_C_CFLAGS) $(NSS_CFLAGS) -Wall -Wextra -Werror
+libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) $(LUKSMETA_LIBS) $(JSON_C_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
 else
-libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) -Wall -Wextra -Werror
-libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) ${builddir}/../utils/libbd_utils.la
+libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(LUKSMETA_CFLAGS) $(JSON_C_CFLAGS) -Wall -Wextra -Werror
+libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) $(LUKSMETA_LIBS) $(JSON_C_LIBS) ${builddir}/../utils/libbd_utils.la
 endif
 libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_crypto_la_CPPFLAGS = -I${builddir}/../../include/

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -156,6 +156,7 @@ gchar* bd_crypto_generate_backup_passphrase(GError **error);
 gboolean bd_crypto_device_is_luks (const gchar *device, GError **error);
 gchar* bd_crypto_luks_uuid (const gchar *device, GError **error);
 guint64 bd_crypto_luks_get_metadata_size (const gchar *device, GError **error);
+gchar *bd_crypto_luks_get_policies (const gchar *device, gboolean include_secrets, GError **error);
 gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint64 key_size, const gchar *passphrase, const gchar *key_file, guint64 min_entropy, GError **error);
 gboolean bd_crypto_luks_format_blob (const gchar *device, const gchar *cipher, guint64 key_size, const guint8 *pass_data, gsize data_len, guint64 min_entropy, GError **error);


### PR DESCRIPTION
This is to support the UDisks2 API discussed in https://github.com/storaged-project/udisks/pull/539

Only the "tang" and "sss" pins are supported for now.  There needs to be explicit support for each pin since this code needs to know how to convert the JWE header stored in the luksmeta slot back to the config object that could be passed to "clevis luks bind". 