### PR TITLE
Add functions to get VDO stats for LVM VDO volumes

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -267,6 +267,9 @@ BDLVMCachePoolFlags
 BDLVMCacheStats
 bd_lvm_cache_stats_copy
 bd_lvm_cache_stats_free
+BDLVMVDOStats
+bd_lvm_vdo_stats_free
+bd_lvm_vdo_stats_copy
 bd_lvm_is_supported_pe_size
 bd_lvm_get_supported_pe_sizes
 bd_lvm_get_max_lv_size
@@ -326,6 +329,8 @@ bd_lvm_get_vdo_operating_mode_str
 bd_lvm_get_vdo_compression_state_str
 bd_lvm_get_vdo_index_state_str
 bd_lvm_get_vdo_write_policy_from_str
+bd_lvm_vdo_get_stats
+bd_lvm_vdo_get_stats_full
 BDLVMTech
 BDLVMTechMode
 bd_lvm_is_tech_avail

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -437,6 +437,85 @@ GType bd_lvm_vdodata_get_type () {
     return type;
 }
 
+#define BD_LVM_TYPE_VDO_STATS (bd_lvm_vdo_stats_get_type ())
+GType bd_lvm_vdo_stats_get_type();
+
+/**
+ * BDLVMVDOStats:
+ * @block_size: The block size of a VDO volume, in bytes.
+ * @logical_block_size: The logical block size, in bytes.
+ * @physical_blocks: The total number of physical blocks allocated for a VDO volume.
+ * @data_blocks_used: The number of physical blocks currently in use by a VDO volume
+ *                    to store data.
+ * @overhead_blocks_used: The number of physical blocks currently in use by a VDO volume
+ *                        to store VDO metadata.
+ * @logical_blocks_used: The number of logical blocks currently mapped.
+ * @used_percent: The percentage of physical blocks used on a VDO volume
+ *                (= used blocks / allocated blocks * 100).
+ * @saving_percent: The percentage of physical blocks saved on a VDO volume
+ *                  (= [logical blocks used - physical blocks used] / logical blocks used).
+ * @write_amplification_ratio: The average number of block writes to the underlying storage
+ *                             per block written to the VDO device.
+ */
+typedef struct BDLVMVDOStats {
+    gint64 block_size;
+    gint64 logical_block_size;
+    gint64 physical_blocks;
+    gint64 data_blocks_used;
+    gint64 overhead_blocks_used;
+    gint64 logical_blocks_used;
+    gint64 used_percent;
+    gint64 saving_percent;
+    gdouble write_amplification_ratio;
+} BDLVMVDOStats;
+
+/**
+ * bd_lvm_vdo_stats_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDLVMVDOStats* bd_lvm_vdo_stats_copy (BDLVMVDOStats *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDLVMVDOStats *new_data = g_new0 (BDLVMVDOStats, 1);
+
+    new_data->block_size = data->block_size;
+    new_data->logical_block_size = data->logical_block_size;
+    new_data->physical_blocks = data->physical_blocks;
+    new_data->data_blocks_used = data->data_blocks_used;
+    new_data->overhead_blocks_used = data->overhead_blocks_used;
+    new_data->logical_blocks_used = data->logical_blocks_used;
+    new_data->used_percent = data->used_percent;
+    new_data->saving_percent = data->saving_percent;
+    new_data->write_amplification_ratio = data->write_amplification_ratio;
+    return new_data;
+}
+
+/**
+ * bd_lvm_vdo_stats_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_lvm_vdo_stats_free (BDLVMVDOStats *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data);
+}
+
+GType bd_lvm_vdo_stats_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDLVMVDOStats",
+                                            (GBoxedCopyFunc) bd_lvm_vdo_stats_copy,
+                                            (GBoxedFreeFunc) bd_lvm_vdo_stats_free);
+    }
+
+    return type;
+}
+
 #define BD_LVM_TYPE_CACHE_STATS (bd_lvm_cache_stats_get_type ())
 GType bd_lvm_cache_stats_get_type();
 
@@ -1535,5 +1614,40 @@ const gchar* bd_lvm_get_vdo_write_policy_str (BDLVMVDOWritePolicy policy, GError
  * Tech category: always provided/supported
  */
 BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_str, GError **error);
