### PR TITLE
Add libblkid-devel as a build dependency for the swap plugin

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -523,6 +523,7 @@ with the libblockdev-part plugin/library.
 
 %if %{with_swap}
 %package swap
+BuildRequires: libblkid-devel
 Summary:     The swap plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
 Requires: util-linux


### PR DESCRIPTION
I forgot to add this in b6229b845e7cdea022afa23ae49185a20c8adacf