### PR TITLE
Use all CPUs avaiable on host for the Vagrant VMs

### DIFF
--- a/misc/Vagrantfile
+++ b/misc/Vagrantfile
@@ -10,6 +10,17 @@
 # use a Fedora 29 based machine, etc.
 #
 
+def os_cpu_cores
+  case RbConfig::CONFIG['host_os']
+  when /darwin/
+    Integer(`sysctl -n hw.ncpu`)
+  when /linux/
+    Integer(`getconf _NPROCESSORS_ONLN`)
+  else
+    raise StandardError, "Unsupported platform"
+  end
+end
+
 Vagrant.configure("2") do |config|
   # common configuration
 
@@ -19,7 +30,7 @@ Vagrant.configure("2") do |config|
   # CHECK THAT THE BELOW OPTIONS ARE OKAY FOR YOUR HW
   config.vm.provider :libvirt do |v|
     v.memory = "1024"
-    v.cpus = 4
+    v.cpus = os_cpu_cores
     v.volume_cache = :unsafe
   end
 


### PR DESCRIPTION
Makes the builds in those VMs faster.