### PR TITLE
Add extra parameters for creating LVM VDO volumes

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -1336,6 +1336,10 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  * @pool_name: name of the to-be-created VDO pool LV
  * @data_size: requested size of the data VDO LV (physical size of the @pool_name VDO pool LV)
  * @virtual_size: requested virtual_size of the @lv_name VDO LV
+ * @index_memory: amount of index memory (in bytes) or 0 for default
+ * @compression: whether to enable compression or not
+ * @deduplication: whether to enable deduplication or not
+ * @write_policy: write policy for the volume
  * @extra: (allow-none) (array zero-terminated=1): extra options for the VDO LV creation
  *                                                 (just passed to LVM as is)
  * @error: (out): place to store error (if any)
@@ -1344,7 +1348,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_CREATE
  */
-gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, const gchar *pool_name, guint64 data_size, guint64 virtual_size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, const gchar *pool_name, guint64 data_size, guint64 virtual_size, guint64 index_memory, gboolean compression, gboolean deduplication, BDLVMVDOWritePolicy write_policy, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vdo_enable_compression:
@@ -1456,6 +1460,10 @@ gboolean bd_lvm_vdo_pool_resize (const gchar *vg_name, const gchar *pool_name, g
  * @pool_lv: name of the LV that should become the new VDO pool LV
  * @name: (allow-none): name for the VDO LV or %NULL for default name
  * @virtual_size: virtual size for the new VDO LV
+ * @index_memory: amount of index memory (in bytes) or 0 for default
+ * @compression: whether to enable compression or not
+ * @deduplication: whether to enable deduplication or not
+ * @write_policy: write policy for the volume
  * @extra: (allow-none) (array zero-terminated=1): extra options for the VDO pool creation
  *                                                 (just passed to LVM as is)
  * @error: (out): place to store error (if any)
@@ -1469,7 +1477,7 @@ gboolean bd_lvm_vdo_pool_resize (const gchar *vg_name, const gchar *pool_name, g
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_CREATE&%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, const gchar *name, guint64 virtual_size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, const gchar *name, guint64 virtual_size, guint64 index_memory, gboolean compression, gboolean deduplication, BDLVMVDOWritePolicy write_policy, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_get_vdo_operating_mode_str:

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -3399,6 +3399,10 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  * @pool_name: name of the to-be-created VDO pool LV
  * @data_size: requested size of the data VDO LV (physical size of the @pool_name VDO pool LV)
  * @virtual_size: requested virtual_size of the @lv_name VDO LV
+ * @index_memory: amount of index memory (in bytes) or 0 for default
+ * @compression: whether to enable compression or not
+ * @deduplication: whether to enable deduplication or not
+ * @write_policy: write policy for the volume
  * @extra: (allow-none) (array zero-terminated=1): extra options for the VDO LV creation
  *                                                 (just passed to LVM as is)
  * @error: (out): place to store error (if any)
@@ -3407,9 +3411,16 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_CREATE
  */
-gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, const gchar *pool_name, guint64 data_size, guint64 virtual_size, const BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, const gchar *pool_name, guint64 data_size, guint64 virtual_size, guint64 index_memory, gboolean compression, gboolean deduplication, BDLVMVDOWritePolicy write_policy, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
+    GVariant *extra_params = NULL;
+    gchar *old_config = NULL;
+    const gchar *write_policy_str = NULL;
+
+    write_policy_str = bd_lvm_get_vdo_write_policy_str (write_policy, error);
+    if (*error)
+        return FALSE;
 
     /* build the params tuple */
     g_variant_builder_init (&builder, G_VARIANT_TYPE_TUPLE);
@@ -3420,7 +3431,29 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_obj_method_sync (vg_name, VG_VDO_INTF, "CreateVdoPoolandLv", params, NULL, extra, error);
+    /* and now the extra_params params */
+    g_variant_builder_init (&builder, G_VARIANT_TYPE_DICTIONARY);
+    g_variant_builder_add_value (&builder, g_variant_new ("{sv}", "--compression", g_variant_new ("s", compression ? "y" : "n")));
+    g_variant_builder_add_value (&builder, g_variant_new ("{sv}", "--deduplication", g_variant_new ("s", deduplication ? "y" : "n")));
+    extra_params = g_variant_builder_end (&builder);
+    g_variant_builder_clear (&builder);
+
+    /* index_memory and write_policy can be specified only using the config */
+    g_mutex_lock (&global_config_lock);
+    old_config = global_config_str;
+    if (index_memory != 0)
+        global_config_str = g_strdup_printf ("%s allocation {vdo_index_memory_size_mb=%"G_GUINT64_FORMAT" vdo_write_policy=\"%s\"}", old_config ? old_config : "",
+                                                                                                                                     index_memory / (1024 * 1024),
+                                                                                                                                     write_policy_str);
+    else
+        global_config_str = g_strdup_printf ("%s allocation {vdo_write_policy=\"%s\"}", old_config ? old_config : "",
+                                                                                        write_policy_str);
+
+    call_lvm_obj_method_sync (vg_name, VG_VDO_INTF, "CreateVdoPoolandLv", params, extra_params, extra, FALSE, error);
+
+    g_free (global_config_str);
+    global_config_str = old_config;
+    g_mutex_unlock (&global_config_lock);
 
     return ((*error) == NULL);
 }
@@ -3584,7 +3617,7 @@ gboolean bd_lvm_vdo_pool_resize (const gchar *vg_name, const gchar *pool_name, g
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_CREATE&%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name UNUSED, const gchar *pool_lv UNUSED, const gchar *name UNUSED, guint64 virtual_size UNUSED, const BDExtraArg **extra UNUSED, GError **error) {
+gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name UNUSED, const gchar *pool_lv UNUSED, const gchar *name UNUSED, guint64 virtual_size UNUSED, guint64 index_memory UNUSED, gboolean compression UNUSED, gboolean deduplication UNUSED, BDLVMVDOWritePolicy write_policy UNUSED, const BDExtraArg **extra UNUSED, GError **error) {
     return bd_lvm_is_tech_avail (BD_LVM_TECH_VDO, BD_LVM_TECH_MODE_CREATE | BD_LVM_TECH_MODE_MODIFY, error);
 }
 

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -537,7 +537,7 @@ static gboolean unbox_params_and_add (GVariant *params, GVariantBuilder *builder
     return FALSE;
 }
 
-static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, guint64 *task_id, guint64 *progress_id, GError **error) {
+static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, guint64 *task_id, guint64 *progress_id, gboolean lock_config, GError **error) {
     GVariant *config = NULL;
     GVariant *param = NULL;
     GVariantIter iter;
@@ -557,7 +557,8 @@ static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gch
         return NULL;
 
     /* don't allow global config string changes during the run */
-    g_mutex_lock (&global_config_lock);
+    if (lock_config)
+        g_mutex_lock (&global_config_lock);
 
     if (global_config_str || extra_params || extra_args) {
         if (global_config_str || extra_args) {
@@ -629,7 +630,8 @@ static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gch
     ret = g_dbus_connection_call_sync (bus, LVM_BUS_NAME, obj, intf, method, all_params,
                                        NULL, G_DBUS_CALL_FLAGS_NONE, METHOD_CALL_TIMEOUT, NULL, error);
 
-    g_mutex_unlock (&global_config_lock);
+    if (lock_config)
+         g_mutex_unlock (&global_config_lock);
     prog_msg = g_strdup_printf ("Started the '%s.%s' method on the '%s' object with the following parameters: '%s'",
                                intf, method, obj, params_str);
     g_free (params_str);
@@ -644,7 +646,7 @@ static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gch
     return ret;
 }
 
-static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
+static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, gboolean lock_config, GError **error) {
     GVariant *ret = NULL;
     gchar *obj_path = NULL;
     gchar *task_path = NULL;
@@ -656,7 +658,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
     gint64 error_code = 0;
     gchar *error_msg = NULL;
 
-    ret = call_lvm_method (obj, intf, method, params, extra_params, extra_args, &log_task_id, &prog_id, error);
+    ret = call_lvm_method (obj, intf, method, params, extra_params, extra_args, &log_task_id, &prog_id, lock_config, error);
     log_task_status (log_task_id, "Done.");
     if (!ret) {
         if (*error) {
@@ -802,26 +804,26 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
     g_free (task_path);
 }
 
-static void call_lvm_obj_method_sync (const gchar *obj_id, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
+static void call_lvm_obj_method_sync (const gchar *obj_id, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, gboolean lock_config, GError **error) {
     gchar *obj_path = get_object_path (obj_id, error);
     if (!obj_path)
         return;
 
-    call_lvm_method_sync (obj_path, intf, method, params, extra_params, extra_args, error);
+    call_lvm_method_sync (obj_path, intf, method, params, extra_params, extra_args, lock_config, error);
     g_free (obj_path);
 }
 
-static void call_lv_method_sync (const gchar *vg_name, const gchar *lv_name, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
+static void call_lv_method_sync (const gchar *vg_name, const gchar *lv_name, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, gboolean lock_config, GError **error) {
     gchar *obj_id = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
-    call_lvm_obj_method_sync (obj_id, LV_INTF, method, params, extra_params, extra_args, error);
+    call_lvm_obj_method_sync (obj_id, LV_INTF, method, params, extra_params, extra_args, lock_config, error);
     g_free (obj_id);
 }
 
-static void call_thpool_method_sync (const gchar *vg_name, const gchar *pool_name, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
+static void call_thpool_method_sync (const gchar *vg_name, const gchar *pool_name, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, gboolean lock_config, GError **error) {
     gchar *obj_id = g_strdup_printf ("%s/%s", vg_name, pool_name);
 
-    call_lvm_obj_method_sync (obj_id, THPOOL_INTF, method, params, extra_params, extra_args, error);
+    call_lvm_obj_method_sync (obj_id, THPOOL_INTF, method, params, extra_params, extra_args, lock_config, error);
     g_free (obj_id);
 }
 
@@ -1419,7 +1421,7 @@ gboolean bd_lvm_pvcreate (const gchar *device, guint64 data_alignment, guint64 m
 
     params = g_variant_new ("(s)", device);
 
-    call_lvm_method_sync (MANAGER_OBJ, MANAGER_INTF, "PvCreate", params, extra_params, extra, error);
+    call_lvm_method_sync (MANAGER_OBJ, MANAGER_INTF, "PvCreate", params, extra_params, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1446,7 +1448,7 @@ gboolean bd_lvm_pvresize (const gchar *device, guint64 size, const BDExtraArg **
         return FALSE;
 
     params = g_variant_new ("(u)", size);
-    call_lvm_method_sync (obj_path, PV_INTF, "ReSize", params, NULL, extra, error);
+    call_lvm_method_sync (obj_path, PV_INTF, "ReSize", params, NULL, extra, TRUE, error);
 
     return (*error == NULL);
 }
@@ -1480,7 +1482,7 @@ gboolean bd_lvm_pvremove (const gchar *device, const BDExtraArg **extra, GError 
 
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
-    call_lvm_obj_method_sync (device, PV_INTF, "Remove", NULL, params, extra, error);
+    call_lvm_obj_method_sync (device, PV_INTF, "Remove", NULL, params, extra, TRUE, error);
     if (*error && g_error_matches (*error, BD_LVM_ERROR, BD_LVM_ERROR_NOEXIST))
         /* if the object doesn't exist, the given device is not a PV and thus
            this function should be a noop */
@@ -1551,7 +1553,7 @@ gboolean bd_lvm_pvmove (const gchar *src, const gchar *dest, const BDExtraArg **
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_method_sync (vg_obj_path, VG_INTF, "Move", params, NULL, extra, error);
+    call_lvm_method_sync (vg_obj_path, VG_INTF, "Move", params, NULL, extra, TRUE, error);
 
     g_free (src_path);
     g_free (dest_path);
@@ -1601,7 +1603,7 @@ gboolean bd_lvm_pvscan (const gchar *device, gboolean update_cache, const BDExtr
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_method_sync (MANAGER_OBJ, MANAGER_INTF, "PvScan", params, NULL, extra, error);
+    call_lvm_method_sync (MANAGER_OBJ, MANAGER_INTF, "PvScan", params, NULL, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1730,7 +1732,7 @@ gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_s
     extra_params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_method_sync (MANAGER_OBJ, MANAGER_INTF, "VgCreate", params, extra_params, extra, error);
+    call_lvm_method_sync (MANAGER_OBJ, MANAGER_INTF, "VgCreate", params, extra_params, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1746,7 +1748,7 @@ gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_s
  * Tech category: %BD_LVM_TECH_BASIC-%BD_LVM_TECH_MODE_REMOVE
  */
 gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "Remove", NULL, NULL, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "Remove", NULL, NULL, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1764,7 +1766,7 @@ gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError
  */
 gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(s)", new_vg_name);
-    call_lvm_obj_method_sync (old_vg_name, VG_INTF, "Rename", params, NULL, extra, error);
+    call_lvm_obj_method_sync (old_vg_name, VG_INTF, "Rename", params, NULL, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1781,7 +1783,7 @@ gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, co
  */
 gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", (guint64) 0);
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "Activate", params, NULL, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "Activate", params, NULL, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1798,7 +1800,7 @@ gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GErr
  */
 gboolean bd_lvm_vgdeactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", (guint64) 0);
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "Deactivate", params, NULL, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "Deactivate", params, NULL, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -1827,7 +1829,7 @@ gboolean bd_lvm_vgextend (const gchar *vg_name, const gchar *device, const BDExt
     pv_var = g_variant_new ("o", pv);
     pvs = g_variant_new_array (NULL, &pv_var, 1);
     params = g_variant_new_tuple (&pvs, 1);
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "Extend", params, NULL, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "Extend", params, NULL, extra, TRUE, error);
     g_free (pv);
     return ((*error) == NULL);
 }
@@ -1885,7 +1887,7 @@ gboolean bd_lvm_vgreduce (const gchar *vg_name, const gchar *device, const BDExt
         g_variant_builder_clear (&builder);
     }
 
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "Reduce", params, extra_params, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "Reduce", params, extra_params, extra, TRUE, error);
     g_free (pv);
     return ((*error) == NULL);
 }
@@ -2069,7 +2071,7 @@ gboolean bd_lvm_lvcreate (const gchar *vg_name, const gchar *lv_name, guint64 si
         g_variant_builder_clear (&builder);
     }
 
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "LvCreate", params, extra_params, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "LvCreate", params, extra_params, extra, TRUE, error);
 
     return ((*error) == NULL);
 }
@@ -2100,7 +2102,7 @@ gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean f
     extra_params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lv_method_sync (vg_name, lv_name, "Remove", NULL, extra_params, extra, error);
+    call_lv_method_sync (vg_name, lv_name, "Remove", NULL, extra_params, extra, TRUE, error);
 
     return (*error == NULL);
 }
@@ -2123,7 +2125,7 @@ gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gcha
     GVariant *params = NULL;
 
     params = g_variant_new ("(s)", new_name);
-    call_lv_method_sync (vg_name, lv_name, "Rename", params, NULL, extra, error);
+    call_lv_method_sync (vg_name, lv_name, "Rename", params, NULL, extra, TRUE, error);
     return (*error == NULL);
 }
 
@@ -2153,7 +2155,7 @@ gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 si
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lv_method_sync (vg_name, lv_name, "Resize", params, NULL, extra, error);
+    call_lv_method_sync (vg_name, lv_name, "Resize", params, NULL, extra, TRUE, error);
     return (*error == NULL);
 }
 
@@ -2181,7 +2183,7 @@ gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean
         extra_params = g_variant_builder_end (&builder);
         g_variant_builder_clear (&builder);
     }
-    call_lv_method_sync (vg_name, lv_name, "Activate", params, extra_params, extra, error);
+    call_lv_method_sync (vg_name, lv_name, "Activate", params, extra_params, extra, TRUE, error);
 
     return (*error == NULL);
 }
@@ -2200,7 +2202,7 @@ gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean
  */
 gboolean bd_lvm_lvdeactivate (const gchar *vg_name, const gchar *lv_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", (guint64) 0);
-    call_lv_method_sync (vg_name, lv_name, "Deactivate", params, NULL, extra, error);
+    call_lv_method_sync (vg_name, lv_name, "Deactivate", params, NULL, extra, TRUE, error);
     return (*error == NULL);
 }
 
@@ -2229,7 +2231,7 @@ gboolean bd_lvm_lvsnapshotcreate (const gchar *vg_name, const gchar *origin_name
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lv_method_sync (vg_name, origin_name, "Snapshot", params, NULL, extra, error);
+    call_lv_method_sync (vg_name, origin_name, "Snapshot", params, NULL, extra, TRUE, error);
 
     return (*error == NULL);
 }
@@ -2257,7 +2259,7 @@ gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_nam
     if (!obj_path)
         return FALSE;
 
-    call_lvm_method_sync (obj_path, SNAP_INTF, "Merge", NULL, NULL, extra, error);
+    call_lvm_method_sync (obj_path, SNAP_INTF, "Merge", NULL, NULL, extra, TRUE, error);
     return (*error == NULL);
 }
 
@@ -2513,7 +2515,7 @@ gboolean bd_lvm_thpoolcreate (const gchar *vg_name, const gchar *lv_name, guint6
     extra_params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "LvCreateLinear", params, extra_params, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "LvCreateLinear", params, extra_params, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -2541,7 +2543,7 @@ gboolean bd_lvm_thlvcreate (const gchar *vg_name, const gchar *pool_name, const 
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_thpool_method_sync (vg_name, pool_name, "LvCreate", params, NULL, extra, error);
+    call_thpool_method_sync (vg_name, pool_name, "LvCreate", params, NULL, extra, TRUE, error);
 
     return (*error == NULL);
 }
@@ -2621,7 +2623,7 @@ gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name
         g_variant_builder_clear (&builder);
     }
 
-    call_lv_method_sync (vg_name, origin_name, "Snapshot", params, extra_params, extra, error);
+    call_lv_method_sync (vg_name, origin_name, "Snapshot", params, extra_params, extra, TRUE, error);
 
     return (*error == NULL);
 }
@@ -2872,7 +2874,7 @@ gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name,
     extra = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateCachePool", params, extra, NULL, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateCachePool", params, extra, NULL, TRUE, error);
     if (*error)
         bd_utils_report_finished (progress_id, (*error)->message);
     else
@@ -2912,7 +2914,7 @@ gboolean bd_lvm_cache_attach (const gchar *vg_name, const gchar *data_lv, const 
 
     lv_id = g_strdup_printf ("%s/%s", vg_name, cache_pool_lv);
 
-    call_lvm_obj_method_sync (lv_id, CACHE_POOL_INTF, "CacheLv", params, NULL, extra, error);
+    call_lvm_obj_method_sync (lv_id, CACHE_POOL_INTF, "CacheLv", params, NULL, extra, TRUE, error);
     return ((*error) == NULL);
 }
 
@@ -2946,7 +2948,7 @@ gboolean bd_lvm_cache_detach (const gchar *vg_name, const gchar *cached_lv, gboo
     if (!cache_pool_name)
         return FALSE;
     lv_id = g_strdup_printf ("%s/%s", vg_name, cached_lv);
-    call_lvm_obj_method_sync (lv_id, CACHED_LV_INTF, "DetachCachePool", params, NULL, extra, error);
+    call_lvm_obj_method_sync (lv_id, CACHED_LV_INTF, "DetachCachePool", params, NULL, extra, TRUE, error);
     g_free (lv_id);
     return ((*error) == NULL);
 }
@@ -3332,7 +3334,7 @@ gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, cons
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateThinPool", params, NULL, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateThinPool", params, NULL, extra, TRUE, error);
 
     if (((*error) == NULL) && name)
         bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
