### PR TITLE
Add custom error code and message for wrong passphrase for open

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -1033,8 +1033,13 @@ static gboolean luks_open (const gchar *device, const gchar *name, const guint8 
     g_free (key_buffer);
 
     if (ret < 0) {
-        g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
-                     "Failed to activate device: %s", strerror_l(-ret, c_locale));
+        if (ret == -EPERM)
+          g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
+                       "Failed to activate device: Incorrect passphrase.");
+        else
+          g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
+                       "Failed to activate device: %s", strerror_l(-ret, c_locale));
+
         crypt_free (cd);
         bd_utils_report_finished (progress_id, (*error)->message);
         return FALSE;
@@ -1487,8 +1492,12 @@ static gboolean luks_resize (const gchar *luks_device, guint64 size, const guint
         g_free (key_buffer);
 
         if (ret < 0) {
-            g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
-                         "Failed to activate device: %s", strerror_l(-ret, c_locale));
+            if (ret == -EPERM)
+              g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
+                           "Failed to activate device: Incorrect passphrase.");
+            else
+              g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
+                           "Failed to activate device: %s", strerror_l(-ret, c_locale));
             crypt_free (cd);
             bd_utils_report_finished (progress_id, (*error)->message);
             return FALSE;

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -284,7 +284,7 @@ class CryptoTestOpenClose(CryptoTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", None, None, False)
 
-        with self.assertRaises(GLib.GError):
+        with six.assertRaisesRegex(self, GLib.GError, r"Incorrect passphrase"):
             BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", "wrong-passhprase", None, False)
 
         with self.assertRaises(GLib.GError):


### PR DESCRIPTION
'crypt_activate_by_*' returns -EPERM which translates to
'Operation not permitted' which might be confusing.