### PR TITLE
vdo: Properly destroy the yaml parser

### DIFF
--- a/src/plugins/vdo.c
+++ b/src/plugins/vdo.c
@@ -228,6 +228,8 @@ static GHashTable* parse_yaml_output (const gchar *output, GError **error) {
               yaml_token_delete (&token);
     } while (token.type != YAML_STREAM_END_TOKEN);
 
+    yaml_parser_delete (&parser);
+
     return table;
 }
 


### PR DESCRIPTION
Just a small fix to prevent memory leaks - even though the `yaml_parser_t` structure is allocated on the stack, its members may point to a dynamically allocated memory.