@@ -3382,7 +3384,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
     params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
-    call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateCachePool", params, NULL, extra, error);
+    call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateCachePool", params, NULL, extra, TRUE, error);
 
     if (((*error) == NULL) && name)
         bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -331,7 +331,7 @@ gboolean bd_lvm_is_tech_avail (BDLVMTech tech, guint64 mode, GError **error) {
     }
 }
 
-static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg **extra, GError **error) {
+static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg **extra, gboolean lock_config, GError **error) {
     gboolean success = FALSE;
     guint i = 0;
     guint args_length = g_strv_length ((gchar **) args);
@@ -340,7 +340,8 @@ static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg 
         return FALSE;
 
     /* don't allow global config string changes during the run */
-    g_mutex_lock (&global_config_lock);
+    if (lock_config)
+        g_mutex_lock (&global_config_lock);
 
     /* allocate enough space for the args plus "lvm", "--config" and NULL */
     const gchar **argv = g_new0 (const gchar*, args_length + 3);
@@ -353,7 +354,8 @@ static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg 
     argv[args_length + 2] = NULL;
 
     success = bd_utils_exec_and_report_error (argv, extra, error);
-    g_mutex_unlock (&global_config_lock);
+    if (lock_config)
+        g_mutex_unlock (&global_config_lock);
     g_free ((gchar *) argv[args_length + 1]);
     g_free (argv);
 
@@ -934,7 +936,7 @@ gboolean bd_lvm_pvcreate (const gchar *device, guint64 data_alignment, guint64 m
         args[next_arg++] = metadata_str;
     }
 
-    ret = call_lvm_and_report_error (args, extra, error);
+    ret = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free (dataalign_str);
     g_free (metadata_str);
 
@@ -975,7 +977,7 @@ gboolean bd_lvm_pvresize (const gchar *device, guint64 size, const BDExtraArg **
 
     args[next_pos] = device;
 
-    ret = call_lvm_and_report_error (args, extra, error);
+    ret = call_lvm_and_report_error (args, extra, TRUE, error);
     if (to_free_pos > 0)
         g_free ((gchar *) args[to_free_pos]);
 
@@ -998,7 +1000,7 @@ gboolean bd_lvm_pvremove (const gchar *device, const BDExtraArg **extra, GError 
        bug, at least not in this code) */
     const gchar *args[6] = {"pvremove", "--force", "--force", "--yes", device, NULL};
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 static gboolean extract_pvmove_progress (const gchar *line, guint8 *completion) {
@@ -1067,7 +1069,7 @@ gboolean bd_lvm_pvscan (const gchar *device, gboolean update_cache, const BDExtr
         if (device)
             bd_utils_log_format (BD_UTILS_LOG_WARNING, "Ignoring the device argument in pvscan (cache update not requested)");
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1218,7 +1220,7 @@ gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_s
     }
     argv[i] = NULL;
 
-    success = call_lvm_and_report_error (argv, extra, error);
+    success = call_lvm_and_report_error (argv, extra, TRUE, error);
     g_free ((gchar *) argv[2]);
     g_free (argv);
 
@@ -1239,7 +1241,7 @@ gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_s
 gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"vgremove", "--force", vg_name, NULL};
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1257,7 +1259,7 @@ gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError
 gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"vgrename", old_vg_name, new_vg_name, NULL};
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1274,7 +1276,7 @@ gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, co
 gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"vgchange", "-ay", vg_name, NULL};
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1291,7 +1293,7 @@ gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GErr
 gboolean bd_lvm_vgdeactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"vgchange", "-an", vg_name, NULL};
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1309,7 +1311,7 @@ gboolean bd_lvm_vgdeactivate (const gchar *vg_name, const BDExtraArg **extra, GE
 gboolean bd_lvm_vgextend (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"vgextend", vg_name, device, NULL};
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1340,7 +1342,7 @@ gboolean bd_lvm_vgreduce (const gchar *vg_name, const gchar *device, const BDExt
         args[2] = device;
     }
 
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 /**
@@ -1536,7 +1538,7 @@ gboolean bd_lvm_lvcreate (const gchar *vg_name, const gchar *lv_name, guint64 si
 
     args[i] = NULL;
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free (size_str);
     g_free (type_str);
     g_free (args);
@@ -1570,7 +1572,7 @@ gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean f
 
     args[next_arg] = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[next_arg]);
 
     return success;
@@ -1592,7 +1594,7 @@ gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean f
  */
 gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gchar *new_name, const BDExtraArg **extra, GError **error) {
     const gchar *args[5] = {"lvrename", vg_name, lv_name, new_name, NULL};
-    return call_lvm_and_report_error (args, extra, error);
+    return call_lvm_and_report_error (args, extra, TRUE, error);
 }
 
 
