### PR TITLE
Do not build VDO plugin on non-x86_64 architectures

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -50,6 +50,12 @@
 %define vdo_copts --without-vdo
 %endif
 
+# vdo is available only on x86_64
+%ifnarch x86_64
+%define with_vdo 0
+%define vdo_copts --without-vdo
+%endif
+
 %if %{with_btrfs} != 1
 %define btrfs_copts --without-btrfs
 %endif


### PR DESCRIPTION
VDO plugin dependencies (vdo and kmod-kvdo) are available only
for x86_64 so it doesn't make sense to build the module on other
architectures.