### PR TITLE
Use unsafe caching for storage for devel/testing VMs

### DIFF
--- a/misc/Vagrantfile.tmpl
+++ b/misc/Vagrantfile.tmpl
@@ -21,6 +21,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |v|
     v.memory = "1024"
     v.cpus = 4
+    v.volume_cache = :unsafe
   end
 
   # just some handy stuff to have in shell OOTB


### PR DESCRIPTION
This can speed things up quite a lot in some cases. And the
vagrant VMs for devel/testing are not supposed to be (considered)
persistent.