+
+/**
+ * bd_lvm_vdo_get_stats_full:
+ * @vg_name: name of the VG that contains @pool_name VDO pool
+ * @pool_name: name of the VDO pool to get statistics for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (element-type utf8 utf8): hashtable of type string - string of available
+ *                                                    statistics or %NULL in case of error
+ *                                                    (@error gets populated in those cases)
+ *
+ * Statistics are collected from the values exposed by the kernel `kvdo` module
+ * at the `/sys/kvdo/<VDO_NAME>/statistics/` path.
+ * Some of the keys are computed to mimic the information produced by the vdo tools.
+ * Please note the contents of the hashtable may vary depending on the actual kvdo module version.
+ *
+ * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
+ */
+GHashTable* bd_lvm_vdo_get_stats_full (const gchar *vg_name, const gchar *pool_name, GError **error);
+
+/**
+ * bd_lvm_vdo_get_stats:
+ * @vg_name: name of the VG that contains @pool_name VDO pool
+ * @pool_name: name of the VDO pool to get statistics for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): a structure containing selected statistics or %NULL in case of error
+ *                           (@error gets populated in those cases)
+ *
+ * In contrast to @bd_lvm_vdo_get_stats_full this function will only return selected statistics
+ * in a fixed structure. In case a value is not available, -1 would be returned.
+ *
+ * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
+ */
+BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_name, GError **error);
 
 #endif  /* BD_LVM_API */

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -363,7 +363,7 @@ GType bd_lvm_lvdata_get_type () {
     return type;
 }
 
