### PR TITLE
lvm-dbus: LVM VDO fixes

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -49,6 +49,7 @@ static gchar *global_config_str = NULL;
 #define HIDDEN_LV_OBJ_PREFIX LVM_OBJ_PREFIX"/HiddenLv"
 #define THIN_POOL_OBJ_PREFIX LVM_OBJ_PREFIX"/ThinPool"
 #define CACHE_POOL_OBJ_PREFIX LVM_OBJ_PREFIX"/CachePool"
+#define VDO_POOL_OBJ_PREFIX LVM_OBJ_PREFIX"/VdoPool"
 #define PV_INTF LVM_BUS_NAME".Pv"
 #define VG_INTF LVM_BUS_NAME".Vg"
 #define VG_VDO_INTF LVM_BUS_NAME".VgVdo"
@@ -2396,6 +2397,19 @@ BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error) {
     }
 
     lvs = get_existing_objects (CACHE_POOL_OBJ_PREFIX, error);
+    if (!lvs && (*error)) {
+        /* error is already populated */
+        g_slist_free_full (matched_lvs, g_free);
+        return NULL;
+    }
+    success = filter_lvs_by_vg (lvs, vg_name, &matched_lvs, &n_lvs, error);
+    g_free (lvs);
+    if (!success) {
+        g_slist_free_full (matched_lvs, g_free);
+        return NULL;
+    }
+
+    lvs = get_existing_objects (VDO_POOL_OBJ_PREFIX, error);
     if (!lvs && (*error)) {
         /* error is already populated */
         g_slist_free_full (matched_lvs, g_free);

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1491,8 +1491,9 @@ class LVMVDOTest(LVMTestCase):
 
         try:
             BlockDev.utils_load_kernel_module("kvdo")
-        except GLib.GError:
-            raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
+        except GLib.GError as e:
+            if "File exists" not in e.message:
+                raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         lvm_version = cls._get_lvm_version()
         if lvm_version < LooseVersion("2.3.07"):

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1551,6 +1551,10 @@ class LVMVDOTest(LVMTestCase):
         self.assertGreater(vdo_info.used_size, 0)
         self.assertTrue(0 <= vdo_info.saving_percent <= 100)
 
+        lvs = BlockDev.lvm_lvs("testVDOVG")
+        self.assertIn("vdoPool", [l.lv_name for l in lvs])
+        self.assertIn("vdoLV", [l.lv_name for l in lvs])
+
         mode_str = BlockDev.lvm_get_vdo_operating_mode_str(vdo_info.operating_mode)
         self.assertEqual(mode_str, "normal")
 

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1541,6 +1541,11 @@ class LVMVDOTest(LVMTestCase):
         self.assertEqual(lv_info.segtype, "vdo")
         self.assertEqual(lv_info.pool_lv, "vdoPool")
 
+        pool_info = BlockDev.lvm_lvinfo("testVDOVG", "vdoPool")
+        self.assertEqual(pool_info.segtype, "vdo-pool")
+        self.assertEqual(pool_info.data_lv, "vdoPool_vdata")
+        self.assertGreater(pool_info.data_percent, 0)
+
         vdo_info = BlockDev.lvm_vdo_info("testVDOVG", "vdoPool")
         self.assertIsNotNone(vdo_info)
         self.assertEqual(vdo_info.operating_mode, BlockDev.LVMVDOOperatingMode.NORMAL)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1473,6 +1473,10 @@ class LVMVDOTest(LVMTestCase):
         self.assertGreater(vdo_info.used_size, 0)
         self.assertTrue(0 <= vdo_info.saving_percent <= 100)
 
+        lvs = BlockDev.lvm_lvs("testVDOVG")
+        self.assertIn("vdoPool", [l.lv_name for l in lvs])
+        self.assertIn("vdoLV", [l.lv_name for l in lvs])
+
         mode_str = BlockDev.lvm_get_vdo_operating_mode_str(vdo_info.operating_mode)
         self.assertEqual(mode_str, "normal")
 

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1463,6 +1463,11 @@ class LVMVDOTest(LVMTestCase):
         self.assertEqual(lv_info.segtype, "vdo")
         self.assertEqual(lv_info.pool_lv, "vdoPool")
 
+        pool_info = BlockDev.lvm_lvinfo("testVDOVG", "vdoPool")
+        self.assertEqual(pool_info.segtype, "vdo-pool")
+        self.assertEqual(pool_info.data_lv, "vdoPool_vdata")
+        self.assertGreater(pool_info.data_percent, 0)
+
         vdo_info = BlockDev.lvm_vdo_info("testVDOVG", "vdoPool")
         self.assertIsNotNone(vdo_info)
         self.assertEqual(vdo_info.operating_mode, BlockDev.LVMVDOOperatingMode.NORMAL)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1413,8 +1413,9 @@ class LVMVDOTest(LVMTestCase):
 
         try:
             BlockDev.utils_load_kernel_module("kvdo")
-        except GLib.GError:
-            raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
+        except GLib.GError as e:
+            if "File exists" not in e.message:
+                raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         lvm_version = cls._get_lvm_version()
         if lvm_version < LooseVersion("2.3.07"):

--- a/tests/vdo_test.py
+++ b/tests/vdo_test.py
@@ -25,8 +25,9 @@ class VDOTestCase(unittest.TestCase):
 
         try:
             BlockDev.utils_load_kernel_module("kvdo")
-        except GLib.GError:
-            raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
+        except GLib.GError as e:
+            if "File exists" not in e.message:
+                raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         if not find_executable("vdo"):
             raise unittest.SkipTest("vdo executable not foundin $PATH, skipping.")


### PR DESCRIPTION
I found few issues in the LVM DBus plugin implementation of the LVM VDO support. Mostly functionality not used by UDisks. Hopefully there's not more.