### PR TITLE
Mark the function stubs as static

### DIFF
--- a/scripts/boilerplate_generator.py
+++ b/scripts/boilerplate_generator.py
@@ -160,7 +160,7 @@ def get_func_boilerplate(fn_info):
         default_ret = 0
 
     # first add the stub function doing nothing and just reporting error
-    ret = ("{0.rtype} {0.name}_stub ({0.args}) {{\n" +
+    ret = ("static {0.rtype} {0.name}_stub ({0.args}) {{\n" +
            "    g_critical (\"The function '{0.name}' called, but not implemented!\");\n" +
            "    g_set_error (error, BD_INIT_ERROR, BD_INIT_ERROR_NOT_IMPLEMENTED,\n"+
            "                \"The function '{0.name}' called, but not implemented!\");\n"
@@ -169,7 +169,7 @@ def get_func_boilerplate(fn_info):
 
     # then add a variable holding a reference to the dynamically loaded function
     # (if any) initialized to the stub
-    ret += "{0.rtype} (*_{0.name}) ({0.args}) = {0.name}_stub;\n\n".format(fn_info)
+    ret += "static {0.rtype} (*_{0.name}) ({0.args}) = {0.name}_stub;\n\n".format(fn_info)
 
     # then add a documented function calling the dynamically loaded one via the
     # reference


### PR DESCRIPTION
These are just internal helpers that should not be exported.

Related: GH-366