### PR TITLE
exec: Disable encoding when reading data from stdout/stderr

### DIFF
--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -347,6 +347,10 @@ static gboolean _utils_exec_and_report_progress (const gchar **argv, const BDExt
     out_pipe = g_io_channel_unix_new (out_fd);
     err_pipe = g_io_channel_unix_new (err_fd);
 
+    /* set encoding to NULL so we can read binary */
+    g_io_channel_set_encoding (out_pipe, NULL, NULL);
+    g_io_channel_set_encoding (err_pipe, NULL, NULL);
+
     if (input) {
         in_pipe = g_io_channel_unix_new (in_fd);
         io_status = g_io_channel_write_chars (in_pipe,


### PR DESCRIPTION
Default encoding is UTF-8 and this is more strictly enforced in
newest GLib and things like nul bytes are not longer considered
valid.

See also https://github.com/storaged-project/udisks/pull/729 and
https://gitlab.gnome.org/GNOME/glib/merge_requests/967