### PR TITLE
Add write policy and index size to LVM VDO data

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -88,6 +88,14 @@ typedef enum {
     BD_LVM_VDO_INDEX_UNKNOWN = 255,
 } BDLVMVDOIndexState;
 
+typedef enum {
+    BD_LVM_VDO_WRITE_POLICY_AUTO = 0,
+    BD_LVM_VDO_WRITE_POLICY_SYNC,
+    BD_LVM_VDO_WRITE_POLICY_ASYNC,
+    BD_LVM_VDO_WRITE_POLICY_UNKNOWN = 255
+} BDLVMVDOWritePolicy;
+
+
 #define BD_LVM_TYPE_PVDATA (bd_lvm_pvdata_get_type ())
 GType bd_lvm_pvdata_get_type();
 
@@ -362,7 +370,9 @@ GType bd_lvm_vdodata_get_type();
  * @operating_mode: operating mode of the VDO pool (e.g. %BD_LVM_VDO_MODE_NORMAL)
  * @compression_state: state of the compression
  * @index_state: state of the VDO index
+ * @write_policy: write policy of the VDO LV
  * @saving_percent: percentage of physical blocks saved
+ * @index_memory_size: index memory size of the VDO volume
  * @deduplication: whether deduplication is enabled
  * @compression: whether compression is enabled
  */
@@ -371,8 +381,10 @@ typedef struct BDLVMVDOPooldata {
     BDLVMVDOOperatingMode operating_mode;
     BDLVMVDOCompressionState compression_state;
     BDLVMVDOIndexState index_state;
+    BDLVMVDOWritePolicy write_policy;
     guint64 used_size;
     gint32 saving_percent;
+    guint64 index_memory_size;
     gboolean deduplication;
     gboolean compression;
 } BDLVMVDOPooldata;
@@ -391,8 +403,10 @@ BDLVMVDOPooldata* bd_lvm_vdodata_copy (BDLVMVDOPooldata *data) {
     new_data->operating_mode = data->operating_mode;
     new_data->compression_state = data->compression_state;
     new_data->index_state = data->index_state;
+    new_data->write_policy = data->write_policy;
     new_data->used_size = data->used_size;
     new_data->saving_percent = data->saving_percent;
+    new_data->index_memory_size = data->index_memory_size;
     new_data->deduplication = data->deduplication;
     new_data->compression = data->compression;
     return new_data;
@@ -1489,5 +1503,16 @@ const gchar* bd_lvm_get_vdo_compression_state_str (BDLVMVDOCompressionState stat
  * Tech category: always provided/supported
  */
 const gchar* bd_lvm_get_vdo_index_state_str (BDLVMVDOIndexState state, GError **error);
+
+/**
+ * bd_lvm_get_vdo_write_policy_str:
+ * @policy: policy to get the string representation for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: string representation of @policy or %NULL in case of error
+ *
+ * Tech category: always provided/supported
+ */
+const gchar* bd_lvm_get_vdo_write_policy_str (BDLVMVDOWritePolicy policy, GError **error);
 
 #endif  /* BD_LVM_API */

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1140,6 +1140,9 @@ static BDLVMVDOPooldata* get_vdo_data_from_props (GVariant *props, GError **erro
     }
     g_free (value);
 
+    g_variant_dict_lookup (&dict, "UsedSize", "t", &(data->used_size));
+    g_variant_dict_lookup (&dict, "SavingPercent", "d", &(data->saving_percent));
+
     g_variant_dict_lookup (&dict, "IndexMemorySize", "t", &(data->index_memory_size));
 
     g_variant_dict_lookup (&dict, "Compression", "s", &value);

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1127,6 +1127,21 @@ static BDLVMVDOPooldata* get_vdo_data_from_props (GVariant *props, GError **erro
     }
     g_free (value);
 
+    g_variant_dict_lookup (&dict, "WritePolicy", "s", &value);
+    if (g_strcmp0 (value, "auto") == 0)
+        data->write_policy = BD_LVM_VDO_WRITE_POLICY_AUTO;
+    else if (g_strcmp0 (value, "sync") == 0)
+        data->write_policy = BD_LVM_VDO_WRITE_POLICY_SYNC;
+    else if (g_strcmp0 (value, "async") == 0)
+        data->write_policy = BD_LVM_VDO_WRITE_POLICY_ASYNC;
+    else {
+        bd_utils_log_format (BD_UTILS_LOG_DEBUG, "Unknown VDO write policy: %s", value);
+        data->write_policy = BD_LVM_VDO_WRITE_POLICY_UNKNOWN;
+    }
+    g_free (value);
+
+    g_variant_dict_lookup (&dict, "IndexMemorySize", "t", &(data->index_memory_size));
+
     g_variant_dict_lookup (&dict, "Compression", "s", &value);
     if (value && g_strcmp0 (value, "enabled") == 0)
         data->compression = TRUE;
@@ -3644,6 +3659,32 @@ const gchar* bd_lvm_get_vdo_index_state_str (BDLVMVDOIndexState state, GError **
     default:
         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
                      "Invalid LVM VDO index state.");
+        return NULL;
+    }
+}
+
+/**
+ * bd_lvm_get_vdo_write_policy_str:
+ * @policy: policy to get the string representation for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: string representation of @policy or %NULL in case of error
+ *
+ * Tech category: always provided/supported
+ */
+const gchar* bd_lvm_get_vdo_write_policy_str (BDLVMVDOWritePolicy policy, GError **error) {
+    switch (policy) {
+    case BD_LVM_VDO_WRITE_POLICY_AUTO:
+        return "auto";
+    case BD_LVM_VDO_WRITE_POLICY_SYNC:
+        return "sync";
+    case BD_LVM_VDO_WRITE_POLICY_ASYNC:
+        return "async";
+    case BD_LVM_VDO_WRITE_POLICY_UNKNOWN:
+        return "unknown";
+    default:
+        g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
+                     "Invalid LVM VDO write policy.");
         return NULL;
     }
 }

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -3656,6 +3656,8 @@ const gchar* bd_lvm_get_vdo_index_state_str (BDLVMVDOIndexState state, GError **
         return "offline";
     case BD_LVM_VDO_INDEX_ONLINE:
         return "online";
+    case BD_LVM_VDO_INDEX_UNKNOWN:
+        return "unknown";
     default:
         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
                      "Invalid LVM VDO index state.");

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -2954,6 +2954,8 @@ const gchar* bd_lvm_get_vdo_index_state_str (BDLVMVDOIndexState state, GError **
         return "offline";
     case BD_LVM_VDO_INDEX_ONLINE:
         return "online";
+    case BD_LVM_VDO_INDEX_UNKNOWN:
+        return "unknown";
     default:
         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
                      "Invalid LVM VDO index state.");

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -90,6 +90,13 @@ typedef enum {
     BD_LVM_VDO_INDEX_UNKNOWN = 255,
 } BDLVMVDOIndexState;
 