@@ -1616,7 +1618,7 @@ gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 si
     args[3] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size/1024);
     args[4] = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[3]);
     g_free ((gchar *) args[4]);
 
@@ -1647,7 +1649,7 @@ gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean
     }
     args[next_arg] = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[next_arg]);
 
     return success;
@@ -1671,7 +1673,7 @@ gboolean bd_lvm_lvdeactivate (const gchar *vg_name, const gchar *lv_name, const 
 
     args[2] = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[2]);
 
     return success;
@@ -1699,7 +1701,7 @@ gboolean bd_lvm_lvsnapshotcreate (const gchar *vg_name, const gchar *origin_name
     args[3] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size / 1024);
     args[6] = g_strdup_printf ("%s/%s", vg_name, origin_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[3]);
     g_free ((gchar *) args[6]);
 
@@ -1724,7 +1726,7 @@ gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_nam
 
     args[2] = g_strdup_printf ("%s/%s", vg_name, snapshot_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[2]);
 
     return success;
@@ -1899,7 +1901,7 @@ gboolean bd_lvm_thpoolcreate (const gchar *vg_name, const gchar *lv_name, guint6
 
     args[next_arg] = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[3]);
     g_free ((gchar *) args[4]);
     g_free ((gchar *) args[5]);
@@ -1930,7 +1932,7 @@ gboolean bd_lvm_thlvcreate (const gchar *vg_name, const gchar *pool_name, const 
     args[2] = g_strdup_printf ("%s/%s", vg_name, pool_name);
     args[4] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size / 1024);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[2]);
     g_free ((gchar *) args[4]);
 
