### PR TITLE
pkg-config: add -L${libdir} and -I${includedir}

### DIFF
--- a/src/lib/blockdev.pc.in
+++ b/src/lib/blockdev.pc.in
@@ -8,4 +8,5 @@ Description: Library for doing low-level operations with block devices
 URL: https://github.com/storaged-project/libblockdev
 Version: @VERSION@
 Requires: glib-2.0
-Libs: -lblockdev
+Libs: -L${libdir} -lblockdev
+Cflags: -I${includedir}

--- a/src/utils/blockdev-utils.pc.in
+++ b/src/utils/blockdev-utils.pc.in
@@ -8,4 +8,5 @@ Description: A library with utility functions used by the libblockdev library
 URL: https://github.com/storaged-project/libblockdev
 Version: @VERSION@
 Requires: glib-2.0
-Libs: -lbd_utils
+Libs: -L${libdir} -lbd_utils
+Cflags: -I${includedir}


### PR DESCRIPTION
Just declaring `libdir` and `includedir` in the `pkg-config` header
doesn't do anything; the following section needs to use them.

This fixes build breakages with programs using `libblockdev` installed
with a non-standard prefix.