### PR TITLE
crypto_test.py: Use blkid instead of lsblk to check luks label

### DIFF
--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -148,7 +148,7 @@ class CryptoTestFormat(CryptoTestCase):
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, label, _err = run_command("lsblk -oLABEL -n %s" % self.loop_dev)
+        _ret, label, _err = run_command("blkid -p -ovalue -sLABEL %s" % self.loop_dev)
         self.assertEqual(label, "blockdevLUKS")
 
         # different key derivation function


### PR DESCRIPTION
This test sometimes fails because lsblk doesn't have up-to-date
information. We can force blkid to scan the device and not use
udev.