-#define BD_LVM_TYPE_VDODATA (bd_lvm_lvdata_get_type ())
+#define BD_LVM_TYPE_VDODATA (bd_lvm_vdodata_get_type ())
 GType bd_lvm_vdodata_get_type();
 
 /**

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -113,7 +113,7 @@ libbd_lvm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_lvm_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(DEVMAPPER_LIBS)
 libbd_lvm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_lvm_la_CPPFLAGS = -I${builddir}/../../include/
-libbd_lvm_la_SOURCES = lvm.c lvm.h check_deps.c check_deps.h dm_logging.c dm_logging.h
+libbd_lvm_la_SOURCES = lvm.c lvm.h check_deps.c check_deps.h dm_logging.c dm_logging.h vdo_stats.c vdo_stats.h
 endif
 
 if WITH_LVM_DBUS
@@ -121,7 +121,7 @@ libbd_lvm_dbus_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) -Wal
 libbd_lvm_dbus_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS)
 libbd_lvm_dbus_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_lvm_dbus_la_CPPFLAGS = -I${builddir}/../../include/
-libbd_lvm_dbus_la_SOURCES = lvm-dbus.c lvm.h check_deps.c check_deps.h dm_logging.c dm_logging.h
+libbd_lvm_dbus_la_SOURCES = lvm-dbus.c lvm.h check_deps.c check_deps.h dm_logging.c dm_logging.h vdo_stats.c vdo_stats.h
 endif
 
 if WITH_MDRAID
@@ -194,7 +194,7 @@ libbd_vdo_la_CFLAGS = $(GLIB_CFLAGS) $(BYTESIZE_CFLAGS) $(YAML_CFLAGS) -Wall -We
 libbd_vdo_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(BYTESIZE_LIBS) $(YAML_LIBS)
 libbd_vdo_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_vdo_la_CPPFLAGS = -I${builddir}/../../include/
-libbd_vdo_la_SOURCES = vdo.c vdo.h check_deps.c check_deps.h
+libbd_vdo_la_SOURCES = vdo.c vdo.h check_deps.c check_deps.h vdo_stats.c vdo_stats.h
 endif
 
 libincludedir = $(includedir)/blockdev

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -28,9 +28,11 @@
 #include "lvm.h"
 #include "check_deps.h"
 #include "dm_logging.h"
+#include "vdo_stats.h"
 
 #define INT_FLOAT_EPS 1e-5
 #define SECTOR_SIZE 512
+#define VDO_POOL_SUFFIX "vpool"
 
 static GMutex global_config_lock;
 static gchar *global_config_str = NULL;
@@ -3752,4 +3754,65 @@ BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_st
                      "Invalid policy given: %s", policy_str);
         return BD_LVM_VDO_WRITE_POLICY_UNKNOWN;
     }
+}
+
+/**
+ * bd_lvm_vdo_get_stats_full:
+ * @vg_name: name of the VG that contains @pool_name VDO pool
+ * @pool_name: name of the VDO pool to get statistics for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (element-type utf8 utf8): hashtable of type string - string of available
+ *                                                    statistics or %NULL in case of error
+ *                                                    (@error gets populated in those cases)
+ *
+ * Statistics are collected from the values exposed by the kernel `kvdo` module
+ * at the `/sys/kvdo/<VDO_NAME>/statistics/` path.
+ * Some of the keys are computed to mimic the information produced by the vdo tools.
+ * Please note the contents of the hashtable may vary depending on the actual kvdo module version.
+ *
+ * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
+ */
+GHashTable* bd_lvm_vdo_get_stats_full (const gchar *vg_name, const gchar *pool_name, GError **error) {
+    g_autofree gchar *kvdo_name = g_strdup_printf ("%s-%s-%s", vg_name, pool_name, VDO_POOL_SUFFIX);
+    return vdo_get_stats_full(kvdo_name, error);
+}
+
+/**
+ * bd_lvm_vdo_get_stats:
+ * @vg_name: name of the VG that contains @pool_name VDO pool
+ * @pool_name: name of the VDO pool to get statistics for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): a structure containing selected statistics or %NULL in case of error
+ *                           (@error gets populated in those cases)
+ *
+ * In contrast to @bd_lvm_vdo_get_stats_full this function will only return selected statistics
+ * in a fixed structure. In case a value is not available, -1 would be returned.
+ *
+ * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
+ */
+BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_name, GError **error) {
+    GHashTable *full_stats = NULL;
+    BDLVMVDOStats *stats = NULL;
+
+    full_stats = bd_lvm_vdo_get_stats_full (vg_name, pool_name, error);
+    if (!full_stats)
+        return NULL;
+
+    stats = g_new0 (BDLVMVDOStats, 1);
+    get_stat_val64_default (full_stats, "block_size", &stats->block_size, -1);
+    get_stat_val64_default (full_stats, "logical_block_size", &stats->logical_block_size, -1);
+    get_stat_val64_default (full_stats, "physical_blocks", &stats->physical_blocks, -1);
+    get_stat_val64_default (full_stats, "data_blocks_used", &stats->data_blocks_used, -1);
+    get_stat_val64_default (full_stats, "overhead_blocks_used", &stats->overhead_blocks_used, -1);
+    get_stat_val64_default (full_stats, "logical_blocks_used", &stats->logical_blocks_used, -1);
+    get_stat_val64_default (full_stats, "usedPercent", &stats->used_percent, -1);
+    get_stat_val64_default (full_stats, "savingPercent", &stats->saving_percent, -1);
+    if (!get_stat_val_double (full_stats, "writeAmplificationRatio", &stats->write_amplification_ratio))
+        stats->write_amplification_ratio = -1;
+
+    g_hash_table_destroy (full_stats);
+
+    return stats;
 }

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -27,9 +27,11 @@
 #include "lvm.h"
 #include "check_deps.h"
 #include "dm_logging.h"
+#include "vdo_stats.h"
 
 #define INT_FLOAT_EPS 1e-5
 #define SECTOR_SIZE 512
+#define VDO_POOL_SUFFIX "vpool"
 
 static GMutex global_config_lock;
 static gchar *global_config_str = NULL;
@@ -3083,3 +3085,63 @@ BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_st
     }
 }
 