+typedef enum {
+    BD_LVM_VDO_WRITE_POLICY_AUTO = 0,
+    BD_LVM_VDO_WRITE_POLICY_SYNC,
+    BD_LVM_VDO_WRITE_POLICY_ASYNC,
+    BD_LVM_VDO_WRITE_POLICY_UNKNOWN = 255
+} BDLVMVDOWritePolicy;
+
 typedef struct BDLVMPVdata {
     gchar *pv_name;
     gchar *pv_uuid;
@@ -149,8 +156,10 @@ typedef struct BDLVMVDOPooldata {
     BDLVMVDOOperatingMode operating_mode;
     BDLVMVDOCompressionState compression_state;
     BDLVMVDOIndexState index_state;
+    BDLVMVDOWritePolicy write_policy;
     guint64 used_size;
     gint32 saving_percent;
+    guint64 index_memory_size;
     gboolean deduplication;
     gboolean compression;
 } BDLVMVDOPooldata;
@@ -290,5 +299,6 @@ gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, co
 const gchar* bd_lvm_get_vdo_operating_mode_str (BDLVMVDOOperatingMode mode, GError **error);
 const gchar* bd_lvm_get_vdo_compression_state_str (BDLVMVDOCompressionState state, GError **error);
 const gchar* bd_lvm_get_vdo_index_state_str (BDLVMVDOIndexState state, GError **error);
+const gchar* bd_lvm_get_vdo_write_policy_str (BDLVMVDOWritePolicy policy, GError **error);
 
 #endif /* BD_LVM */

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1536,9 +1536,19 @@ class LVMVDOTest(LVMTestCase):
         self.assertEqual(vdo_info.compression_state, BlockDev.LVMVDOCompressionState.ONLINE)
         self.assertTrue(vdo_info.compression)
         self.assertTrue(vdo_info.deduplication)
+        self.assertGreater(vdo_info.index_memory_size, 0)
+        self.assertGreater(vdo_info.used_size, 0)
+        self.assertTrue(0 <= vdo_info.saving_percent <= 100)
 
         mode_str = BlockDev.lvm_get_vdo_operating_mode_str(vdo_info.operating_mode)
         self.assertEqual(mode_str, "normal")
+
+        state_str = BlockDev.lvm_get_vdo_compression_state_str(vdo_info.compression_state)
+        self.assertEqual(state_str, "online")
+
+        policy_str = BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy)
+        self.assertIn(policy_str, ["sync", "async", "auto"])
+
 
         state_str = BlockDev.lvm_get_vdo_compression_state_str(vdo_info.compression_state)
         self.assertEqual(state_str, "online")

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1460,6 +1460,7 @@ class LVMVDOTest(LVMTestCase):
         self.assertTrue(vdo_info.deduplication)
         self.assertGreater(vdo_info.index_memory_size, 0)
         self.assertGreater(vdo_info.used_size, 0)
+        self.assertTrue(0 <= vdo_info.saving_percent <= 100)
 
         mode_str = BlockDev.lvm_get_vdo_operating_mode_str(vdo_info.operating_mode)
         self.assertEqual(mode_str, "normal")

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1458,12 +1458,17 @@ class LVMVDOTest(LVMTestCase):
         self.assertEqual(vdo_info.compression_state, BlockDev.LVMVDOCompressionState.ONLINE)
         self.assertTrue(vdo_info.compression)
         self.assertTrue(vdo_info.deduplication)
+        self.assertGreater(vdo_info.index_memory_size, 0)
+        self.assertGreater(vdo_info.used_size, 0)
 
         mode_str = BlockDev.lvm_get_vdo_operating_mode_str(vdo_info.operating_mode)
         self.assertEqual(mode_str, "normal")
 
         state_str = BlockDev.lvm_get_vdo_compression_state_str(vdo_info.compression_state)
         self.assertEqual(state_str, "online")
+
+        policy_str = BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy)
+        self.assertIn(policy_str, ["sync", "async", "auto"])
 
     @tag_test(TestTags.SLOW)
     def test_resize(self):


### PR DESCRIPTION
Also contains two unrelated fixes for issues discovered during writing this.
Note this is technically an ABI break but the LVM VDO changes are not released yet.