### PR TITLE
Manually remove symlinks not removed by udev in tests

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -5,6 +5,7 @@ import math
 import overrides_hack
 import six
 import re
+import shutil
 import subprocess
 from distutils.version import LooseVersion
 from itertools import chain
@@ -1200,6 +1201,10 @@ class LvmPVVGLVcachePoolTestCase(LvmPVVGLVTestCase):
             BlockDev.lvm_lvremove("testVG", "testCache", True, None)
         except:
             pass
+
+        # lets help udev with removing stale symlinks
+        if not BlockDev.lvm_lvs("testVG") and os.path.exists("/dev/testVG/testCache_meta"):
+            shutil.rmtree("/dev/testVG", ignore_errors=True)
 
         LvmPVVGLVTestCase._clean_up(self)
 

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -5,6 +5,7 @@ import math
 import overrides_hack
 import six
 import re
+import shutil
 import subprocess
 from distutils.version import LooseVersion
 
@@ -1120,6 +1121,10 @@ class LvmPVVGLVcachePoolTestCase(LvmPVVGLVTestCase):
             BlockDev.lvm_lvremove("testVG", "testCache", True, None)
         except:
             pass
+
+        # lets help udev with removing stale symlinks
+        if not BlockDev.lvm_lvs("testVG") and os.path.exists("/dev/testVG/testCache_meta"):
+            shutil.rmtree("/dev/testVG", ignore_errors=True)
 
         LvmPVVGLVTestCase._clean_up(self)
 


### PR DESCRIPTION
The metadata LV symlink is sometimes not removed after removing
a cache pool we created for tests. This is a huge problem for our
CI because other LVM tests will immediately fail when trying to
create the testVG volume group.
The bug was reported to LVM as rhbz#1800475