+/**
+ * bd_lvm_vdo_get_stats_full:
+ * @vg_name: name of the VG that contains @pool_name VDO pool
+ * @pool_name: name of the VDO pool to get statistics for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (element-type utf8 utf8): hashtable of type string - string of available
+ *                                                    statistics or %NULL in case of error
+ *                                                    (@error gets populated in those cases)
+ *
+ * Statistics are collected from the values exposed by the kernel `kvdo` module
+ * at the `/sys/kvdo/<VDO_NAME>/statistics/` path.
+ * Some of the keys are computed to mimic the information produced by the vdo tools.
+ * Please note the contents of the hashtable may vary depending on the actual kvdo module version.
+ *
+ * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
+ */
+GHashTable* bd_lvm_vdo_get_stats_full (const gchar *vg_name, const gchar *pool_name, GError **error) {
+    g_autofree gchar *kvdo_name = g_strdup_printf ("%s-%s-%s", vg_name, pool_name, VDO_POOL_SUFFIX);
+    return vdo_get_stats_full(kvdo_name, error);
+}
+
+/**
+ * bd_lvm_vdo_get_stats:
+ * @vg_name: name of the VG that contains @pool_name VDO pool
+ * @pool_name: name of the VDO pool to get statistics for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): a structure containing selected statistics or %NULL in case of error
+ *                           (@error gets populated in those cases)
+ *
+ * In contrast to @bd_lvm_vdo_get_stats_full this function will only return selected statistics
+ * in a fixed structure. In case a value is not available, -1 would be returned.
+ *
+ * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
+ */
+BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_name, GError **error) {
+    GHashTable *full_stats = NULL;
+    BDLVMVDOStats *stats = NULL;
+
+    full_stats = bd_lvm_vdo_get_stats_full (vg_name, pool_name, error);
+    if (!full_stats)
+        return NULL;
+
+    stats = g_new0 (BDLVMVDOStats, 1);
+    get_stat_val64_default (full_stats, "block_size", &stats->block_size, -1);
+    get_stat_val64_default (full_stats, "logical_block_size", &stats->logical_block_size, -1);
+    get_stat_val64_default (full_stats, "physical_blocks", &stats->physical_blocks, -1);
+    get_stat_val64_default (full_stats, "data_blocks_used", &stats->data_blocks_used, -1);
+    get_stat_val64_default (full_stats, "overhead_blocks_used", &stats->overhead_blocks_used, -1);
+    get_stat_val64_default (full_stats, "logical_blocks_used", &stats->logical_blocks_used, -1);
+    get_stat_val64_default (full_stats, "usedPercent", &stats->used_percent, -1);
+    get_stat_val64_default (full_stats, "savingPercent", &stats->saving_percent, -1);
+    if (!get_stat_val_double (full_stats, "writeAmplificationRatio", &stats->write_amplification_ratio))
+        stats->write_amplification_ratio = -1;
+
+    g_hash_table_destroy (full_stats);
+
+    return stats;
+}

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -168,6 +168,21 @@ typedef struct BDLVMVDOPooldata {
 void bd_lvm_vdopooldata_free (BDLVMVDOPooldata *data);
 BDLVMVDOPooldata* bd_lvm_vdopooldata_copy (BDLVMVDOPooldata *data);
 
+typedef struct BDLVMVDOStats {
+    gint64 block_size;
+    gint64 logical_block_size;
+    gint64 physical_blocks;
+    gint64 data_blocks_used;
+    gint64 overhead_blocks_used;
+    gint64 logical_blocks_used;
+    gint64 used_percent;
+    gint64 saving_percent;
+    gdouble write_amplification_ratio;
+} BDLVMVDOStats;
+
+void bd_lvm_vdo_stats_free (BDLVMVDOStats *stats);
+BDLVMVDOStats* bd_lvm_vdo_stats_copy (BDLVMVDOStats *stats);
+
 typedef struct BDLVMCacheStats {
     guint64 block_size;
     guint64 cache_size;
@@ -303,5 +318,8 @@ const gchar* bd_lvm_get_vdo_index_state_str (BDLVMVDOIndexState state, GError **
 const gchar* bd_lvm_get_vdo_write_policy_str (BDLVMVDOWritePolicy policy, GError **error);
 
 BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_str, GError **error);
+
+BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_name, GError **error);
+GHashTable* bd_lvm_vdo_get_stats_full (const gchar *vg_name, const gchar *pool_name, GError **error);
 
 #endif /* BD_LVM */

--- a/src/plugins/vdo_stats.c
+++ b/src/plugins/vdo_stats.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2020  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vojtech Trefny <vtrefny@redhat.com>
+ */
+
+#include <glib.h>
+#include <parted/parted.h>
+#include <blockdev/utils.h>
+
+#include "vdo_stats.h"
+
+#define VDO_SYS_PATH "/sys/kvdo"
+
+
+gboolean __attribute__ ((visibility ("hidden")))
+get_stat_val64 (GHashTable *stats, const gchar *key, gint64 *val) {
+    const gchar *s;
+    gchar *endptr = NULL;
+
+    s = g_hash_table_lookup (stats, key);
+    if (s == NULL)
+        return FALSE;
+
+    *val = g_ascii_strtoll (s, &endptr, 0);
+    if (endptr == NULL || *endptr != '\0')
+        return FALSE;
+
+    return TRUE;
+}
+
+gboolean __attribute__ ((visibility ("hidden")))
+get_stat_val64_default (GHashTable *stats, const gchar *key, gint64 *val, gint64 def) {
+    if (!get_stat_val64 (stats, key, val))
+        *val = def;
+    return TRUE;
+}
+
+gboolean __attribute__ ((visibility ("hidden")))
+get_stat_val_double (GHashTable *stats, const gchar *key, gdouble *val) {
+    const gchar *s;
+    gchar *endptr = NULL;
+
+    s = g_hash_table_lookup (stats, key);
+    if (s == NULL)
+        return FALSE;
+
+    *val = g_ascii_strtod (s, &endptr);
+    if (endptr == NULL || *endptr != '\0')
+        return FALSE;
+
+    return TRUE;
+}
+
+static void add_write_ampl_r_stats (GHashTable *stats) {
+    gint64 bios_meta_write, bios_out_write, bios_in_write;
+
+    if (! get_stat_val64 (stats, "bios_meta_write", &bios_meta_write) ||
+        ! get_stat_val64 (stats, "bios_out_write", &bios_out_write) ||
+        ! get_stat_val64 (stats, "bios_in_write", &bios_in_write))
+        return;
+
+    if (bios_in_write <= 0)
+        g_hash_table_replace (stats, g_strdup ("writeAmplificationRatio"), g_strdup ("0.00"));
+    else
+        g_hash_table_replace (stats,
+                              g_strdup ("writeAmplificationRatio"),
+                              g_strdup_printf ("%.2f", (gfloat) (bios_meta_write + bios_out_write) / (gfloat) bios_in_write));
+}
+
+static void add_block_stats (GHashTable *stats) {
+    gint64 physical_blocks, block_size, data_blocks_used, overhead_blocks_used, logical_blocks_used;
+    gint64 savings;
+
+    if (! get_stat_val64 (stats, "physical_blocks", &physical_blocks) ||
+        ! get_stat_val64 (stats, "block_size", &block_size) ||
+        ! get_stat_val64 (stats, "data_blocks_used", &data_blocks_used) ||
+        ! get_stat_val64 (stats, "overhead_blocks_used", &overhead_blocks_used) ||
+        ! get_stat_val64 (stats, "logical_blocks_used", &logical_blocks_used))
+        return;
+
+    g_hash_table_replace (stats, g_strdup ("oneKBlocks"), g_strdup_printf ("%"G_GINT64_FORMAT, physical_blocks * block_size / 1024));
+    g_hash_table_replace (stats, g_strdup ("oneKBlocksUsed"), g_strdup_printf ("%"G_GINT64_FORMAT, (data_blocks_used + overhead_blocks_used) * block_size / 1024));
+    g_hash_table_replace (stats, g_strdup ("oneKBlocksAvailable"), g_strdup_printf ("%"G_GINT64_FORMAT, (physical_blocks - data_blocks_used - overhead_blocks_used) * block_size / 1024));
+    g_hash_table_replace (stats, g_strdup ("usedPercent"), g_strdup_printf ("%.0f", 100.0 * (gfloat) (data_blocks_used + overhead_blocks_used) / (gfloat) physical_blocks + 0.5));
+    savings = (logical_blocks_used > 0) ? (gint64) (100.0 * (gfloat) (logical_blocks_used - data_blocks_used) / (gfloat) logical_blocks_used) : -1;
+    g_hash_table_replace (stats, g_strdup ("savings"), g_strdup_printf ("%"G_GINT64_FORMAT, savings));
+    if (savings >= 0)
+        g_hash_table_replace (stats, g_strdup ("savingPercent"), g_strdup_printf ("%"G_GINT64_FORMAT, savings));
+}
+
+static void add_journal_stats (GHashTable *stats) {
+    gint64 journal_entries_committed, journal_entries_started, journal_entries_written;
+    gint64 journal_blocks_committed, journal_blocks_started, journal_blocks_written;
+
+    if (! get_stat_val64 (stats, "journal_entries_committed", &journal_entries_committed) ||
+        ! get_stat_val64 (stats, "journal_entries_started", &journal_entries_started) ||
+        ! get_stat_val64 (stats, "journal_entries_written", &journal_entries_written) ||
+        ! get_stat_val64 (stats, "journal_blocks_committed", &journal_blocks_committed) ||
+        ! get_stat_val64 (stats, "journal_blocks_started", &journal_blocks_started) ||
+        ! get_stat_val64 (stats, "journal_blocks_written", &journal_blocks_written))
+        return;
+
+    g_hash_table_replace (stats, g_strdup ("journal_entries_batching"), g_strdup_printf ("%"G_GINT64_FORMAT, journal_entries_started - journal_entries_written));
+    g_hash_table_replace (stats, g_strdup ("journal_entries_writing"), g_strdup_printf ("%"G_GINT64_FORMAT, journal_entries_written - journal_entries_committed));
+    g_hash_table_replace (stats, g_strdup ("journal_blocks_batching"), g_strdup_printf ("%"G_GINT64_FORMAT, journal_blocks_started - journal_blocks_written));
+    g_hash_table_replace (stats, g_strdup ("journal_blocks_writing"), g_strdup_printf ("%"G_GINT64_FORMAT, journal_blocks_written - journal_blocks_committed));
+}
+
+static void add_computed_stats (GHashTable *stats) {
+    const gchar *s;
+
+    s = g_hash_table_lookup (stats, "logical_block_size");
+    g_hash_table_replace (stats,
+                          g_strdup ("fiveTwelveByteEmulation"),
+                          g_strdup ((g_strcmp0 (s, "512") == 0) ? "true" : "false"));
+
+    add_write_ampl_r_stats (stats);
+    add_block_stats (stats);
+    add_journal_stats (stats);
+}
+
+GHashTable __attribute__ ((visibility ("hidden")))
+*vdo_get_stats_full (const gchar *name, GError **error) {
+    GHashTable *stats;
+    GDir *dir;
+    gchar *stats_dir;
+    const gchar *direntry;
+    gchar *s;
+    gchar *val;
+
+    /* TODO: does the `name` need to be escaped? */
+    stats_dir = g_build_path (G_DIR_SEPARATOR_S, VDO_SYS_PATH, name, "statistics", NULL);
+    dir = g_dir_open (stats_dir, 0, error);
+    if (dir == NULL) {
+        g_prefix_error (error, "Error reading statistics from %s: ", stats_dir);
+        g_free (stats_dir);
+        return NULL;
+    }
+
+    stats = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
+    while ((direntry = g_dir_read_name (dir))) {
+        s = g_build_filename (stats_dir, direntry, NULL);
+        if (! g_file_get_contents (s, &val, NULL, error)) {
+            g_prefix_error (error, "Error reading statistics from %s: ", s);
+            g_free (s);
+            g_hash_table_destroy (stats);
+            stats = NULL;
+            break;
+        }
+        g_hash_table_replace (stats, g_strdup (direntry), g_strdup (g_strstrip (val)));
+        g_free (val);
+        g_free (s);
+    }
+    g_dir_close (dir);
+    g_free (stats_dir);
+
+    if (stats != NULL)
+        add_computed_stats (stats);
+
+    return stats;
+}

--- a/src/plugins/vdo_stats.h
+++ b/src/plugins/vdo_stats.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vojtech Trefny <vtrefny@redhat.com>
+ */
+
+#include <glib.h>
+
+gboolean get_stat_val_double (GHashTable *stats, const gchar *key, gdouble *val);
+gboolean get_stat_val64 (GHashTable *stats, const gchar *key, gint64 *val);
+gboolean get_stat_val64_default (GHashTable *stats, const gchar *key, gint64 *val, gint64 def);
+
+GHashTable* vdo_get_stats_full (const gchar *name, GError **error);

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1598,3 +1598,28 @@ class LVMVDOTest(LVMTestCase):
     @tag_test(TestTags.SLOW)
     def test_vdo_pool_convert(self):
         self.skipTest("LVM VDO pool convert not implemented in LVM DBus API.")
+
+    @tag_test(TestTags.SLOW)
+    def test_stats(self):
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3)
+        self.assertTrue(succ)
+
+        vdo_info = BlockDev.lvm_vdo_info("testVDOVG", "vdoPool")
+        self.assertIsNotNone(vdo_info)
+        self.assertTrue(vdo_info.deduplication)
+
+        vdo_stats = BlockDev.lvm_vdo_get_stats("testVDOVG", "vdoPool")
+        self.assertEqual(vdo_info.saving_percent, vdo_stats.saving_percent)
+
+        # just sanity check
+        self.assertNotEqual(vdo_stats.used_percent, -1)
+        self.assertNotEqual(vdo_stats.block_size, -1)
+        self.assertNotEqual(vdo_stats.logical_block_size, -1)
+        self.assertNotEqual(vdo_stats.physical_blocks, -1)
+        self.assertNotEqual(vdo_stats.data_blocks_used, -1)
+        self.assertNotEqual(vdo_stats.overhead_blocks_used, -1)
+        self.assertNotEqual(vdo_stats.logical_blocks_used, -1)
+        self.assertNotEqual(vdo_stats.write_amplification_ratio, -1)
+
+        full_stats = BlockDev.lvm_vdo_get_stats_full("testVDOVG", "vdoPool")
+        self.assertIn("writeAmplificationRatio", full_stats.keys())

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1579,3 +1579,28 @@ class LVMVDOTest(LVMTestCase):
         self.assertTrue(vdo_info.compression)
         self.assertTrue(vdo_info.deduplication)
         self.assertEqual(BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy), "auto")
