### PR TITLE
Fix how we check zram stats from /sys/block/zram0/stat

### DIFF
--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -192,7 +192,7 @@ class KbdZRAMStatsTestCase(KbdZRAMTestCase):
 
         # read 'num_reads' and 'num_writes' from '/sys/block/zram0/stat'
         sys_stats = read_file("/sys/block/zram0/stat").strip().split()
-        self.assertEqual(len(sys_stats), 11)
+        self.assertGreaterEqual(len(sys_stats), 11)  # 15 stats since 4.19
         num_reads = int(sys_stats[0])
         num_writes = int(sys_stats[4])
         self.assertEqual(stats.num_reads, num_reads)


### PR DESCRIPTION
There are four new stats since kernel 4.19. Checking if we read
more than 11 values should be enough to be sure that the file
has the stats we want.