### PR TITLE
New function to get supported sector sizes for NVDIMM namespaces

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -618,6 +618,7 @@ bd_nvdimm_namespace_disable
 bd_nvdimm_namespace_info
 bd_nvdimm_list_namespaces
 bd_nvdimm_namespace_reconfigure
+bd_nvdimm_namepace_get_supported_sector_sizes
 BDNVDIMMTech
 BDNVDIMMTechMode
 bd_nvdimm_is_tech_avail

--- a/src/lib/plugin_apis/nvdimm.api
+++ b/src/lib/plugin_apis/nvdimm.api
@@ -224,4 +224,15 @@ BDNVDIMMNamespaceInfo** bd_nvdimm_list_namespaces (const gchar *bus, const gchar
  */
 gboolean bd_nvdimm_namespace_reconfigure (const gchar* namespace, BDNVDIMMNamespaceMode mode, gboolean force, const BDExtraArg **extra, GError** error);
 
+/**
+ * bd_nvdimm_namepace_get_supported_sector_sizes:
+ * @mode: namespace mode
+ * @error: (out): place to store error if any
+ *
+ * Returns: (transfer none) (array zero-terminated=1): list of supported sector sizes for @mode
+ *
+ * Tech category: %BD_NVDIMM_TECH_NAMESPACE-%BD_NVDIMM_TECH_MODE_QUERY
+ */
+const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error);
+
 #endif  /* BD_NVDIMM_API */

--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -636,3 +636,38 @@ gboolean bd_nvdimm_namespace_reconfigure (const gchar* namespace, BDNVDIMMNamesp
     g_free ((gchar *) args[5]);
     return ret;
 }
+
+
+static guint64 blk_sector_sizes[] = { 512, 520, 528, 4096, 4104, 4160, 4224, 0 };
+static guint64 pmem_sector_sizes[] = { 512, 4096, 0 };
+static guint64 io_sector_sizes[] = { 0 };
+
+/**
+ * bd_nvdimm_namepace_get_supported_sector_sizes:
+ * @mode: namespace mode
+ * @error: (out): place to store error if any
+ *
+ * Returns: (transfer none) (array zero-terminated=1): list of supported sector sizes for @mode
+ *
+ * Tech category: %BD_NVDIMM_TECH_NAMESPACE-%BD_NVDIMM_TECH_MODE_QUERY
+ */
+const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error) {
+    switch (mode) {
+        case BD_NVDIMM_NAMESPACE_MODE_RAW:
+        case BD_NVDIMM_NAMESPACE_MODE_MEMORY:
+        case BD_NVDIMM_NAMESPACE_MODE_FSDAX:
+            return pmem_sector_sizes;
+
+        case BD_NVDIMM_NAMESPACE_MODE_DAX:
+        case BD_NVDIMM_NAMESPACE_MODE_DEVDAX:
+            return io_sector_sizes;
+
+        case BD_NVDIMM_NAMESPACE_MODE_SECTOR:
+            return blk_sector_sizes;
+
+        default:
+            g_set_error (error, BD_NVDIMM_ERROR, BD_NVDIMM_ERROR_NAMESPACE_MODE_INVAL,
+                         "Invalid/unknown mode specified.");
+            return NULL;
+    }
+}

--- a/src/plugins/nvdimm.h
+++ b/src/plugins/nvdimm.h
@@ -77,4 +77,6 @@ BDNVDIMMNamespaceInfo** bd_nvdimm_list_namespaces (const gchar *bus, const gchar
 
 gboolean bd_nvdimm_namespace_reconfigure (const gchar* namespace, BDNVDIMMNamespaceMode mode, gboolean force, const BDExtraArg **extra, GError** error);
 
+const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error);
+
 #endif  /* BD_CRYPTO */

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -207,3 +207,19 @@ class NVDIMMUnloadTest(NVDIMMTestCase):
         # load the plugins back
         self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
         self.assertIn("nvdimm", BlockDev.get_available_plugin_names())
+
+
+class NVDIMMNoDevTest(NVDIMMTestCase):
+
+    @skip_on(skip_on_arch="i686", reason="Lists of 64bit integers are broken on i686 with GI")
+    def test_supported_sector_sizes(self):
+        """Verify that getting supported sector sizes works as expected"""
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.nvdimm_namepace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.UNKNOWN)
+
+        sizes = BlockDev.nvdimm_namepace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.SECTOR)
+        self.assertListEqual(sizes, [512, 520, 528, 4096, 4104, 4160, 4224])
+
+        sizes = BlockDev.nvdimm_namepace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.FSDAX)
+        self.assertListEqual(sizes, [512, 4096])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -272,7 +272,7 @@ def get_version():
     return (distro, version)
 
 
-def skip_on(skip_on_distros, skip_on_version="", skip_on_arch="", reason=""):
+def skip_on(skip_on_distros=None, skip_on_version="", skip_on_arch="", reason=""):
     """A function returning a decorator to skip some test on a given distribution-version combination
 
     :param skip_on_distros: distro(s) to skip the test on
@@ -288,7 +288,7 @@ def skip_on(skip_on_distros, skip_on_version="", skip_on_arch="", reason=""):
     arch = os.uname()[-1]
 
     def decorator(func):
-        if distro in skip_on_distros and (not skip_on_version or skip_on_version == version) and \
+        if (skip_on_distros is None or distro in skip_on_distros) and (not skip_on_version or skip_on_version == version) and \
            (not skip_on_arch or skip_on_arch == arch):
             msg = "not supported on this distribution in this version and arch" + (": %s" % reason if reason else "")
             return unittest.skip(msg)(func)


### PR DESCRIPTION
Unfortunately 'ndctl_namespace_get_supported_sector_size' needs
an existing namespace to tell us what sector sizes it supports so
we need to hard code the values.