### PR TITLE
lvm-dbus: Do not activate LVs during pvscan --cache

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1585,9 +1585,8 @@ gboolean bd_lvm_pvscan (const gchar *device, gboolean update_cache, const BDExtr
     GVariant *device_var = NULL;
 
     g_variant_builder_init (&builder, G_VARIANT_TYPE_TUPLE);
-    /* activate LVs if updating the cache, update the cache and specify the
-       device (if any) */
-    g_variant_builder_add_value (&builder, g_variant_new_boolean (update_cache));
+    /* update the cache and specify the device (if any) */
+    g_variant_builder_add_value (&builder, g_variant_new_boolean (FALSE));
     g_variant_builder_add_value (&builder, g_variant_new_boolean (update_cache));
     if (update_cache && device) {
         device_var = g_variant_new ("s", device);


### PR DESCRIPTION
We do not use --activate -ay in the cli plugin and the docstring
doesn't mention the auto activation, so we probably shouldn't do
this in the DBus plugin.

----

I don't have a strong opinion about the auto activation, I just want the DBus and CLI plugins to behave the same way, so if you think we should do the activation, I can change the CLI plugin instead.
The best solution would be to add new argument to the function, but that would be an API break, so maybe for 3.0?