### PR TITLE
Do not remove all "flags" in bd_part_set_part_flags on GPT

### DIFF
--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -2264,7 +2264,7 @@ gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 f
         return FALSE;
     }
 
-    /* first unset all the flags */
+    /* first unset all the flags on MSDOS */
     if (table_type == BD_PART_TABLE_MSDOS) {
         if (!set_boot_flag (cxt, part_num, FALSE, error)) {
             close_context (cxt);
@@ -2275,13 +2275,6 @@ gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 f
 
         if (!set_part_type (cxt, part_num, DEFAULT_PART_ID, BD_PART_TABLE_MSDOS, error)) {
             g_prefix_error (error, "Failed to reset partition ID on partition '%s': ", part);
-            bd_utils_report_finished (progress_id, (*error)->message);
-            close_context (cxt);
-            return FALSE;
-        }
-    } else if (table_type == BD_PART_TABLE_GPT) {
-        if (!set_part_type (cxt, part_num, DEFAULT_PART_GUID, BD_PART_TABLE_GPT, error)) {
-            g_prefix_error (error, "Failed to reset partition type on partition '%s': ", part);
             bd_utils_report_finished (progress_id, (*error)->message);
             close_context (cxt);
             return FALSE;

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1486,6 +1486,13 @@ class PartSetGptFlagsCase(PartTestCase):
         self.assertTrue(ps.flags & BlockDev.PartFlag.LEGACY_BOOT)
         self.assertEqual(ps.type_guid, esp_guid)
 
+        # same but set_part_flags
+        succ = BlockDev.part_set_part_flags (self.loop_dev, ps.path, BlockDev.PartFlag.LEGACY_BOOT)
+        self.assertTrue(succ)
+        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        self.assertTrue(ps.flags & BlockDev.PartFlag.LEGACY_BOOT)
+        self.assertEqual(ps.type_guid, esp_guid)
+
 class PartNoDevCase(PartTestCase):
 
     def setUp(self):


### PR DESCRIPTION
We want to remove all preexisting flags in this function, but only
"real" flags for give partition type, we don't want to remove or
reset GUIDs on GPT.

This is the good old parted flags vs. real flags. Some of flags
that parted uses are in fact GUIDs on GPT and we don't want to
touch these, only the real GPT flags which is already covered by
only setting requested flags when calling "set_gpt_flags".

This is expected functionality consistent with the previous parted
based implementation, see:

https://github.com/storaged-project/udisks/issues/418
https://github.com/storaged-project/libblockdev/pull/306