### PR TITLE
tests: Skip LVM VDO tests if kvdo module cannot be loaded

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1489,6 +1489,11 @@ class LVMVDOTest(LVMTestCase):
         if not BlockDev.utils_have_kernel_module("kvdo"):
             raise unittest.SkipTest("VDO kernel module not available, skipping.")
 
+        try:
+            BlockDev.utils_load_kernel_module("kvdo")
+        except GLib.GError:
+            raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
+
         lvm_version = cls._get_lvm_version()
         if lvm_version < LooseVersion("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1411,6 +1411,11 @@ class LVMVDOTest(LVMTestCase):
         if not BlockDev.utils_have_kernel_module("kvdo"):
             raise unittest.SkipTest("VDO kernel module not available, skipping.")
 
+        try:
+            BlockDev.utils_load_kernel_module("kvdo")
+        except GLib.GError:
+            raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
+
         lvm_version = cls._get_lvm_version()
         if lvm_version < LooseVersion("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")

--- a/tests/vdo_test.py
+++ b/tests/vdo_test.py
@@ -23,6 +23,11 @@ class VDOTestCase(unittest.TestCase):
         if not BlockDev.utils_have_kernel_module("kvdo"):
             raise unittest.SkipTest("VDO kernel module not available, skipping.")
 
+        try:
+            BlockDev.utils_load_kernel_module("kvdo")
+        except GLib.GError:
+            raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
+
         if not find_executable("vdo"):
             raise unittest.SkipTest("vdo executable not foundin $PATH, skipping.")
 


### PR DESCRIPTION
Just checking for the kvdo module is not enough because often
the kvdo module can't be loaded after kernel update on unstable
distributions.