### PR TITLE
BlockDev.py Convert dictionary keys to list before using them

### DIFF
--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -942,7 +942,7 @@ class ErrorProxy(object):
         """Let's make TAB-TAB in ipython work!"""
 
         if self._use_local:
-            items = set(dir(self._mod) + locals().keys())
+            items = set(dir(self._mod)) | set(locals().keys())
         else:
             items = set(dir(self._mod))
 


### PR DESCRIPTION
"dict_keys" is a special type in Python 3, not a list-like object.

Fixes: #373 