### PR TITLE
libfdisk: create part

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,9 +226,8 @@ AS_IF([test "x$with_dm" != "xno" -a "x$with_dmraid" != "xno"],
       [LIBBLOCKDEV_CHECK_HEADER([dmraid/dmraid.h], [], [dmraid.h not available])],
       [])
 
-AS_IF([test "x$with_part" != "xno" -o "x$with_fs" != "xno"],
-      [LIBBLOCKDEV_PKG_CHECK_MODULES([PARTED], [libparted >= 3.1])
-      LIBBLOCKDEV_PKG_CHECK_MODULES([FDISK], [fdisk >= 2.31.0])]
+AS_IF([test "x$with_part" != "xno"],
+      [LIBBLOCKDEV_PKG_CHECK_MODULES([FDISK], [fdisk >= 2.31.0])],
       [])
 
 AS_IF([test "x$with_fs" != "xno"],
@@ -236,6 +235,8 @@ AS_IF([test "x$with_fs" != "xno"],
        # new versions of libmount has some new functions we can use
        AS_IF([$PKG_CONFIG --atleast-version=2.30.0 mount],
              [AC_DEFINE([LIBMOUNT_NEW_ERR_API])], [])
+
+       LIBBLOCKDEV_PKG_CHECK_MODULES([PARTED], [libparted >= 3.1])
 
        # older versions of parted don't provide the libparted-fs-resize.pc file
        AS_IF([$PKG_CONFIG libparted-fs-resize],

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -174,8 +174,8 @@ libbd_s390_la_SOURCES = s390.c s390.h check_deps.c check_deps.h
 endif
 
 if WITH_PART
-libbd_part_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(PARTED_CFLAGS) $(FDISK_CFLAGS) $(BLKID_CFLAGS) -Wall -Wextra -Werror
-libbd_part_la_LIBADD = ${builddir}/../utils/libbd_utils.la ${builddir}/libbd_part_err.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(PARTED_LIBS) $(FDISK_LIBS) $(BLKID_LIBS)
+libbd_part_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(FDISK_CFLAGS) $(BLKID_CFLAGS) -Wall -Wextra -Werror
+libbd_part_la_LIBADD = ${builddir}/../utils/libbd_utils.la ${builddir}/libbd_part_err.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(FDISK_LIBS) $(BLKID_LIBS)
 libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_part_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_part_la_SOURCES = part.c part.h check_deps.c check_deps.h

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -175,7 +175,7 @@ endif
 
 if WITH_PART
 libbd_part_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(FDISK_CFLAGS) $(BLKID_CFLAGS) -Wall -Wextra -Werror
-libbd_part_la_LIBADD = ${builddir}/../utils/libbd_utils.la ${builddir}/libbd_part_err.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(FDISK_LIBS) $(BLKID_LIBS)
+libbd_part_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(FDISK_LIBS) $(BLKID_LIBS)
 libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_part_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_part_la_SOURCES = part.c part.h check_deps.c check_deps.h

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -33,7 +33,6 @@
 #include <libfdisk.h>
 #include <locale.h>
 #include <blkid.h>
-#include <syslog.h>
 
 #include "part.h"
 
@@ -182,6 +181,8 @@ static const PartFlag part_flags[18] = {
 #define _PART_NTFS        0x07
 #define _PART_FLAG_HIDDEN 0x10
 
+#define UNUSED __attribute__((unused))
+
 /**
  * get_part_num: (skip)
  *
@@ -215,6 +216,33 @@ static gint get_part_num (const gchar *part, GError **error) {
     return part_num;
 }
 
+static int fdisk_ask_callback (struct fdisk_context *cxt UNUSED, struct fdisk_ask *ask, void *data UNUSED) {
+    gint type = 0;
+    const gchar *fdisk_msg = NULL;
+    gchar *message = NULL;
+
+    type = fdisk_ask_get_type (ask);
+    fdisk_msg = fdisk_ask_print_get_mesg (ask);
+
+    switch (type) {
+        case FDISK_ASKTYPE_INFO:
+            message = g_strdup_printf ("[fdisk] %s", fdisk_msg);
+            bd_utils_log (BD_UTILS_LOG_INFO, message);
+            g_free (message);
+            break;
+        case FDISK_ASKTYPE_WARNX:
+        case FDISK_ASKTYPE_WARN:
+            message = g_strdup_printf ("[fdisk] %s", fdisk_msg);
+            bd_utils_log (BD_UTILS_LOG_WARNING, message);
+            g_free (message);
+            break;
+        default:
+            break;
+    }
+
+    return 0;
+}
+
 static struct fdisk_context* get_device_context (const gchar *disk, GError **error) {
     struct fdisk_context *cxt = fdisk_new_context ();
     gint ret = 0;
@@ -234,6 +262,7 @@ static struct fdisk_context* get_device_context (const gchar *disk, GError **err
     }
 
     fdisk_disable_dialogs(cxt, 1);
+    fdisk_set_ask (cxt, fdisk_ask_callback, NULL);
     return cxt;
 }
 
@@ -1919,7 +1948,7 @@ static gchar* get_lba_hidden_id (const gchar *part, gboolean hidden, gboolean lb
          */
         message = g_strdup_printf ("Ignoring requested flag: setting hidden/lba flag is supported only "\
                                    "on partitions with FAT, NTFS or HPFS filesystem.");
-        bd_utils_log (LOG_INFO, message);
+        bd_utils_log (BD_UTILS_LOG_INFO, message);
         g_free (message);
         return NULL;
     }

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -283,13 +283,14 @@ static gboolean write_label (struct fdisk_context *cxt, struct fdisk_table *orig
 
     /* XXX: try to grab a lock for the device so that udev doesn't step in
        between the two operations we need to perform (see below) with its
-       BLKRRPART ioctl() call which makes the device busy */
+       BLKRRPART ioctl() call which makes the device busy
+       see https://systemd.io/BLOCK_DEVICE_LOCKING */
     dev_fd = open (disk, O_RDONLY|O_CLOEXEC);
     if (dev_fd >= 0) {
-        ret = flock (dev_fd, LOCK_SH|LOCK_NB);
+        ret = flock (dev_fd, LOCK_EX|LOCK_NB);
         while ((ret != 0) && (num_tries <= 5)) {
             g_usleep (100 * 1000); /* microseconds */
-            ret = flock (dev_fd, LOCK_SH|LOCK_NB);
+            ret = flock (dev_fd, LOCK_EX|LOCK_NB);
             num_tries++;
         }
     }

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1032,8 +1032,8 @@ class PartCreateResizePartCase(PartTestCase):
         self.assertEqual(initial_start, ps.start)
         self.assertEqual(initial_size, ps.size)  # should grow to the same size again
 
-        # resize to maximum explicitly
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, initial_size, BlockDev.PartAlign.OPTIMAL)
+        # resize to maximum explicitly with no alignment (we know exact size)
+        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, initial_size, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
         ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
         self.assertEqual(initial_start, ps.start)


### PR DESCRIPTION
Support for creating partitions using libfdisk. This is currently broken because of bug in udev (maybe) -- when creating partition table and a partition directly after that the add event for the partition isn't created.