### PR TITLE
Add repr and str function to our structs in Python

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -183,8 +183,10 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 
 %if 0%{?fedora} <= 26 || 0%{?rhel} <= 7
 Requires: pygobject3-base
+Requires: python-bytesize
 %else
 Requires: python2-gobject-base
+Requires: python2-bytesize
 %endif
 %{?python_provide:%python_provide python2-blockdev}
 
@@ -198,6 +200,7 @@ libblockdev in Python2.
 Summary:     Python3 gobject-introspection bindings for libblockdev
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: python3-gobject-base
+Requires: python3-bytesize
 %{?python_provide:%python_provide python3-blockdev}
 
 %description -n python3-blockdev


### PR DESCRIPTION
This makes working with libblockdev from Python more user friendly.

Before:
-------
```
<BlockDev.PartSpec object at 0x7f1600306600 (BDPartSpec at 0x563e2eca2450)>
```
After:
------
```
BlockDev.PartSpec (BDPartSpec) instance (0x7fbd382e6360)
 flags: 0
 name: None
 path: /dev/vdg2
 size: 5046796288
 start: 11812208640
 type: 0
 type_guid: None
```

Fixes #424 