### PR TITLE
Add new function 'bd_fs_wipe_force' to control force wipe

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -502,6 +502,7 @@ BDFsError
 BD_FS_ERROR
 bd_fs_error_quark
 bd_fs_wipe
+bd_fs_wipe_force
 bd_fs_clean
 bd_fs_get_fstype
 bd_fs_freeze

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -372,11 +372,28 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
  * @all: whether to wipe all (%TRUE) signatures or just the first (%FALSE) one
  * @error: (out): place to store error (if any)
  *
+ * Note: This function will wipe signatures on a mounted @device without
+ *       asking. Use %bd_fs_wipe_force if you want to control this
+ *       behaviour manually.
+ *
  * Returns: whether signatures were successfully wiped on @device or not
  *
  * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_WIPE
  */
 gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
+
+/**
+ * bd_fs_wipe_force:
+ * @device: the device to wipe signatures from
+ * @all: whether to wipe all (%TRUE) signatures or just the first (%FALSE) one
+ * @force: whether to force wipe even if the filesystem is mounted
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether signatures were successfully wiped on @device or not
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_wipe_force (const gchar *device, gboolean all, gboolean force, GError **error);
 
 /**
  * bd_fs_clean:

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -4,6 +4,7 @@
 #define BD_FS_GENERIC
 
 gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
+gboolean bd_fs_wipe_force (const gchar *device, gboolean all, gboolean force, GError **error);
 gboolean bd_fs_clean (const gchar *device, GError **error);
 gchar* bd_fs_get_fstype (const gchar *device,  GError **error);
 

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -156,6 +156,22 @@ class TestGenericWipe(FSTestCase):
         with six.assertRaisesRegex(self, GLib.GError, "No signature detected on the device"):
             BlockDev.fs_wipe(self.loop_dev, True)
 
+    def test_generic_wipe_force(self):
+        """Verify that generic signature wipe works as expected with the force option"""
+
+        succ = BlockDev.fs_ext4_mkfs(self.loop_dev)
+        self.assertTrue(succ)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            with self.assertRaises(GLib.GError):
+                # force wipe with force=False should fail
+                BlockDev.fs_wipe_force(self.loop_dev, True, False)
+
+            succ = BlockDev.fs_wipe_force(self.loop_dev, True, True)
+            self.assertTrue(succ)
+
+        fs_type = check_output(["blkid", "-ovalue", "-sTYPE", "-p", self.loop_dev]).strip()
+        self.assertEqual(fs_type, b"")
 
 class TestClean(FSTestCase):
     def test_clean(self):


### PR DESCRIPTION
Our current implementation allows to wipe mounted devices by
default. We can't change this behaviour but we want to allow to
control this so we need a new function.

Related: https://github.com/storaged-project/libblockdev/issues/483