### PR TITLE
Move the NTFS read-only device test to a separate test case

### DIFF
--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1199,18 +1199,34 @@ class MountTest(FSTestCase):
         self.assertTrue(succ)
         self.assertFalse(os.path.ismount(tmp))
 
+    def test_mount_ntfs_ro(self):
+        """ Test mounting and unmounting read-only device with NTFS filesystem"""
+
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        tmp = tempfile.mkdtemp(prefix="libblockdev.", suffix="mount_test")
+        self.addCleanup(os.rmdir, tmp)
+
+        if not self.ntfs_avail:
+            self.skipTest("skipping NTFS: not available")
+
         # set the device read-only
         self.setro(self.loop_dev)
         self.addCleanup(self.setrw, self.loop_dev)
 
-        # standard mount (rw) should fail
+        # forced rw mount should fail
         with self.assertRaises(GLib.GError):
-            BlockDev.fs_mount(self.loop_dev, tmp, "ntfs", None)
+            BlockDev.fs_mount(self.loop_dev, tmp, "ntfs", "rw")
 
         # read-only mount should work
         succ = BlockDev.fs_mount(self.loop_dev, tmp, "ntfs", "ro")
         self.assertTrue(succ)
         self.assertTrue(os.path.ismount(tmp))
+
+        succ = BlockDev.fs_unmount(self.loop_dev, False, False, None)
+        self.assertTrue(succ)
+        self.assertFalse(os.path.ismount(tmp))
 
 class GenericCheck(FSTestCase):
     log = []

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -34,11 +34,11 @@
       version: "9"
       reason: "volume_key asks for password in non-interactive mode on this release"
 
-- test: fs_test.MountTest.test_mount_ntfs
+- test: fs_test.MountTest.test_mount_ntfs_ro
   skip_on:
     - distro: "debian"
-      version: "10"
-      reason: "NTFS mounting is broken on Debian testing"
+      version: ["9", "10", "testing"]
+      reason: "NTFS mounting of read-only devices doesn't work as expected on Debian"
 
 - test: kbd_test.KbdZRAM*
   skip_on:


### PR DESCRIPTION
And also skip this test case on Debian. On Debian mounting a read
only NTFS device succeeds even if 'rw' option is specified.

On the other hand on Fedora mounting without the 'rw' option fails
instead of mounting the device as read-only. NTFS mounting is just
weird but the test is now written in a way which expects the same
behaviour other filesystems have.

This is not a bug in libblockdev, running mount manually shows the
same inconsistent behaviour.