### PR TITLE
Allow specifying extra options for PBKDF when creating LUKS2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -193,7 +193,7 @@ LIBBLOCKDEV_PKG_CHECK_MODULES([KMOD], [libkmod >= 19])
 
 AS_IF([test "x$with_crypto" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([CRYPTSETUP], [libcryptsetup >= 1.6.7])
-      AS_IF([$PKG_CONFIG --atleast-version=2.0 libcryptsetup],
+      AS_IF([$PKG_CONFIG --atleast-version=2.0.3 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_2])], [])
       AS_IF([test "x$with_escrow" != "xno"],
             [LIBBLOCKDEV_PKG_CHECK_MODULES([NSS], [nss >= 3.18.0])

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -75,7 +75,12 @@ bd_crypto_luks_format
 bd_crypto_luks_format_blob
 bd_crypto_luks_extra_free
 bd_crypto_luks_extra_copy
+bd_crypto_luks_extra_new
 BDCryptoLUKSExtra
+bd_crypto_luks_pbkdf_free
+bd_crypto_luks_pbkdf_copy
+bd_crypto_luks_pbkdf_new
+BDCryptoLUKSPBKDF
 BDCryptoLUKSVersion
 bd_crypto_luks_format_luks2
 bd_crypto_luks_format_luks2_blob

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -50,6 +50,96 @@ typedef enum {
     BD_CRYPTO_LUKS_VERSION_LUKS2,
 } BDCryptoLUKSVersion;
 
+#define BD_CRYPTO_TYPE_LUKS_PBKDF (bd_crypto_luks_pbkdf_get_type ())
+GType bd_crypto_luks_pbkdf_get_type();
+
+/**
+ * BDCryptoLUKSPBKDF
+ * @type: PBKDF algorithm
+ * @hash: hash for LUKS header or NULL
+ * @max_memory_kb: requested memory cost (in KiB) or 0 for default (benchmark)
+ * @iterations: requested iterations or 0 for default (benchmark)
+ * @time_ms: requested time cost or 0 for default (benchmark)
+ * @parallel_threads: requested parallel cost (threads) or 0 for default (benchmark)
+*/
+typedef struct BDCryptoLUKSPBKDF {
+    gchar *type;
+    gchar *hash;
+    guint32 max_memory_kb;
+    guint32 iterations;
+    guint32 time_ms;
+    guint32 parallel_threads;
+} BDCryptoLUKSPBKDF;
+
+/**
+ * bd_crypto_luks_pbkdf_copy: (skip)
+ *
+ * Creates a new copy of @pbkdf.
+ */
+BDCryptoLUKSPBKDF* bd_crypto_luks_pbkdf_copy (BDCryptoLUKSPBKDF *pbkdf) {
+    if (pbkdf == NULL)
+        return NULL;
+
+    BDCryptoLUKSPBKDF *new_pbkdf = g_new0 (BDCryptoLUKSPBKDF, 1);
+    new_pbkdf->type = g_strdup (pbkdf->type);
+    new_pbkdf->hash = g_strdup (pbkdf->hash);
+    new_pbkdf->max_memory_kb = pbkdf->max_memory_kb;
+    new_pbkdf->iterations = pbkdf->iterations;
+    new_pbkdf->time_ms = pbkdf->time_ms;
+    new_pbkdf->parallel_threads = pbkdf->parallel_threads;
+
+    return new_pbkdf;
+}
+
+/**
+ * bd_crypto_luks_pbkdf_free: (skip)
+ *
+ * Frees @pbkdf.
+ */
+void bd_crypto_luks_pbkdf_free (BDCryptoLUKSPBKDF *pbkdf) {
+    if (pbkdf == NULL)
+        return;
+
+    g_free (pbkdf->type);
+    g_free (pbkdf->hash);
+    g_free (pbkdf);
+}
+
+/**
+ * bd_crypto_luks_pbkdf_new: (constructor)
+ * @type: (allow-none): PBKDF algorithm
+ * @hash: (allow-none): hash for LUKS header or NULL for default
+ * @max_memory_kb: requested memory cost (in KiB) or 0 for default (benchmark)
+ * @iterations: requested iterations or 0 for default (benchmark)
+ * @time_ms: requested time cost or 0 for default (benchmark)
+ * @parallel_threads: requested parallel cost (threads) or 0 for default (benchmark)
+ *
+ * Returns: (transfer full): a new pbkdf argument
+ */
+BDCryptoLUKSPBKDF* bd_crypto_luks_pbkdf_new (const gchar *type, const gchar *hash, guint32 max_memory_kb, guint32 iterations, guint32 time_ms, guint32 parallel_threads) {
+    BDCryptoLUKSPBKDF *ret = g_new0 (BDCryptoLUKSPBKDF, 1);
+    ret->type = g_strdup (type);
+    ret->hash = g_strdup (hash);
+    ret->max_memory_kb = max_memory_kb;
+    ret->iterations = iterations;
+    ret->time_ms = time_ms;
+    ret->parallel_threads = parallel_threads;
+
+    return ret;
+}
+
+GType bd_crypto_luks_pbkdf_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDCryptoLUKSPBKDF",
+                                            (GBoxedCopyFunc) bd_crypto_luks_pbkdf_copy,
+                                            (GBoxedFreeFunc) bd_crypto_luks_pbkdf_free);
+    }
+
+    return type;
+}
+
 #define BD_CRYPTO_TYPE_LUKS_EXTRA (bd_crypto_luks_extra_get_type ())
 GType bd_crypto_luks_extra_get_type();
 