@@ -1993,7 +1995,7 @@ gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name
 
     args[next_arg] = g_strdup_printf ("%s/%s", vg_name, origin_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[next_arg]);
 
     return success;
@@ -2215,7 +2217,7 @@ gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name,
     }
     name = g_strdup_printf ("%s/%s", vg_name, pool_name);
     args[8] = name;
-    success = call_lvm_and_report_error (args, NULL, error);
+    success = call_lvm_and_report_error (args, NULL, TRUE, error);
     g_free ((gchar *) args[5]);
     g_free ((gchar *) args[8]);
 
@@ -2247,7 +2249,7 @@ gboolean bd_lvm_cache_attach (const gchar *vg_name, const gchar *data_lv, const 
 
     args[5] = g_strdup_printf ("%s/%s", vg_name, cache_pool_lv);
     args[6] = g_strdup_printf ("%s/%s", vg_name, data_lv);
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
 
     g_free ((gchar *) args[5]);
     g_free ((gchar *) args[6]);
@@ -2277,7 +2279,7 @@ gboolean bd_lvm_cache_detach (const gchar *vg_name, const gchar *cached_lv, gboo
 
     args[3] = destroy ? "--uncache" : "--splitcache";
     args[4] = g_strdup_printf ("%s/%s", vg_name, cached_lv);
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
 
     g_free ((gchar *) args[4]);
     return success;
@@ -2592,7 +2594,7 @@ gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, cons
 
     args[6] = g_strdup_printf ("%s/%s", vg_name, data_lv);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[6]);
 
     if (success && name)
@@ -2625,7 +2627,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
 
     args[6] = g_strdup_printf ("%s/%s", vg_name, data_lv);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[6]);
 
     if (success && name)
