### PR TITLE
Do not open devices as read-write for read-only fs operations

### DIFF
--- a/src/plugins/fs/common.c
+++ b/src/plugins/fs/common.c
@@ -243,7 +243,7 @@ get_uuid_label (const gchar *device, gchar **uuid, gchar **label, GError **error
         return FALSE;
     }
 
-    fd = open (device, O_RDWR|O_CLOEXEC);
+    fd = open (device, O_RDONLY|O_CLOEXEC);
     if (fd == -1) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
                      "Failed to create a probe for the device '%s'", device);

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -271,7 +271,7 @@ gchar* bd_fs_get_fstype (const gchar *device,  GError **error) {
         return FALSE;
     }
 
-    fd = open (device, O_RDWR|O_CLOEXEC);
+    fd = open (device, O_RDONLY|O_CLOEXEC);
     if (fd == -1) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
                      "Failed to open the device '%s'", device);


### PR DESCRIPTION
We don't need write support for operations like getting uuid or
label and closing the device opened as rw also emits udev change
event.