### PR TITLE
vdo: Implement bd_vdo_get_statistics()

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -647,6 +647,7 @@ bd_vdo_start
 bd_vdo_stop
 bd_vdo_grow_logical
 bd_vdo_grow_physical
+bd_vdo_get_statistics
 BDVDOTech
 BDVDOTechMode
 bd_vdo_is_tech_avail

--- a/features.rst
+++ b/features.rst
@@ -319,6 +319,7 @@ VDO
    * stop
    * grow_logical
    * grow_physical
+   * get_statistics
 
 utils
 ------

--- a/src/lib/plugin_apis/vdo.api
+++ b/src/lib/plugin_apis/vdo.api
@@ -342,4 +342,18 @@ gboolean bd_vdo_grow_logical (const gchar *name, guint64 size, const BDExtraArg 
  */
 gboolean bd_vdo_grow_physical (const gchar *name, const BDExtraArg **extra, GError **error);
 
+/**
+ * bd_vdo_get_statistics:
+ * @name: name of an existing VDO volume
+ * @extra: (allow-none) (array zero-terminated=1): extra options, currently unused
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (element-type utf8 utf8): hashtable of type string - string of available statistics
+ *
+ * Statistics are collected from the values exposed by the kernel `kvdo` module at the `/sys/kvdo/<VDO_NAME>/statistics/` path. Some of the keys are computed to mimic the information produced by the vdo tools.
+ *
+ * Tech category: %BD_VDO_TECH_VDO-%BD_VDO_TECH_MODE_QUERY
+ */
+GHashTable* bd_vdo_get_statistics (const gchar *name, const BDExtraArg **extra, GError **error);
+
 #endif  /* BD_VDO_API */

--- a/src/plugins/vdo.c
+++ b/src/plugins/vdo.c
@@ -864,3 +864,141 @@ gboolean bd_vdo_grow_physical (const gchar *name, const BDExtraArg **extra, GErr
 
     return ret;
 }
+
+
+static gboolean get_stat_val (GHashTable *stats, const gchar *key, gint64 *val) {
+    const gchar *s;
+    gchar *endptr = NULL;
+
+    s = g_hash_table_lookup (stats, key);
+    if (s == NULL)
+        return FALSE;
+
+    *val = g_ascii_strtoll (s, &endptr, 0);
+    if (endptr == NULL || *endptr != '\0')
+        return FALSE;
+
+    return TRUE;
+}
+
+static void add_write_ampl_r_stats (GHashTable *stats) {
+    gint64 bios_meta_write, bios_out_write, bios_in_write;
+
+    if (! get_stat_val (stats, "bios_meta_write", &bios_meta_write) ||
+        ! get_stat_val (stats, "bios_out_write", &bios_out_write) ||
+        ! get_stat_val (stats, "bios_in_write", &bios_in_write))
+        return;
+
+    if (bios_in_write <= 0)
+        g_hash_table_replace (stats, g_strdup ("writeAmplificationRatio"), g_strdup ("0.00"));
+    else
+        g_hash_table_replace (stats,
+                              g_strdup ("writeAmplificationRatio"),
+                              g_strdup_printf ("%.2f", (gfloat) (bios_meta_write + bios_out_write) / (gfloat) bios_in_write));
+}
+
+static void add_block_stats (GHashTable *stats) {
+    gint64 physical_blocks, block_size, data_blocks_used, overhead_blocks_used, logical_blocks_used;
+    gint64 savings;
+
+    if (! get_stat_val (stats, "physical_blocks", &physical_blocks) ||
+        ! get_stat_val (stats, "block_size", &block_size) ||
+        ! get_stat_val (stats, "data_blocks_used", &data_blocks_used) ||
+        ! get_stat_val (stats, "overhead_blocks_used", &overhead_blocks_used) ||
+        ! get_stat_val (stats, "logical_blocks_used", &logical_blocks_used))
+        return;
+
+    g_hash_table_replace (stats, g_strdup ("oneKBlocks"), g_strdup_printf ("%ld", physical_blocks * block_size / 1024));
+    g_hash_table_replace (stats, g_strdup ("oneKBlocksUsed"), g_strdup_printf ("%ld", (data_blocks_used + overhead_blocks_used) * block_size / 1024));
+    g_hash_table_replace (stats, g_strdup ("oneKBlocksAvailable"), g_strdup_printf ("%ld", (physical_blocks - data_blocks_used - overhead_blocks_used) * block_size / 1024));
+    g_hash_table_replace (stats, g_strdup ("usedPercent"), g_strdup_printf ("%.0f", 100.0 * (gfloat) (data_blocks_used + overhead_blocks_used) / (gfloat) physical_blocks + 0.5));
+    savings = (logical_blocks_used > 0) ? (gint64) (100.0 * (gfloat) (logical_blocks_used - data_blocks_used) / (gfloat) logical_blocks_used) : -1;
+    g_hash_table_replace (stats, g_strdup ("savings"), g_strdup_printf ("%ld", savings));
+    if (savings >= 0)
+        g_hash_table_replace (stats, g_strdup ("savingPercent"), g_strdup_printf ("%ld", savings));
+}
+
+static void add_journal_stats (GHashTable *stats) {
+    gint64 journal_entries_committed, journal_entries_started, journal_entries_written;
+    gint64 journal_blocks_committed, journal_blocks_started, journal_blocks_written;
+
+    if (! get_stat_val (stats, "journal_entries_committed", &journal_entries_committed) ||
+        ! get_stat_val (stats, "journal_entries_started", &journal_entries_started) ||
+        ! get_stat_val (stats, "journal_entries_written", &journal_entries_written) ||
+        ! get_stat_val (stats, "journal_blocks_committed", &journal_blocks_committed) ||
+        ! get_stat_val (stats, "journal_blocks_started", &journal_blocks_started) ||
+        ! get_stat_val (stats, "journal_blocks_written", &journal_blocks_written))
+        return;
+
+    g_hash_table_replace (stats, g_strdup ("journal_entries_batching"), g_strdup_printf ("%ld", journal_entries_started - journal_entries_written));
+    g_hash_table_replace (stats, g_strdup ("journal_entries_writing"), g_strdup_printf ("%ld", journal_entries_written - journal_entries_committed));
+    g_hash_table_replace (stats, g_strdup ("journal_blocks_batching"), g_strdup_printf ("%ld", journal_blocks_started - journal_blocks_written));
+    g_hash_table_replace (stats, g_strdup ("journal_blocks_writing"), g_strdup_printf ("%ld", journal_blocks_written - journal_blocks_committed));
+}
+
+static void add_computed_stats (GHashTable *stats) {
+    const gchar *s;
+
+    s = g_hash_table_lookup (stats, "logical_block_size");
+    g_hash_table_replace (stats,
+                          g_strdup ("fiveTwelveByteEmulation"),
+                          g_strdup ((g_strcmp0 (s, "512") == 0) ? "true" : "false"));
+
+    add_write_ampl_r_stats (stats);
+    add_block_stats (stats);
+    add_journal_stats (stats);
+}
+
+/**
+ * bd_vdo_get_statistics:
+ * @name: name of an existing VDO volume
+ * @extra: (allow-none) (array zero-terminated=1): extra options, currently unused
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (element-type utf8 utf8): hashtable of type string - string of available statistics
+ *
+ * Statistics are collected from the values exposed by the kernel `kvdo` module at the `/sys/kvdo/<VDO_NAME>/statistics/` path. Some of the keys are computed to mimic the information produced by the vdo tools.
+ *
+ * Tech category: %BD_VDO_TECH_VDO-%BD_VDO_TECH_MODE_QUERY
+ */
+GHashTable* bd_vdo_get_statistics (const gchar *name, const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
+    GHashTable *stats;
+    GDir *dir;
+    gchar *stats_dir;
+    const gchar *direntry;
+    gchar *s;
+    gchar *val;
+
+    if (!check_deps (&avail_deps, DEPS_VDO_MASK, deps, DEPS_LAST, &deps_check_lock, error) ||
+        !check_module_deps (&avail_module_deps, MODULE_DEPS_VDO_MASK, module_deps, MODULE_DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    /* TODO: does the `name` need to be escaped? */
+    stats_dir = g_build_path (G_DIR_SEPARATOR_S, "/sys/kvdo", name, "statistics", NULL);
+    dir = g_dir_open (stats_dir, 0, error);
+    if (dir == NULL) {
+        g_free (stats_dir);
+        return NULL;
+    }
+
+    stats = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+    while ((direntry = g_dir_read_name (dir))) {
+        s = g_build_filename (stats_dir, direntry, NULL);
+        if (! g_file_get_contents (s, &val, NULL, error)) {
+            g_free (s);
+            g_hash_table_destroy (stats);
+            stats = NULL;
+            break;
+        }
+        g_hash_table_replace (stats, g_strdup (direntry), g_strdup (g_strstrip (val)));
+        g_free (val);
+        g_free (s);
+    }
+    g_dir_close (dir);
+    g_free (stats_dir);
+
+    if (stats != NULL)
+        add_computed_stats (stats);
+
+    return stats;
+}

--- a/src/plugins/vdo.h
+++ b/src/plugins/vdo.h
@@ -88,4 +88,6 @@ gboolean bd_vdo_stop (const gchar *name, gboolean force, const BDExtraArg **extr
 gboolean bd_vdo_grow_logical (const gchar *name, guint64 size, const BDExtraArg **extra, GError **error);
 gboolean bd_vdo_grow_physical (const gchar *name, const BDExtraArg **extra, GError **error);
 
+GHashTable* bd_vdo_get_statistics (const gchar *name, const BDExtraArg **extra, GError **error);
+
 #endif  /* BD_VDO */

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -860,6 +860,13 @@ def vdo_grow_physical(name, extra=None, **kwargs):
     return _vdo_grow_physical(name, extra)
 __all__.append("vdo_grow_physical")
 
+_vdo_get_statistics = BlockDev.vdo_get_statistics
+@override(BlockDev.vdo_get_statistics)
+def vdo_get_statistics(name, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _vdo_get_statistics(name, extra)
+__all__.append("vdo_get_statistics")
+
 
 ## defined in this overrides only!
 def plugin_specs_from_names(plugin_names):

--- a/tests/vdo_test.py
+++ b/tests/vdo_test.py
@@ -4,6 +4,7 @@ import os
 import yaml
 import unittest
 import overrides_hack
+import six
 
 from utils import run_command, read_file, skip_on, fake_path, create_sparse_tempfile, create_lio_device, delete_lio_device
 from gi.repository import BlockDev, GLib
@@ -276,6 +277,20 @@ class VDOTest(VDOTestCase):
         self.assertIsNotNone(info_after)
         self.assertEqual(info_before.logical_size, info_after.logical_size)
         self.assertGreater(info_after.physical_size, info_before.physical_size)
+
+    def test_statistics(self):
+        """Verify that it is possible to retrieve statistics of an existing VDO volume"""
+
+        ret = BlockDev.vdo_create(self.vdo_name, self.loop_dev)
+        self.addCleanup(self._remove_vdo, self.vdo_name)
+        self.assertTrue(ret)
+
+        with six.assertRaisesRegex(self, GLib.GError, "No such file or directory"):
+            stats = BlockDev.vdo_get_statistics("nonexistingxxx")
+
+        stats = BlockDev.vdo_get_statistics(self.vdo_name)
+        self.assertIsNotNone(stats)
+        self.assertGreater(len(stats), 0)
 
 
 class VDOUnloadTest(VDOTestCase):


### PR DESCRIPTION
This exposes statistics of the specified VDO volume. Instead of calling either
`vdostats` or `vdo info` whose output keys are human-readable strings with
no stability guarantees the statistics are actually taken from /sys/kvdo structure
which seems to be reasonably stable.

There are some keys that are computed by the vdo tools from existing values
so those are backported.

The fact that no calls to the vdo tools are involved makes this function suitable
for reuse within potential VDO support integration in the LVM module. Also since
there's no real I/O involved this function should be reasonably fast.