### PR TITLE
Fix checking for tech modes in the filesystem plugin

### DIFF
--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -104,6 +104,25 @@ gboolean bd_fs_check_deps (void) {
         bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
         g_clear_error (&error);
     }
+    ret = ret && bd_fs_f2fs_is_tech_avail (BD_FS_TECH_F2FS,
+                                           BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                           BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                           BD_FS_TECH_MODE_QUERY | BD_FS_TECH_MODE_RESIZE,
+                                           &error);
+    if (!ret && error) {
+        bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
+        g_clear_error (&error);
+    }
+    ret = ret && bd_fs_reiserfs_is_tech_avail (BD_FS_TECH_REISERFS,
+                                               BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                               BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                               BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                               BD_FS_TECH_MODE_RESIZE | BD_FS_TECH_MODE_SET_UUID,
+                                               &error);
+    if (!ret && error) {
+        bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
+        g_clear_error (&error);
+    }
     return ret;
 }
 

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -63,23 +63,43 @@ gboolean bd_fs_check_deps (void) {
     GError *error = NULL;
 
     for (i = BD_FS_TECH_EXT2; i <= BD_FS_TECH_EXT4; i++) {
-        ret = ret && bd_fs_ext_is_tech_avail (i, 0xffffffff, &error);
+        ret = ret && bd_fs_ext_is_tech_avail (i,
+                                              BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                              BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                              BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                              BD_FS_TECH_MODE_RESIZE | BD_FS_TECH_MODE_SET_UUID,
+                                              &error);
         if (!ret && error) {
             bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
             g_clear_error (&error);
         }
     }
-    ret = ret && bd_fs_xfs_is_tech_avail (BD_FS_TECH_XFS, 0xffffffff, &error);
+    ret = ret && bd_fs_xfs_is_tech_avail (BD_FS_TECH_XFS,
+                                          BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                          BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                          BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                          BD_FS_TECH_MODE_RESIZE | BD_FS_TECH_MODE_SET_UUID,
+                                          &error);
     if (!ret && error) {
         bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
         g_clear_error (&error);
     }
-    ret = ret && bd_fs_vfat_is_tech_avail (BD_FS_TECH_VFAT, 0xffffffff, &error);
+    ret = ret && bd_fs_vfat_is_tech_avail (BD_FS_TECH_VFAT,
+                                           BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                           BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                           BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                           BD_FS_TECH_MODE_RESIZE,
+                                           &error);
     if (!ret && error) {
         bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
         g_clear_error (&error);
     }
-    ret = ret && bd_fs_ntfs_is_tech_avail (BD_FS_TECH_NTFS, 0xffffffff, &error);
+    ret = ret && bd_fs_ntfs_is_tech_avail (BD_FS_TECH_NTFS,
+                                           BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                           BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                           BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                           BD_FS_TECH_MODE_RESIZE | BD_FS_TECH_MODE_SET_UUID,
+                                           &error);
     if (!ret && error) {
         bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
         g_clear_error (&error);

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -119,6 +119,12 @@ gboolean bd_fs_f2fs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **
         return FALSE;
     }
 
+    if (mode & BD_FS_TECH_MODE_SET_UUID) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "F2FS doesn't support setting UUID for an existing device.");
+        return FALSE;
+    }
+
     if (mode & BD_FS_TECH_MODE_CHECK) {
         if (!can_check_f2fs_version (deps[DEPS_CHECKF2FS], error))
             return FALSE;

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -78,6 +78,13 @@ gboolean __attribute__ ((visibility ("hidden")))
 bd_fs_vfat_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
+
+    if (mode & BD_FS_TECH_MODE_SET_UUID) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "FAT doesn't support setting UUID for an existing device.");
+        return FALSE;
+    }
+
     for (i = 0; i <= BD_FS_MODE_LAST; i++)
         if (mode & (1 << i))
             required |= fs_mode_util[i];


### PR DESCRIPTION
Fixes: #515 

There are no tests for this because the `*_check_deps` functions are not in the Python API, I don't know if this is intentional. Should I add these these to the API files so I can test this or should I try to find a different way? @vpodzime 