### PR TITLE
Rewrite 'bd_part_get_disk_spec' and 'bd_part_set_disk_flag' to libfdisk 

### DIFF
--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1189,6 +1189,12 @@ class PartSetDiskFlagCase(PartTestCase):
         self.assertTrue(ps)
         self.assertEqual(ps.flags, BlockDev.PartDiskFlag.PART_DISK_FLAG_GPT_PMBR_BOOT)
 
+        # try to set the flag again, just to make sure it doesn't change
+        succ = BlockDev.part_set_disk_flag (self.loop_dev, BlockDev.PartDiskFlag.PART_DISK_FLAG_GPT_PMBR_BOOT, True)
+        ps = BlockDev.part_get_disk_spec (self.loop_dev)
+        self.assertTrue(ps)
+        self.assertEqual(ps.flags, BlockDev.PartDiskFlag.PART_DISK_FLAG_GPT_PMBR_BOOT)
+
         succ = BlockDev.part_set_disk_flag (self.loop_dev, BlockDev.PartDiskFlag.PART_DISK_FLAG_GPT_PMBR_BOOT, False)
         ps = BlockDev.part_get_disk_spec (self.loop_dev)
         self.assertTrue(ps)


### PR DESCRIPTION
First commit is copied from #272 -- this PR creates a new libfdisk based plugin, but we have decided to slowly rewrite current (libparted based) plugin to libfdisk and completely remove dependency libparted instead. This commit will be removed after #272 is changed and merged.