### PR TITLE
Remove device-mapper-multipath dependency from fs and part plugins

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -315,7 +315,6 @@ BuildRequires: libblkid-devel
 BuildRequires: libmount-devel
 Summary:     The FS plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
-Requires: device-mapper-multipath
 
 %description fs
 The libblockdev library plugin (and in the same time a standalone library)
@@ -505,7 +504,6 @@ with the libblockdev-nvdimm plugin/library.
 BuildRequires: parted-devel
 Summary:     The partitioning plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
-Requires: device-mapper-multipath
 Requires: gdisk
 Requires: util-linux
 


### PR DESCRIPTION
Only mpath plugin needs device-mapper-multipath so the dependency
for fs and part was probably added by accident.