### PR TITLE
Fix LVM_MAX_LV_SIZE in the GIR file

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -5,13 +5,15 @@
 #ifndef BD_LVM_API
 #define BD_LVM_API
 
-#ifdef __LP64__
-// 64bit system
-#define BD_LVM_MAX_LV_SIZE (8 EiB)
-#else
-// 32bit system
-#define BD_LVM_MAX_LV_SIZE (16 TiB)
-#endif
+/**
+ * BD_LVM_MAX_LV_SIZE:
+ *
+ * Deprecated: 2.23: Use bd_lvm_get_max_lv_size() function instead.
+ */
+/* 8 EiB (valid only for 64bit devices but we can't have architecture
+   specific constant here) */
+#define BD_LVM_MAX_LV_SIZE G_GUINT64_CONSTANT (9223372036854775808ULL)
+
 
 #define BD_LVM_DEFAULT_PE_START (1 MiB)
 #define BD_LVM_DEFAULT_PE_SIZE (4 MiB)


### PR DESCRIPTION
GObject instrospection doesn't automatically detect types of the
constants and thinks that all are gint, which doesn't work for
LVM_MAX_LV_SIZE because it's bigger than gint64 and should be
guint64.
Unfortunately there is not way to make the constant in GIR arch
dependent, so we are deprecating it, users shoud use the
bd_lvm_get_max_lv_size function instead.

Fixes #462 