+
+    @tag_test(TestTags.SLOW)
+    def test_stats(self):
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3)
+        self.assertTrue(succ)
+
+        vdo_info = BlockDev.lvm_vdo_info("testVDOVG", "vdoPool")
+        self.assertIsNotNone(vdo_info)
+        self.assertTrue(vdo_info.deduplication)
+
+        vdo_stats = BlockDev.lvm_vdo_get_stats("testVDOVG", "vdoPool")
+        self.assertEqual(vdo_info.saving_percent, vdo_stats.saving_percent)
+
+        # just sanity check
+        self.assertNotEqual(vdo_stats.used_percent, -1)
+        self.assertNotEqual(vdo_stats.block_size, -1)
+        self.assertNotEqual(vdo_stats.logical_block_size, -1)
+        self.assertNotEqual(vdo_stats.physical_blocks, -1)
+        self.assertNotEqual(vdo_stats.data_blocks_used, -1)
+        self.assertNotEqual(vdo_stats.overhead_blocks_used, -1)
+        self.assertNotEqual(vdo_stats.logical_blocks_used, -1)
+        self.assertNotEqual(vdo_stats.write_amplification_ratio, -1)
+
+        full_stats = BlockDev.lvm_vdo_get_stats_full("testVDOVG", "vdoPool")
+        self.assertIn("writeAmplificationRatio", full_stats.keys())


### PR DESCRIPTION
We need to read the stats from `/sys/kvdo`. Code is shared with the original vdo plugin.