### PR TITLE
lvm: Add exported information to BDLVMVGdata

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -168,6 +168,7 @@ GType bd_lvm_vgdata_get_type();
  * @extent_count: number of extents in the VG
  * @free_count: number of free extents in the VG
  * @pv_count: number of PVs that belong to the VG
+ * @exported: whether the VG is exported or not
  */
 typedef struct BDLVMVGdata {
     gchar *name;
@@ -178,6 +179,7 @@ typedef struct BDLVMVGdata {
     guint64 extent_count;
     guint64 free_count;
     guint64 pv_count;
+    gboolean exported;
 } BDLVMVGdata;
 
 /**
@@ -199,6 +201,7 @@ BDLVMVGdata* bd_lvm_vgdata_copy (BDLVMVGdata *data) {
     new_data->extent_count = data->extent_count;
     new_data->free_count = data->free_count;
     new_data->pv_count = data->pv_count;
+    new_data->exported = data->exported;
 
     return new_data;
 }

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -944,6 +944,7 @@ static BDLVMVGdata* get_vg_data_from_props (GVariant *props, GError **error __at
     g_variant_dict_lookup (&dict, "ExtentCount", "t", &(data->extent_count));
     g_variant_dict_lookup (&dict, "FreeCount", "t", &(data->free_count));
     g_variant_dict_lookup (&dict, "PvCount", "t", &(data->pv_count));
+    g_variant_dict_lookup (&dict, "Exportable", "b", &(data->exported));
 
     g_variant_dict_clear (&dict);
 

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -497,6 +497,12 @@ static BDLVMVGdata* get_vg_data_from_table (GHashTable *table, gboolean free_tab
     else
         data->pv_count = 0;
 
+    value = (gchar*) g_hash_table_lookup (table, "LVM2_VG_EXPORTED");
+    if (value && g_strcmp0 (value, "exported") == 0)
+        data->exported = TRUE;
+    else
+        data->exported = FALSE;
+
     if (free_table)
         g_hash_table_destroy (table);
 
@@ -1220,7 +1226,7 @@ gboolean bd_lvm_vgreduce (const gchar *vg_name, const gchar *device, const BDExt
 BDLVMVGdata* bd_lvm_vginfo (const gchar *vg_name, GError **error) {
     const gchar *args[10] = {"vgs", "--noheadings", "--nosuffix", "--nameprefixes",
                        "--unquoted", "--units=b",
-                       "-o", "name,uuid,size,free,extent_size,extent_count,free_count,pv_count",
+                       "-o", "name,uuid,size,free,extent_size,extent_count,free_count,pv_count,vg_exported",
                        vg_name, NULL};
 
     GHashTable *table = NULL;
@@ -1240,7 +1246,7 @@ BDLVMVGdata* bd_lvm_vginfo (const gchar *vg_name, GError **error) {
 
     for (lines_p = lines; *lines_p; lines_p++) {
         table = parse_lvm_vars ((*lines_p), &num_items);
-        if (table && (num_items == 8)) {
+        if (table && (num_items == 9)) {
             g_strfreev (lines);
             return get_vg_data_from_table (table, TRUE);
         } else

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -94,6 +94,7 @@ typedef struct BDLVMVGdata {
     guint64 extent_count;
     guint64 free_count;
     guint64 pv_count;
+    gboolean exported;
 } BDLVMVGdata;
 
 void bd_lvm_vgdata_free (BDLVMVGdata *data);

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1420,3 +1420,40 @@ class LvmTestPVremoveConfig(LvmPVonlyTestCase):
 
         succ = BlockDev.lvm_pvremove(self.loop_dev2, None)
         self.assertTrue(succ)
+
+@unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
+@unittest.skip("LVM DBus crashes if an exported VG is present in the system")
+class LvmVGExportedTestCase(LvmPVVGLVTestCase):
+
+    def _clean_up(self):
+        run_command("vgimport testVG")
+
+        LvmPVVGLVTestCase._clean_up(self)
+
+    @tag_test(TestTags.SLOW)
+    def test_exported_vg(self):
+        """Verify that info has correct information about exported VGs"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        info = BlockDev.lvm_vginfo("testVG")
+        self.assertTrue(info)
+        self.assertFalse(info.exported)
+
+        ret, out, err = run_command("vgexport testVG")
+        if ret != 0:
+            self.fail("Failed to export VG:\n%s %s" % (out, err))
+
+        info = BlockDev.lvm_vginfo("testVG")
+        self.assertTrue(info)
+        self.assertTrue(info.exported)
+
+
+        self.assertTrue(succ)


### PR DESCRIPTION
Blivet will use this new information to mark exported VGs as protected -- we had some anaconda bugs where installation crashed because user tried to remove an exported VG.
Unfortunately this doesn't work with the DBus plugin. This is already fixed upstream -- https://sourceware.org/git/?p=lvm2.git;a=commit;h=5bdcafff47ee6a2e57e0c57d18cbc36cf1a2973e -- but not yet released.