### PR TITLE
Fix how/where the bcache tests are skipped

### DIFF
--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -294,7 +294,7 @@ class KbdBcacheTestCase(unittest.TestCase):
         else:
             BlockDev.reinit(cls.requested_plugins, True, None)
 
-    @skip_on(("fedora", "29"), reason="running bcache tests causes system to run out of kernel memory on rawhide")
+    @skip_on("fedora", "29", reason="running bcache tests causes system to run out of kernel memory on rawhide")
     @skip_on("debian", "testing", reason="running bcache tests causes system to run out of kernel memory on testing")
     def setUp(self):
         self.addCleanup(self._clean_up)


### PR DESCRIPTION
The first argument to the 'skip_on' decorator is an iterable of
distos to skip the test on, the second argument is the version.