@@ -65,6 +155,8 @@ GType bd_crypto_luks_extra_get_type();
  *         Note: this field is valid only for LUKS 2
  * @subsytem: LUKS header subsystem or NULL
  *            Note: this field is valid only for LUKS 2
+ * @pbkdf: key derivation function specification or NULL for default
+ *         Note: this field is valid only for LUKS 2
  */
 typedef struct BDCryptoLUKSExtra {
     guint64 data_alignment;
@@ -73,6 +165,7 @@ typedef struct BDCryptoLUKSExtra {
     guint64 sector_size;
     gchar *label;
     gchar *subsystem;
+    BDCryptoLUKSPBKDF *pbkdf;
 } BDCryptoLUKSExtra;
 
 /**
@@ -92,6 +185,7 @@ BDCryptoLUKSExtra* bd_crypto_luks_extra_copy (BDCryptoLUKSExtra *extra) {
     new_extra->sector_size = extra->sector_size;
     new_extra->label = g_strdup (extra->label);
     new_extra->subsystem = g_strdup (extra->subsystem);
+    new_extra->pbkdf = bd_crypto_luks_pbkdf_copy (extra->pbkdf);
 
     return new_extra;
 }
@@ -109,7 +203,33 @@ void bd_crypto_luks_extra_free (BDCryptoLUKSExtra *extra) {
     g_free (extra->data_device);
     g_free (extra->label);
     g_free (extra->subsystem);
+    bd_crypto_luks_pbkdf_free (extra->pbkdf);
     g_free (extra);
+}
+
+/**
+ * bd_crypto_luks_extra_new: (constructor)
+ * @data_alignment: data alignment in sectors, 0 for default/auto detection
+ * @data_device: (allow-none): detached encrypted data device or NULL
+ * @integrity: (allow-none): integrity algorithm (e.g. "hmac-sha256") or NULL for no integrity support
+ * @sector_size: encryption sector size, 0 for default (512)
+ * @label: (allow-none): LUKS header label or NULL
+ * @subsystem: (allow-none): LUKS header subsystem or NULL
+ * @pbkdf: (allow-none): key derivation function specification or NULL for default
+ *
+ * Returns: (transfer full): a new LUKS extra argument
+ */
+BDCryptoLUKSExtra* bd_crypto_luks_extra_new (guint64 data_alignment, const gchar *data_device, const gchar *integrity, guint64 sector_size, const gchar *label, const gchar *subsystem, BDCryptoLUKSPBKDF *pbkdf) {
+    BDCryptoLUKSExtra *ret = g_new0 (BDCryptoLUKSExtra, 1);
+    ret->integrity = g_strdup (integrity);
+    ret->data_alignment = data_alignment;
+    ret->data_device = g_strdup (data_device);
+    ret->sector_size = sector_size;
+    ret->label = g_strdup (label);
+    ret->subsystem = g_strdup (subsystem);
+    ret->pbkdf = bd_crypto_luks_pbkdf_copy (pbkdf);
+
+    return ret;
 }
 
 GType bd_crypto_luks_extra_get_type () {

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -64,6 +64,27 @@ typedef enum {
     BD_CRYPTO_LUKS_VERSION_LUKS2,
 } BDCryptoLUKSVersion;
 
+/**
+ * BDCryptoLUKSPBKDF
+ * @type: PBKDF algorithm
+ * @hash: hash for LUKS header or NULL
+ * @max_memory_kb: requested memory cost (in KiB) or 0 for default (benchmark)
+ * @iterations: requested iterations or 0 for default (benchmark)
+ * @time_ms: requested time cost or 0 for default (benchmark)
+ * @parallel_threads: requested parallel cost (threads) or 0 for default (benchmark)
+*/
+typedef struct BDCryptoLUKSPBKDF {
+    gchar *type;
+    gchar *hash;
+    guint32 max_memory_kb;
+    guint32 iterations;
+    guint32 time_ms;
+    guint32 parallel_threads;
+} BDCryptoLUKSPBKDF;
+
+void bd_crypto_luks_pbkdf_free (BDCryptoLUKSPBKDF *pbkdf);
+BDCryptoLUKSPBKDF* bd_crypto_luks_pbkdf_copy (BDCryptoLUKSPBKDF *pbkdf);
+BDCryptoLUKSPBKDF* bd_crypto_luks_pbkdf_new (const gchar *type, const gchar *hash, guint32 max_memory_kb, guint32 iterations, guint32 time_ms, guint32 parallel_threads);
 
 /**
  * BDCryptoLUKSExtra:
@@ -77,6 +98,8 @@ typedef enum {
  *         Note: this field is valid only for LUKS 2
  * @subsytem: LUKS header subsystem or NULL
  *            Note: this field is valid only for LUKS 2
+ * @pbkdf: key derivation function specification or NULL for default
+ *         Note: this field is valid only for LUKS 2
  */
 typedef struct BDCryptoLUKSExtra {
     guint64 data_alignment;
@@ -85,10 +108,12 @@ typedef struct BDCryptoLUKSExtra {
     guint64 sector_size;
     gchar *label;
     gchar *subsystem;
+    BDCryptoLUKSPBKDF *pbkdf;
 } BDCryptoLUKSExtra;
 
 void bd_crypto_luks_extra_free (BDCryptoLUKSExtra *extra);
 BDCryptoLUKSExtra* bd_crypto_luks_extra_copy (BDCryptoLUKSExtra *extra);
+BDCryptoLUKSExtra* bd_crypto_luks_extra_new (guint64 data_alignment, const gchar *data_device, const gchar *integrity, guint64 sector_size, const gchar *label, const gchar *subsystem, BDCryptoLUKSPBKDF *pbkdf);
 
 /**
  * BDCryptoLUKSInfo:

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -192,6 +192,28 @@ def btrfs_check(mountpoint, extra=None, **kwargs):
 __all__.append("btrfs_check")
 
 
+class CryptoLUKSPBKDF(BlockDev.CryptoLUKSPBKDF):
+    def __new__(cls, type=None, hash=None, max_memory_kb=0, iterations=0, time_ms=0, parallel_threads=0):  # pylint: disable=redefined-builtin
+        ret = BlockDev.CryptoLUKSPBKDF.new(type, hash, max_memory_kb, iterations, time_ms, parallel_threads)
+        ret.__class__ = cls
+        return ret
+    def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument
+        super(CryptoLUKSPBKDF, self).__init__()
+CryptoLUKSPBKDF = override(CryptoLUKSPBKDF)
+__all__.append("CryptoLUKSPBKDF")
+
+class CryptoLUKSExtra(BlockDev.CryptoLUKSExtra):
+    def __new__(cls, data_alignment=0, data_device=None, integrity=None, sector_size=0, label=None, subsystem=None, pbkdf=None):
+        if pbkdf is None:
+            pbkdf = CryptoLUKSPBKDF()
+        ret = BlockDev.CryptoLUKSExtra.new(data_alignment, data_device, integrity, sector_size, label, subsystem, pbkdf)
+        ret.__class__ = cls
+        return ret
+    def __init__(self, *args, **kwargs):   # pylint: disable=unused-argument
+        super(CryptoLUKSExtra, self).__init__()
+CryptoLUKSExtra = override(CryptoLUKSExtra)
+__all__.append("CryptoLUKSExtra")
+
 # calling `crypto_luks_format_luks2` with `luks_version` set to
 # `BlockDev.CryptoLUKSVersion.LUKS1` and `extra` to `None` is the same
 # as using the "original" function `crypto_luks_format`


### PR DESCRIPTION
We need to be able to specify different kdf (e.g. pbkdf2) and
change some default parameters for argon2.