### PR TITLE
CentOS 7.6 LUKS 2 related fixes

### DIFF
--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -908,6 +908,9 @@ class CryptoTestIntegrity(CryptoTestCase):
     def test_luks2_integrity(self):
         """Verify that we can get create a LUKS 2 device with integrity"""
 
+        if not BlockDev.utils_have_kernel_module("dm-integrity"):
+            self.skipTest('dm-integrity kernel module not available, skipping.')
+
         extra = BlockDev.CryptoLUKSExtra()
         extra.integrity = "hmac(sha256)"
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -148,8 +148,11 @@ class CryptoTestFormat(CryptoTestCase):
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, label, _err = run_command("blkid -p -ovalue -sLABEL %s" % self.loop_dev)
-        self.assertEqual(label, "blockdevLUKS")
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        m = re.search(r"Label:\s*(\S+)\s*", out)
+        if not m or len(m.groups()) != 1:
+            self.fail("Failed to get label information from:\n%s %s" % (out, err))
+        self.assertEqual(m.group(1), "blockdevLUKS")
 
         # different key derivation function
         pbkdf = BlockDev.CryptoLUKSPBKDF(type="pbkdf2")


### PR DESCRIPTION
CentoOS 7.6 has oder kernel that doesn't support storing keys in kernel keyring. Also older util-linux doesn't fully support LUKS 2.