### PR TITLE
tests: Fix Debian testing "version" for skipping

### DIFF
--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1135,7 +1135,7 @@ class MountTest(FSTestCase):
             BlockDev.fs_unmount(self.loop_dev, run_as_uid=uid, run_as_gid=gid)
         self.assertTrue(os.path.ismount(tmp))
 
-    @skip_on("debian", "testing", reason="NTFS mounting is broken on Debian testing")
+    @skip_on("debian", "10", reason="NTFS mounting is broken on Debian testing")
     def test_mount_ntfs(self):
         """ Test basic mounting and unmounting with NTFS filesystem"""
         # using NTFS because it uses a helper program (mount.ntfs) and libmount

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -295,7 +295,7 @@ class KbdBcacheTestCase(unittest.TestCase):
             BlockDev.reinit(cls.requested_plugins, True, None)
 
     @skip_on("fedora", "29", reason="running bcache tests causes system to run out of kernel memory on rawhide")
-    @skip_on("debian", "testing", reason="running bcache tests causes system to run out of kernel memory on testing")
+    @skip_on("debian", "10", reason="running bcache tests causes system to run out of kernel memory on testing")
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", 10 * 1024**3)


### PR DESCRIPTION
Debian now reports version as "10" instead of "testing" for buster.