### PR TITLE
Fix lots of compiler warnings

### DIFF
--- a/src/lib/blockdev.c.in
+++ b/src/lib/blockdev.c.in
@@ -183,7 +183,7 @@ static gboolean load_config (GSequence *config_files, GSList **plugins_sonames, 
     return TRUE;
 }
 
-static void unload_plugins () {
+static void unload_plugins (void) {
     if (plugins[BD_PLUGIN_LVM].handle && !unload_lvm (plugins[BD_PLUGIN_LVM].handle))
         g_warning ("Failed to close the lvm plugin");
     plugins[BD_PLUGIN_LVM].handle = NULL;
@@ -378,7 +378,7 @@ static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload, g
     return requested_loaded;
 }
 
-GQuark bd_init_error_quark ()
+GQuark bd_init_error_quark (void)
 {
     return g_quark_from_static_string ("g-bd-init-error-quark");
 }
@@ -694,7 +694,7 @@ gboolean bd_try_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtils
  * was/were called and either at least one plugin is loaded or 0 plugins are
  * loaded after an explicit call that requested 0 plugins to be loaded.
  */
-gboolean bd_is_initialized () {
+gboolean bd_is_initialized (void) {
     gboolean is = FALSE;
     g_mutex_lock (&init_lock);
     is = initialized;
@@ -708,7 +708,7 @@ gboolean bd_is_initialized () {
  * Returns: (transfer container) (array zero-terminated=1): an array of string
  * names of plugins that are available
  */
-gchar** bd_get_available_plugin_names () {
+gchar** bd_get_available_plugin_names (void) {
     guint8 i = 0;
     guint8 num_loaded = 0;
     guint8 next = 0;

--- a/src/lib/blockdev.h
+++ b/src/lib/blockdev.h
@@ -9,7 +9,7 @@
 /**
  * bd_init_error_quark: (skip)
  */
-GQuark bd_init_error_quark ();
+GQuark bd_init_error_quark (void);
 #define BD_INIT_ERROR bd_init_error_quark ()
 typedef enum {
     BD_INIT_ERROR_PLUGINS_FAILED,
@@ -24,7 +24,7 @@ gboolean bd_try_init(BDPluginSpec **request_plugins, BDUtilsLogFunc log_func,
                      gchar ***loaded_plugin_names, GError **error);
 gboolean bd_try_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtilsLogFunc log_func,
                         gchar ***loaded_plugin_names, GError **error);
-gboolean bd_is_initialized ();
+gboolean bd_is_initialized (void);
 gboolean bd_switch_init_checks (gboolean enable, GError **error);
 
 #endif  /* BD_LIB */

--- a/src/lib/plugins.c
+++ b/src/lib/plugins.c
@@ -33,7 +33,7 @@ void bd_plugin_spec_free (BDPluginSpec *spec) {
     g_free (spec);
 }
 
-GType bd_plugin_spec_get_type () {
+GType bd_plugin_spec_get_type (void) {
     static GType type = 0;
 
     if (G_UNLIKELY(type == 0)) {

--- a/src/lib/plugins.h
+++ b/src/lib/plugins.h
@@ -23,7 +23,7 @@ typedef enum {
 } BDPlugin;
 
 #define BD_TYPE_PLUGIN_SPEC (bd_plugin_spec_get_type ())
-GType bd_plugin_spec_get_type();
+GType bd_plugin_spec_get_type(void);
 
 typedef struct BDPluginSpec {
     BDPlugin name;
@@ -34,7 +34,7 @@ BDPluginSpec* bd_plugin_spec_copy (BDPluginSpec *spec);
 void bd_plugin_spec_free (BDPluginSpec *spec);
 
 gboolean bd_is_plugin_available (BDPlugin plugin);
-gchar** bd_get_available_plugin_names ();
+gchar** bd_get_available_plugin_names (void);
 gchar* bd_get_plugin_soname (BDPlugin plugin);
 gchar* bd_get_plugin_name (BDPlugin plugin);
 

--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -136,7 +136,7 @@ static gchar* module_deps[MODULE_DEPS_LAST] = { "btrfs" };
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_btrfs_check_deps () {
+gboolean bd_btrfs_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -175,7 +175,7 @@ gboolean bd_btrfs_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_btrfs_init () {
+gboolean bd_btrfs_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -187,7 +187,7 @@ gboolean bd_btrfs_init () {
  * library's functions that unload it.**
  *
  */
-void bd_btrfs_close () {
+void bd_btrfs_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -117,7 +117,7 @@ static GMutex deps_check_lock;
 #define DEPS_BTRFS_MASK (1 << DEPS_BTRFS)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"btrfs", BTRFS_MIN_VERSION, NULL, "[Bb]trfs.* v([\\d\\.]+)"},
 };
 
@@ -125,7 +125,7 @@ static UtilDep deps[DEPS_LAST] = {
 #define MODULE_DEPS_BTRFS_MASK (1 << MODULE_DEPS_BTRFS)
 #define MODULE_DEPS_LAST 1
 
-static gchar* module_deps[MODULE_DEPS_LAST] = { "btrfs" };
+static const gchar*const module_deps[MODULE_DEPS_LAST] = { "btrfs" };
 
 
 /**

--- a/src/plugins/btrfs.h
+++ b/src/plugins/btrfs.h
@@ -71,9 +71,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_btrfs_check_deps ();
-gboolean bd_btrfs_init ();
-void bd_btrfs_close ();
+gboolean bd_btrfs_check_deps (void);
+gboolean bd_btrfs_init (void);
+void bd_btrfs_close (void);
 
 gboolean bd_btrfs_is_tech_avail (BDBtrfsTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/check_deps.c
+++ b/src/plugins/check_deps.c
@@ -23,7 +23,7 @@
 #include "check_deps.h"
 
 gboolean __attribute__ ((visibility ("hidden")))
-check_deps (volatile guint *avail_deps, guint req_deps, UtilDep *deps_specs, guint l_deps, GMutex *deps_check_lock, GError **error) {
+check_deps (volatile guint *avail_deps, guint req_deps, const UtilDep *deps_specs, guint l_deps, GMutex *deps_check_lock, GError **error) {
     guint i = 0;
     gboolean ret = FALSE;
     GError *l_error = NULL;
@@ -68,7 +68,7 @@ check_deps (volatile guint *avail_deps, guint req_deps, UtilDep *deps_specs, gui
 }
 
 gboolean __attribute__ ((visibility ("hidden")))
-check_module_deps (volatile guint *avail_deps, guint req_deps, gchar **modules, guint l_modules, GMutex *deps_check_lock, GError **error) {
+check_module_deps (volatile guint *avail_deps, guint req_deps, const gchar *const*modules, guint l_modules, GMutex *deps_check_lock, GError **error) {
     guint i = 0;
     gboolean ret = FALSE;
     GError *l_error = NULL;

--- a/src/plugins/check_deps.h
+++ b/src/plugins/check_deps.h
@@ -20,11 +20,11 @@
 #include <glib.h>
 
 typedef struct UtilDep {
-    gchar *name;
-    gchar *version;
-    gchar *ver_arg;
-    gchar *ver_regexp;
+    const gchar *name;
+    const gchar *version;
+    const gchar *ver_arg;
+    const gchar *ver_regexp;
 } UtilDep;
 
-gboolean check_deps (volatile guint *avail_deps, guint req_deps, UtilDep *deps_specs, guint l_deps, GMutex *deps_check_lock, GError **error);
-gboolean check_module_deps (volatile guint *avail_deps, guint req_deps, gchar **modules, guint l_modules, GMutex *deps_check_lock, GError **error);
+gboolean check_deps (volatile guint *avail_deps, guint req_deps, const UtilDep *deps_specs, guint l_deps, GMutex *deps_check_lock, GError **error);
+gboolean check_module_deps (volatile guint *avail_deps, guint req_deps, const gchar *const*modules, guint l_modules, GMutex *deps_check_lock, GError **error);

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -582,7 +582,7 @@ guint64 bd_crypto_luks_get_metadata_size (const gchar *device, GError **error) {
 gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error) {
     struct crypt_device *cd = NULL;
     gint ret_num;
-    gchar *ret = NULL;
+    const gchar *ret = NULL;
     crypt_status_info status;
 
     ret_num = crypt_init_by_name (&cd, luks_device);
@@ -613,7 +613,10 @@ gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error) {
     }
 
     crypt_free (cd);
-    return ret;
+    /* cast the "const" away because this API requires returning a
+       non-const string, though the caller isn't allowed to modify its
+       contents */
+    return (gchar *)ret;
 }
 
 #ifdef LIBCRYPTSETUP_2

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -211,7 +211,7 @@ static locale_t c_locale = (locale_t) 0;
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_crypto_check_deps () {
+gboolean bd_crypto_check_deps (void) {
     /* nothing to do here */
     return TRUE;
 }
@@ -249,7 +249,7 @@ static void crypto_log_redirect (gint level, const gchar *msg, void *usrptr __at
  * library's initialization functions.**
  *
  */
-gboolean bd_crypto_init () {
+gboolean bd_crypto_init (void) {
     c_locale = newlocale (LC_ALL_MASK, "C", c_locale);
     crypt_set_log_callback (NULL, &crypto_log_redirect, NULL);
     return TRUE;
@@ -262,7 +262,7 @@ gboolean bd_crypto_init () {
  * library's functions that unload it.**
  *
  */
-void bd_crypto_close () {
+void bd_crypto_close (void) {
     c_locale = (locale_t) 0;
     crypt_set_log_callback (NULL, NULL, NULL);
 }

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -171,9 +171,9 @@ BDCryptoIntegrityInfo* bd_crypto_integrity_info_copy (BDCryptoIntegrityInfo *inf
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_crypto_check_deps ();
-gboolean bd_crypto_init ();
-void bd_crypto_close ();
+gboolean bd_crypto_check_deps (void);
+gboolean bd_crypto_init (void);
+void bd_crypto_close (void);
 
 gboolean bd_crypto_is_tech_avail (BDCryptoTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -64,7 +64,7 @@ static GMutex deps_check_lock;
 #define DEPS_DMSETUP_MASK (1 << DEPS_DMSETUP)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"dmsetup", DM_MIN_VERSION, NULL, "Library version:\\s+([\\d\\.]+)"},
 };
 

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -85,7 +85,7 @@ static void discard_dm_log (int level __attribute__((unused)), const char *file 
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_dm_check_deps () {
+gboolean bd_dm_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -115,7 +115,7 @@ gboolean bd_dm_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_dm_init () {
+gboolean bd_dm_init (void) {
     dm_log_with_errno_init ((dm_log_with_errno_fn) discard_dm_log);
     dm_log_init_verbose (0);
 
@@ -129,7 +129,7 @@ gboolean bd_dm_init () {
  * library's functions that unload it.**
  *
  */
-void bd_dm_close () {
+void bd_dm_close (void) {
     dm_log_with_errno_init (NULL);
     dm_log_init_verbose (0);
 }

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -405,7 +405,7 @@ gboolean bd_dm_map_exists (const gchar *map_name, gboolean live_only, gboolean a
  */
 static struct lib_context* init_dmraid_stack (GError **error) {
     gint rc = 0;
-    gchar *argv[] = {"blockdev.dmraid", NULL};
+    gchar *argv[] = {(gchar *)"blockdev.dmraid", NULL};
     struct lib_context *lc;
 
     /* the code for this function was cherry-picked from the pyblock code */

--- a/src/plugins/dm.h
+++ b/src/plugins/dm.h
@@ -37,9 +37,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_dm_check_deps ();
-gboolean bd_dm_init ();
-void bd_dm_close ();
+gboolean bd_dm_check_deps (void);
+gboolean bd_dm_init (void);
+void bd_dm_close (void);
 
 gboolean bd_dm_is_tech_avail (BDDMTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -55,7 +55,7 @@ GQuark bd_fs_error_quark (void)
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_fs_check_deps () {
+gboolean bd_fs_check_deps (void) {
     gboolean ret = TRUE;
     guint i = 0;
     GError *error = NULL;
@@ -92,7 +92,7 @@ gboolean bd_fs_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_fs_init () {
+gboolean bd_fs_init (void) {
     ped_exception_set_handler ((PedExceptionHandler*) bd_exc_handler);
     return TRUE;
 }
@@ -104,7 +104,7 @@ gboolean bd_fs_init () {
  * library's functions that unload it.**
  *
  */
-void bd_fs_close () {
+void bd_fs_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -54,9 +54,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_fs_check_deps ();
-gboolean bd_fs_init ();
-void bd_fs_close ();
+gboolean bd_fs_check_deps (void);
+gboolean bd_fs_init (void);
+void bd_fs_close (void);
 
 gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -44,7 +44,7 @@ static GMutex deps_check_lock;
 
 #define DEPS_LAST 5
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"mke2fs", NULL, NULL, NULL},
     {"e2fsck", NULL, NULL, NULL},
     {"tune2fs", NULL, NULL, NULL},

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -41,7 +41,7 @@ static GMutex deps_check_lock;
 
 #define DEPS_LAST 5
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"mkntfs", NULL, NULL, NULL},
     {"ntfsfix", NULL, NULL, NULL},
     {"ntfsresize", NULL, NULL, NULL},

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -40,7 +40,7 @@ static GMutex deps_check_lock;
 
 #define DEPS_LAST 3
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"mkfs.vfat", NULL, NULL, NULL},
     {"fatlabel", NULL, NULL, NULL},
     {"fsck.vfat", NULL, NULL, NULL},

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -42,7 +42,7 @@ static GMutex deps_check_lock;
 
 #define DEPS_LAST 5
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"mkfs.xfs", NULL, NULL, NULL},
     {"xfs_db", NULL, NULL, NULL},
     {"xfs_repair", NULL, NULL, NULL},

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -681,7 +681,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (const gchar *device, GError **error) {
 }
 
 
-gboolean wait_for_file (const char *filename) {
+static gboolean wait_for_file (const char *filename) {
     gint count = 500;
     while (count > 0) {
         g_usleep (100000); /* microseconds */

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -53,7 +53,7 @@ static GMutex deps_check_lock;
 #define DEPS_MAKEBCACHE_MASK (1 << DEPS_MAKEBCACHE)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"make-bcache", NULL, NULL, NULL},
 };
 

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -66,7 +66,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_kbd_check_deps () {
+gboolean bd_kbd_check_deps (void) {
     GError *error = NULL;
     gboolean ret = FALSE;
     guint i = 0;
@@ -122,7 +122,7 @@ gboolean bd_kbd_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_kbd_init () {
+gboolean bd_kbd_init (void) {
     c_locale = newlocale (LC_ALL_MASK, "C", c_locale);
     return TRUE;
 }
@@ -134,7 +134,7 @@ gboolean bd_kbd_init () {
  * library's functions that unload it.**
  *
  */
-void bd_kbd_close () {
+void bd_kbd_close (void) {
     freelocale (c_locale);
 }
 

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -83,9 +83,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_kbd_check_deps ();
-gboolean bd_kbd_init ();
-void bd_kbd_close ();
+gboolean bd_kbd_check_deps (void);
+gboolean bd_kbd_init (void);
+void bd_kbd_close (void);
 
 gboolean bd_kbd_is_tech_avail (BDKBDTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -55,7 +55,7 @@ GQuark bd_loop_error_quark (void)
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_loop_check_deps () {
+gboolean bd_loop_check_deps (void) {
     /* nothing to check here */
     return TRUE;
 }
@@ -67,7 +67,7 @@ gboolean bd_loop_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_loop_init () {
+gboolean bd_loop_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -79,7 +79,7 @@ gboolean bd_loop_init () {
  * library's functions that unload it.**
  *
  */
-void bd_loop_close () {
+void bd_loop_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -34,9 +34,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_loop_check_deps ();
-gboolean bd_loop_init ();
-void bd_loop_close ();
+gboolean bd_loop_check_deps (void);
+gboolean bd_loop_init (void);
+void bd_loop_close (void);
 
 gboolean bd_loop_is_tech_avail (BDLoopTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -2544,7 +2544,7 @@ guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error __a
  *
  * Get LV type string from flags.
  */
-static gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error __attribute__((unused))) {
+static const gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error __attribute__((unused))) {
     if (!meta) {
         if (flags & BD_LVM_CACHE_POOL_STRIPED)
             return "striped";
@@ -2640,7 +2640,7 @@ BDLVMCacheMode bd_lvm_cache_get_mode_from_str (const gchar *mode_str, GError **e
  */
 gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, const gchar **fast_pvs, GError **error) {
     gboolean success = FALSE;
-    gchar *type = NULL;
+    const gchar *type = NULL;
     gchar *name = NULL;
     GVariantBuilder builder;
     GVariant *params = NULL;

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -242,7 +242,7 @@ static GMutex deps_check_lock;
 #define DEPS_THMS_MASK (1 << DEPS_THMS)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"thin_metadata_size", NULL, NULL, NULL},
 };
 

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -64,7 +64,7 @@ static gchar *global_config_str = NULL;
 static GDBusConnection *bus = NULL;
 
 /* "friend" functions from the utils library */
-guint64 get_next_task_id ();
+guint64 get_next_task_id (void);
 void log_task_status (guint64 task_id, const gchar *msg);
 
 /**
@@ -255,7 +255,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_lvm_check_deps () {
+gboolean bd_lvm_check_deps (void) {
     GVariant *ret = NULL;
     GVariant *real_ret = NULL;
     GVariantIter iter;
@@ -346,7 +346,7 @@ gboolean bd_lvm_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_lvm_init () {
+gboolean bd_lvm_init (void) {
     GError *error = NULL;
 
     /* the check() call should create the DBus connection for us, but let's not
@@ -366,7 +366,7 @@ gboolean bd_lvm_init () {
  * library's functions that unload it.**
  *
  */
-void bd_lvm_close () {
+void bd_lvm_close (void) {
     GError *error = NULL;
 
     /* the check() call should create the DBus connection for us, but let's not

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -1922,7 +1922,7 @@ guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error __a
  *
  * Get LV type string from flags.
  */
-static gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error __attribute__((unused))) {
+static const gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error __attribute__((unused))) {
     if (!meta) {
         if (flags & BD_LVM_CACHE_POOL_STRIPED)
             return "striped";
@@ -2018,7 +2018,7 @@ BDLVMCacheMode bd_lvm_cache_get_mode_from_str (const gchar *mode_str, GError **e
  */
 gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, const gchar **fast_pvs, GError **error) {
     gboolean success = FALSE;
-    gchar *type = NULL;
+    const gchar *type = NULL;
     gchar *name = NULL;
     gchar *msg = NULL;
     guint64 progress_id = 0;

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -186,7 +186,7 @@ static GMutex deps_check_lock;
 #define DEPS_THMS_MASK (1 << DEPS_THMS)
 #define DEPS_LAST 2
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"lvm", LVM_MIN_VERSION, "version", "LVM version:\\s+([\\d\\.]+)"},
     {"thin_metadata_size", NULL, NULL, NULL},
 };

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -200,7 +200,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_lvm_check_deps () {
+gboolean bd_lvm_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -230,7 +230,7 @@ gboolean bd_lvm_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_lvm_init () {
+gboolean bd_lvm_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -242,7 +242,7 @@ gboolean bd_lvm_init () {
  * library's functions that unload it.**
  *
  */
-void bd_lvm_close () {
+void bd_lvm_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -165,9 +165,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_lvm_check_deps ();
-gboolean bd_lvm_init ();
-void bd_lvm_close ();
+gboolean bd_lvm_check_deps (void);
+gboolean bd_lvm_init (void);
+void bd_lvm_close (void);
 
 gboolean bd_lvm_is_tech_avail (BDLVMTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -160,7 +160,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_md_check_deps () {
+gboolean bd_md_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -191,7 +191,7 @@ gboolean bd_md_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_md_init () {
+gboolean bd_md_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -203,7 +203,7 @@ gboolean bd_md_init () {
  * library's functions that unload it.**
  *
  */
-void bd_md_close () {
+void bd_md_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -147,7 +147,7 @@ static GMutex deps_check_lock;
 #define DEPS_MDADM_MASK (1 << DEPS_MDADM)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"mdadm", MDADM_MIN_VERSION, NULL, "mdadm - v([\\d\\.]+)"},
 };
 

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -81,9 +81,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_md_check_deps ();
-gboolean bd_md_init ();
-void bd_md_close ();
+gboolean bd_md_check_deps (void);
+gboolean bd_md_init (void);
+void bd_md_close (void);
 
 gboolean bd_md_is_tech_avail (BDMDTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/mpath.c
+++ b/src/plugins/mpath.c
@@ -67,7 +67,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_mpath_check_deps () {
+gboolean bd_mpath_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -97,7 +97,7 @@ gboolean bd_mpath_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_mpath_init () {
+gboolean bd_mpath_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -109,7 +109,7 @@ gboolean bd_mpath_init () {
  * library's functions that unload it.**
  *
  */
-void bd_mpath_close () {
+void bd_mpath_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/mpath.c
+++ b/src/plugins/mpath.c
@@ -53,7 +53,7 @@ static GMutex deps_check_lock;
 #define DEPS_MPATHCONF_MASK (1 << DEPS_MPATHCONF)
 #define DEPS_LAST 2
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"multipath", MULTIPATH_MIN_VERSION, NULL, "multipath-tools v([\\d\\.]+)"},
     {"mpathconf", NULL, NULL, NULL},
 };

--- a/src/plugins/mpath.h
+++ b/src/plugins/mpath.h
@@ -35,9 +35,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_mpath_check_deps ();
-gboolean bd_mpath_init ();
-void bd_mpath_close ();
+gboolean bd_mpath_check_deps (void);
+gboolean bd_mpath_init (void);
+void bd_mpath_close (void);
 
 gboolean bd_mpath_is_tech_avail (BDMpathTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -91,7 +91,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_nvdimm_check_deps () {
+gboolean bd_nvdimm_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -121,7 +121,7 @@ gboolean bd_nvdimm_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_nvdimm_init () {
+gboolean bd_nvdimm_init (void) {
     /* nothing to do here */
     return TRUE;
 }
@@ -133,7 +133,7 @@ gboolean bd_nvdimm_init () {
  * library's functions that unload it.**
  *
  */
-void bd_nvdimm_close () {
+void bd_nvdimm_close (void) {
     /* nothing to do here */
     return;
 }

--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -79,7 +79,7 @@ static GMutex deps_check_lock;
 #define DEPS_NDCTL_MASK (1 << DEPS_NDCTL)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"ndctl", NULL, NULL, NULL},
 };
 

--- a/src/plugins/nvdimm.h
+++ b/src/plugins/nvdimm.h
@@ -58,9 +58,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_nvdimm_check_deps ();
-gboolean bd_nvdimm_init ();
-void bd_nvdimm_close ();
+gboolean bd_nvdimm_check_deps (void);
+gboolean bd_nvdimm_init (void);
+void bd_nvdimm_close (void);
 
 gboolean bd_nvdimm_is_tech_avail (BDNVDIMMTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -159,7 +159,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_part_check_deps () {
+gboolean bd_part_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -189,7 +189,7 @@ gboolean bd_part_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_part_init () {
+gboolean bd_part_init (void) {
     ped_exception_set_handler ((PedExceptionHandler*) bd_exc_handler);
     return TRUE;
 }
@@ -201,7 +201,7 @@ gboolean bd_part_init () {
  * library's functions that unload it.**
  *
  */
-void bd_part_close () {
+void bd_part_close (void) {
     ped_exception_set_handler (NULL);
 }
 

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -145,7 +145,7 @@ static GMutex deps_check_lock;
 #define DEPS_SFDISK_MASK (1 << DEPS_SFDISK)
 #define DEPS_LAST 2
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"sgdisk", "0.8.6", NULL, "GPT fdisk \\(sgdisk\\) version ([\\d\\.]+)"},
     {"sfdisk", NULL, NULL, NULL},
 };

--- a/src/plugins/part.h
+++ b/src/plugins/part.h
@@ -129,9 +129,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_part_check_deps ();
-gboolean bd_part_init ();
-void bd_part_close ();
+gboolean bd_part_check_deps (void);
+gboolean bd_part_init (void);
+void bd_part_close (void);
 
 gboolean bd_part_is_tech_avail (BDPartTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/part_err.c
+++ b/src/plugins/part_err.c
@@ -33,6 +33,6 @@ PedExceptionOption bd_exc_handler (PedException *ex) {
     return PED_EXCEPTION_UNHANDLED;
 }
 
-gchar * bd_get_error_msg () {
+gchar * bd_get_error_msg (void) {
   return g_strdup (error_msg);
 }

--- a/src/plugins/part_err.h
+++ b/src/plugins/part_err.h
@@ -5,6 +5,6 @@
 #define BD_UTILS_PARTED
 
 PedExceptionOption bd_exc_handler (PedException *ex);
-gchar * bd_get_error_msg ();
+gchar * bd_get_error_msg (void);
 
 #endif /* BD_UTILS_PARTED */

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -69,7 +69,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_s390_check_deps () {
+gboolean bd_s390_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -99,7 +99,7 @@ gboolean bd_s390_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_s390_init () {
+gboolean bd_s390_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -111,7 +111,7 @@ gboolean bd_s390_init () {
  * library's functions that unload it.**
  *
  */
-void bd_s390_close () {
+void bd_s390_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -55,7 +55,7 @@ static GMutex deps_check_lock;
 #define DEPS_DASDFMT_MASK (1 << DEPS_DASDFMT)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     /* dasdfmt doesn't return version info */
     {"dasdfmt", NULL, NULL, NULL},
 };

--- a/src/plugins/s390.h
+++ b/src/plugins/s390.h
@@ -30,9 +30,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_s390_check_deps ();
-gboolean bd_s390_init ();
-void bd_s390_close ();
+gboolean bd_s390_check_deps (void);
+gboolean bd_s390_init (void);
+void bd_s390_close (void);
 
 gboolean bd_s390_is_tech_avail (BDS390Tech tech, guint64 mode, GError **error);
 

--- a/src/plugins/swap.c
+++ b/src/plugins/swap.c
@@ -67,7 +67,7 @@ static UtilDep deps[DEPS_LAST] = {
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_swap_check_deps () {
+gboolean bd_swap_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -97,7 +97,7 @@ gboolean bd_swap_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_swap_init () {
+gboolean bd_swap_init (void) {
     /* nothing to do here */
     return TRUE;
 };
@@ -109,7 +109,7 @@ gboolean bd_swap_init () {
  * library's functions that unload it.**
  *
  */
-void bd_swap_close () {
+void bd_swap_close (void) {
     /* nothing to do here */
 }
 

--- a/src/plugins/swap.c
+++ b/src/plugins/swap.c
@@ -53,7 +53,7 @@ static GMutex deps_check_lock;
 #define DEPS_SWAPLABEL_MASK (1 << DEPS_SWAPLABEL)
 #define DEPS_LAST 2
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"mkswap", MKSWAP_MIN_VERSION, NULL, "mkswap from util-linux ([\\d\\.]+)"},
     {"swaplabel", NULL, NULL, NULL},
 };

--- a/src/plugins/swap.h
+++ b/src/plugins/swap.h
@@ -34,9 +34,9 @@ typedef enum {
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_swap_check_deps ();
-gboolean bd_swap_init ();
-void bd_swap_close ();
+gboolean bd_swap_check_deps (void);
+gboolean bd_swap_init (void);
+void bd_swap_close (void);
 
 gboolean bd_swap_is_tech_avail (BDSwapTech tech, guint64 mode, GError **error);
 

--- a/src/plugins/vdo.c
+++ b/src/plugins/vdo.c
@@ -95,7 +95,7 @@ static gchar* module_deps[MODULE_DEPS_LAST] = { "kvdo" };
  * Function checking plugin's runtime dependencies.
  *
  */
-gboolean bd_vdo_check_deps () {
+gboolean bd_vdo_check_deps (void) {
     GError *error = NULL;
     guint i = 0;
     gboolean status = FALSE;
@@ -134,7 +134,7 @@ gboolean bd_vdo_check_deps () {
  * library's initialization functions.**
  *
  */
-gboolean bd_vdo_init () {
+gboolean bd_vdo_init (void) {
     /* nothing to do here */
     return TRUE;
 }
@@ -146,7 +146,7 @@ gboolean bd_vdo_init () {
  * library's functions that unload it.**
  *
  */
-void bd_vdo_close () {
+void bd_vdo_close (void) {
     /* nothing to do here */
     return;
 }

--- a/src/plugins/vdo.c
+++ b/src/plugins/vdo.c
@@ -77,7 +77,7 @@ static GMutex deps_check_lock;
 #define DEPS_VDO_MASK (1 << DEPS_VDO)
 #define DEPS_LAST 1
 
-static UtilDep deps[DEPS_LAST] = {
+static const UtilDep deps[DEPS_LAST] = {
     {"vdo", NULL, NULL, NULL},
 };
 
@@ -85,7 +85,7 @@ static UtilDep deps[DEPS_LAST] = {
 #define MODULE_DEPS_VDO_MASK (1 << MODULE_DEPS_VDO)
 #define MODULE_DEPS_LAST 1
 
-static gchar* module_deps[MODULE_DEPS_LAST] = { "kvdo" };
+static const gchar*const module_deps[MODULE_DEPS_LAST] = { "kvdo" };
 
 /**
  * bd_vdo_check_deps:

--- a/src/plugins/vdo.h
+++ b/src/plugins/vdo.h
@@ -58,9 +58,9 @@ BDVDOInfo* bd_vdo_info_copy (BDVDOInfo *info);
  * close()      - clean after the plugin at the end or if no longer used
  *
  */
-gboolean bd_vdo_check_deps ();
-gboolean bd_vdo_init ();
-void bd_vdo_close ();
+gboolean bd_vdo_check_deps (void);
+gboolean bd_vdo_init (void);
+void bd_vdo_close (void);
 
 gboolean bd_vdo_is_tech_avail (BDVDOTech tech, guint64 mode, GError **error);
 

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -794,7 +794,7 @@ gboolean bd_utils_prog_reporting_initialized (void) {
  *
  * Returns: ID of the started task/action
  */
-guint64 bd_utils_report_started (gchar *msg) {
+guint64 bd_utils_report_started (const gchar *msg) {
     guint64 task_id = 0;
     BDUtilsProgFunc current_prog_func;
 
@@ -806,7 +806,7 @@ guint64 bd_utils_report_started (gchar *msg) {
     g_mutex_unlock (&task_id_counter_lock);
 
     if (current_prog_func)
-        current_prog_func (task_id, BD_UTILS_PROG_STARTED, 0, msg);
+        current_prog_func (task_id, BD_UTILS_PROG_STARTED, 0, (gchar *)msg);
     return task_id;
 }
 
@@ -816,12 +816,12 @@ guint64 bd_utils_report_started (gchar *msg) {
  * @completion: percentage of completion
  * @msg: message describing the status of the task/action
  */
-void bd_utils_report_progress (guint64 task_id, guint64 completion, gchar *msg) {
+void bd_utils_report_progress (guint64 task_id, guint64 completion, const gchar *msg) {
     BDUtilsProgFunc current_prog_func;
 
     current_prog_func = thread_prog_func != NULL ? thread_prog_func : prog_func;
     if (current_prog_func)
-        current_prog_func (task_id, BD_UTILS_PROG_PROGRESS, completion, msg);
+        current_prog_func (task_id, BD_UTILS_PROG_PROGRESS, completion, (gchar *)msg);
 }
 
 /**
@@ -829,12 +829,12 @@ void bd_utils_report_progress (guint64 task_id, guint64 completion, gchar *msg) 
  * @task_id: ID of the task/action
  * @msg: message describing the status of the task/action
  */
-void bd_utils_report_finished (guint64 task_id, gchar *msg) {
+void bd_utils_report_finished (guint64 task_id, const gchar *msg) {
     BDUtilsProgFunc current_prog_func;
 
     current_prog_func = thread_prog_func != NULL ? thread_prog_func : prog_func;
     if (current_prog_func)
-        current_prog_func (task_id, BD_UTILS_PROG_FINISHED, 100, msg);
+        current_prog_func (task_id, BD_UTILS_PROG_FINISHED, 100, (gchar *)msg);
 }
 
 /**

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -54,7 +54,7 @@ GQuark bd_utils_exec_error_quark (void)
 /**
  * get_next_task_id: (skip)
  */
-guint64 get_next_task_id () {
+guint64 get_next_task_id (void) {
     guint64 task_id = 0;
 
     g_mutex_lock (&id_counter_lock);
@@ -784,7 +784,7 @@ gboolean bd_utils_mute_prog_reporting_thread (GError **error __attribute__((unus
  * bd_utils_init_prog_reporting_thread (takes precedence). FALSE if
  * bd_utils_mute_prog_reporting_thread was used to mute the thread.
  */
-gboolean bd_utils_prog_reporting_initialized () {
+gboolean bd_utils_prog_reporting_initialized (void) {
     return (thread_prog_func != NULL || prog_func != NULL) && thread_prog_func != thread_progress_muted;
 }
 

--- a/src/utils/exec.h
+++ b/src/utils/exec.h
@@ -63,9 +63,9 @@ gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **e
 gboolean bd_utils_init_prog_reporting_thread (BDUtilsProgFunc new_prog_func, GError **error);
 gboolean bd_utils_mute_prog_reporting_thread (GError **error);
 gboolean bd_utils_prog_reporting_initialized (void);
-guint64 bd_utils_report_started (gchar *msg);
-void bd_utils_report_progress (guint64 task_id, guint64 completion, gchar *msg);
-void bd_utils_report_finished (guint64 task_id, gchar *msg);
+guint64 bd_utils_report_started (const gchar *msg);
+void bd_utils_report_progress (guint64 task_id, guint64 completion, const gchar *msg);
+void bd_utils_report_finished (guint64 task_id, const gchar *msg);
 
 void bd_utils_log (gint level, const gchar *msg);
 

--- a/src/utils/exec.h
+++ b/src/utils/exec.h
@@ -62,7 +62,7 @@ gboolean bd_utils_check_util_version (const gchar *util, const gchar *version, c
 gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **error);
 gboolean bd_utils_init_prog_reporting_thread (BDUtilsProgFunc new_prog_func, GError **error);
 gboolean bd_utils_mute_prog_reporting_thread (GError **error);
-gboolean bd_utils_prog_reporting_initialized ();
+gboolean bd_utils_prog_reporting_initialized (void);
 guint64 bd_utils_report_started (gchar *msg);
 void bd_utils_report_progress (guint64 task_id, guint64 completion, gchar *msg);
 void bd_utils_report_finished (guint64 task_id, gchar *msg);

--- a/src/utils/extra_arg.h
+++ b/src/utils/extra_arg.h
@@ -5,7 +5,7 @@
 #define BD_UTILS_EXTRA_ARG
 
 #define BD_UTIL_TYPE_EXTRA_ARG (bd_extra_arg_get_type ())
-GType bd_extra_arg_get_type ();
+GType bd_extra_arg_get_type (void);
 
 /**
  * BDExtraArg:

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -16,6 +16,8 @@ class LibraryOpsTestCase(unittest.TestCase):
                                                           "kbd", "loop", "lvm",
                                                           "mdraid", "part", "swap"))
 
+    orig_config_dir = ""
+
     @classmethod
     def setUpClass(cls):
         if not BlockDev.is_initialized():
@@ -24,12 +26,15 @@ class LibraryOpsTestCase(unittest.TestCase):
             BlockDev.reinit(cls.requested_plugins, True, None)
 
     def setUp(self):
+        self.orig_config_dir = os.environ.get("LIBBLOCKDEV_CONFIG_DIR", "")
         self.addCleanup(self._clean_up)
 
     def _clean_up(self):
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?BD_LVM_MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
         os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+
+        os.environ["LIBBLOCKDEV_CONFIG_DIR"] = self.orig_config_dir
 
         # try to get everything back to normal by (re)loading all plugins
         BlockDev.reinit(self.requested_plugins, True, None)
@@ -193,6 +198,7 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so.2")
+        self.addCleanup(os.system, "rm -f src/plugins/.libs/libbd_lvm2.so")
 
         # change the sources back and recompile
         os.system("sed -ri 's?gboolean bd_lvm_check_deps \(\) \{ return FALSE;//test-change?gboolean bd_lvm_check_deps () {?' src/plugins/lvm.c > /dev/null")
@@ -236,9 +242,6 @@ class LibraryOpsTestCase(unittest.TestCase):
         self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
 
         self.assertEqual(BlockDev.lvm_get_max_lv_size(), orig_max_size)
-
-        # clean after ourselves
-        os.system ("rm -f src/plugins/.libs/libbd_lvm2.so")
 
     def my_log_func(self, level, msg):
         # not much to verify here

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -193,7 +193,7 @@ class LibraryOpsTestCase(unittest.TestCase):
         self.assertNotEqual(orig_max_size, 1024)
 
         # change the sources and recompile
-        os.system("sed -ri 's?gboolean bd_lvm_check_deps \(\) \{?gboolean bd_lvm_check_deps () { return FALSE;//test-change?' src/plugins/lvm.c > /dev/null")
+        os.system("sed -ri 's?gboolean bd_lvm_check_deps \(void\) \{?gboolean bd_lvm_check_deps (void) { return FALSE;//test-change?' src/plugins/lvm.c > /dev/null")
         os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
 
         # proclaim the new build a different plugin
@@ -201,7 +201,7 @@ class LibraryOpsTestCase(unittest.TestCase):
         self.addCleanup(os.system, "rm -f src/plugins/.libs/libbd_lvm2.so")
 
         # change the sources back and recompile
-        os.system("sed -ri 's?gboolean bd_lvm_check_deps \(\) \{ return FALSE;//test-change?gboolean bd_lvm_check_deps () {?' src/plugins/lvm.c > /dev/null")
+        os.system("sed -ri 's?gboolean bd_lvm_check_deps \(void\) \{ return FALSE;//test-change?gboolean bd_lvm_check_deps (void) {?' src/plugins/lvm.c > /dev/null")
         os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
 
         # now reinit the library with the config preferring the new build


### PR DESCRIPTION
Those warnings are switched off in the `libblockdev` build, but some of them affect programs which include `libblockdev`'s headers.
And maybe it would be a good idea to enable those warnings. Do you wish to have a PR which enables more compiler warnings?