@@ -2672,7 +2674,7 @@ static gboolean _vdo_set_compression_deduplication (const gchar *vg_name, const 
 
     args[3] = g_strdup_printf ("%s/%s", vg_name, pool_name);
 
-    success = call_lvm_and_report_error (args, extra, error);
+    success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[3]);
 
     return success;

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -278,7 +278,7 @@ gboolean bd_lvm_cache_create_cached_lv (const gchar *vg_name, const gchar *lv_na
 gchar* bd_lvm_cache_pool_name (const gchar *vg_name, const gchar *cached_lv, GError **error);
 BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_lv, GError **error);
 
-gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, const gchar *pool_name, guint64 data_size, guint64 virtual_size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, const gchar *pool_name, guint64 data_size, guint64 virtual_size, guint64 index_memory, gboolean compression, gboolean deduplication, BDLVMVDOWritePolicy write_policy, const BDExtraArg **extra, GError **error);
 BDLVMVDOPooldata *bd_lvm_vdo_info (const gchar *vg_name, const gchar *pool_name, GError **error);
 
 gboolean bd_lvm_vdo_resize (const gchar *vg_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error);
@@ -294,7 +294,7 @@ gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GErr
 
 gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error);
 gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, const gchar *name, guint64 virtual_size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, const gchar *name, guint64 virtual_size, guint64 index_memory, gboolean compression, gboolean deduplication, BDLVMVDOWritePolicy write_policy, const BDExtraArg **extra, GError **error);
 
 const gchar* bd_lvm_get_vdo_operating_mode_str (BDLVMVDOOperatingMode mode, GError **error);
 const gchar* bd_lvm_get_vdo_compression_state_str (BDLVMVDOCompressionState state, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -707,9 +707,9 @@ __all__.append("lvm_cache_pool_convert")
 
 _lvm_vdo_pool_create = BlockDev.lvm_vdo_pool_create
 @override(BlockDev.lvm_vdo_pool_create)
-def lvm_vdo_pool_create(vg_name, lv_name, pool_name, data_size, virtual_size, extra=None, **kwargs):
+def lvm_vdo_pool_create(vg_name, lv_name, pool_name, data_size, virtual_size, index_memory=0, compression=True, deduplication=True, write_policy=BlockDev.LVMVDOWritePolicy.AUTO, extra=None, **kwargs):
     extra = _get_extra(extra, kwargs)
-    return _lvm_vdo_pool_create(vg_name, lv_name, pool_name, data_size,virtual_size, extra)
+    return _lvm_vdo_pool_create(vg_name, lv_name, pool_name, data_size,virtual_size, index_memory, compression, deduplication, write_policy, extra)
 __all__.append("lvm_vdo_pool_create")
 
 _lvm_vdo_resize = BlockDev.lvm_vdo_resize
@@ -756,9 +756,9 @@ __all__.append("lvm_vdo_disable_deduplication")
 
 _lvm_vdo_pool_convert = BlockDev.lvm_vdo_pool_convert
 @override(BlockDev.lvm_vdo_pool_convert)
-def lvm_vdo_pool_convert(vg_name, lv_name, pool_name, virtual_size, extra=None, **kwargs):
+def lvm_vdo_pool_convert(vg_name, lv_name, pool_name, virtual_size, index_memory=0, compression=True, deduplication=True, write_policy=BlockDev.LVMVDOWritePolicy.AUTO, extra=None, **kwargs):
     extra = _get_extra(extra, kwargs)
-    return _lvm_vdo_pool_convert(vg_name, lv_name, pool_name, virtual_size, extra)
+    return _lvm_vdo_pool_convert(vg_name, lv_name, pool_name, virtual_size, index_memory, compression, deduplication, write_policy, extra)
 __all__.append("lvm_vdo_pool_convert")
 
 _md_get_superblock_size = BlockDev.md_get_superblock_size

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1549,9 +1549,22 @@ class LVMVDOTest(LVMTestCase):
         policy_str = BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy)
         self.assertIn(policy_str, ["sync", "async", "auto"])
 
-
         state_str = BlockDev.lvm_get_vdo_compression_state_str(vdo_info.compression_state)
         self.assertEqual(state_str, "online")
+
+    @tag_test(TestTags.SLOW)
+    def test_vdo_pool_create_options(self):
+        # set index size to 300 MiB, disable compression and write policy to sync
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3,
+                                            300 * 1024**2, False, True, BlockDev.LVMVDOWritePolicy.SYNC)
+        self.assertTrue(succ)
+
+        vdo_info = BlockDev.lvm_vdo_info("testVDOVG", "vdoPool")
+        self.assertIsNotNone(vdo_info)
+        self.assertEqual(vdo_info.index_memory_size, 300 * 1024**2)
+        self.assertFalse(vdo_info.compression)
+        self.assertTrue(vdo_info.deduplication)
+        self.assertEqual(BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy), "sync")
 
     @tag_test(TestTags.SLOW)
     def test_resize(self):


### PR DESCRIPTION
Our users expect to be able to manually control compression,
deduplication and VDO index memory size when creating LVM VDO
volumes. This also makes the API consistent with the VDO plugin
API.