### PR TITLE
Fix LVM plugin so names in tests

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -24,7 +24,7 @@ class LVMTestCase(unittest.TestCase):
             # force the new plugin to be used
             cls.ps = BlockDev.PluginSpec()
             cls.ps.name = BlockDev.Plugin.LVM
-            cls.ps.so_name = "libbd_lvm-dbus.so"
+            cls.ps.so_name = "libbd_lvm-dbus.so.2"
             cls.ps2 = BlockDev.PluginSpec()
             cls.ps2.name = BlockDev.Plugin.LOOP
             if not BlockDev.is_initialized():

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -18,7 +18,7 @@ class LVMTestCase(unittest.TestCase):
     def setUpClass(cls):
         ps = BlockDev.PluginSpec()
         ps.name = BlockDev.Plugin.LVM
-        ps.so_name = "libbd_lvm.so"
+        ps.so_name = "libbd_lvm.so.2"
         cls.requested_plugins = [ps]
 
         if not BlockDev.is_initialized():


### PR DESCRIPTION
We need to specify exact version of the plugin otherwise the tests
won't work when running against installed version of libblockdev
because we ship the symlink without the version only in the devel
package.