### PR TITLE
Use python interpreter explicitly when running boilerplate_generator.py

### DIFF
--- a/src/lib/plugin_apis/Makefile.am
+++ b/src/lib/plugin_apis/Makefile.am
@@ -5,7 +5,7 @@ HEADER_FILES := $(patsubst %.api,%.h,${API_FILES})
 all-local: generate_boilerplate
 
 %.c %.h: %.api ${srcdir}/../../../scripts/boilerplate_generator.py
-	${srcdir}/../../../scripts/boilerplate_generator.py $*.api ./ ${skip_patterns}
+	${PYTHON} ${srcdir}/../../../scripts/boilerplate_generator.py $*.api ./ ${skip_patterns}
 
 generate_boilerplate: ${SOURCE_FILES} ${HEADER_FILES}
 


### PR DESCRIPTION
We can't rely on the shebang, because /usr/bin/python may not be
available on all systems. It's better to use python executable path
discovered by the AM_PYTHON_PATH autoconf macro.