### PR TITLE
lvm: Fix getting cache stats for cache thinpools

### DIFF
--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -2415,6 +2415,8 @@ BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_l
     gchar *type = NULL;
     gchar *params = NULL;
     BDLVMCacheStats *ret = NULL;
+    BDLVMLVdata *lvdata = NULL;
+    gchar *data_lv_name = NULL;
 
     if (geteuid () != 0) {
         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_NOT_ROOT,
@@ -2422,10 +2424,27 @@ BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_l
         return NULL;
     }
 
-    pool = dm_pool_create("bd-pool", 20);
+    lvdata = bd_lvm_lvinfo (vg_name, cached_lv, error);
+    if (!lvdata)
+        return NULL;
 
-    /* translate the VG+LV name into the DM map name */
-    map_name = dm_build_dm_name (pool, vg_name, cached_lv, NULL);
+    pool = dm_pool_create ("bd-pool", 20);
+
+    if (g_strcmp0 (lvdata->segtype, "thin-pool") == 0) {
+        data_lv_name = bd_lvm_data_lv_name (vg_name, cached_lv, error);
+        if (!data_lv_name) {
+            dm_pool_destroy (pool);
+            bd_lvm_lvdata_free (lvdata);
+            return NULL;
+        }
+
+        map_name = dm_build_dm_name (pool, vg_name, data_lv_name, NULL);
+        g_free (data_lv_name);
+    } else
+        /* translate the VG+LV name into the DM map name */
+        map_name = dm_build_dm_name (pool, vg_name, cached_lv, NULL);
+
+    bd_lvm_lvdata_free (lvdata);
 
     task = dm_task_create (DM_DEVICE_STATUS);
     if (!task) {

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1381,6 +1381,43 @@ class LvmPVVGcachedLVstatsTestCase(LvmPVVGLVTestCase):
         self.assertEqual(stats.md_size, 8 * 1024**2)
         self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
 
+class LvmPVVGcachedThpoolstatsTestCase(LvmPVVGLVTestCase):
+    @tag_test(TestTags.SLOW)
+    def test_cache_get_stats(self):
+        """Verify that it is possible to get stats for a cached thinpool"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_cache_create_pool("testVG", "testCache", 512 * 1024**2, 0, BlockDev.LVMCacheMode.WRITETHROUGH, 0, [self.loop_dev2])
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_thpoolcreate("testVG", "testPool", 512 * 1024**2, 4 * 1024**2, 512 * 1024, "thin-performance", None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_cache_attach("testVG", "testPool", "testCache", None)
+        self.assertTrue(succ)
+
+        # just ask for the pool itself even if it's not technically cached
+        stats = BlockDev.lvm_cache_stats("testVG", "testPool")
+        self.assertTrue(stats)
+        self.assertEqual(stats.cache_size, 512 * 1024**2)
+        self.assertEqual(stats.md_size, 8 * 1024**2)
+        self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
+
+        # same should work when explicitly asking for the data LV
+        stats = BlockDev.lvm_cache_stats("testVG", "testPool_tdata")
+        self.assertTrue(stats)
+        self.assertEqual(stats.cache_size, 512 * 1024**2)
+        self.assertEqual(stats.md_size, 8 * 1024**2)
+        self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
+
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LVMTechTest(LVMTestCase):
 

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1296,6 +1296,43 @@ class LvmPVVGcachedLVstatsTestCase(LvmPVVGLVTestCase):
         self.assertEqual(stats.md_size, 8 * 1024**2)
         self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
 
+class LvmPVVGcachedThpoolstatsTestCase(LvmPVVGLVTestCase):
+    @tag_test(TestTags.SLOW)
+    def test_cache_get_stats(self):
+        """Verify that it is possible to get stats for a cached thinpool"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_cache_create_pool("testVG", "testCache", 512 * 1024**2, 0, BlockDev.LVMCacheMode.WRITETHROUGH, 0, [self.loop_dev2])
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_thpoolcreate("testVG", "testPool", 512 * 1024**2, 4 * 1024**2, 512 * 1024, "thin-performance", None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_cache_attach("testVG", "testPool", "testCache", None)
+        self.assertTrue(succ)
+
+        # just ask for the pool itself even if it's not technically cached
+        stats = BlockDev.lvm_cache_stats("testVG", "testPool")
+        self.assertTrue(stats)
+        self.assertEqual(stats.cache_size, 512 * 1024**2)
+        self.assertEqual(stats.md_size, 8 * 1024**2)
+        self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
+
+        # same should work when explicitly asking for the data LV
+        stats = BlockDev.lvm_cache_stats("testVG", "testPool_tdata")
+        self.assertTrue(stats)
+        self.assertEqual(stats.cache_size, 512 * 1024**2)
+        self.assertEqual(stats.md_size, 8 * 1024**2)
+        self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
+
 class LvmVGExportedTestCase(LvmPVVGLVTestCase):
 
     def _clean_up(self):


### PR DESCRIPTION
We currently fail to gather LVM cache stats for cached thinpools
because the pool LV itself is actually not cached, only the
internal data LV is. This change gets the data LV and cache
information for it if user specifies the "public" thinpool LV.

Resolves: rhbz#1832838

-----

I'n not 100 % sure if this is the best approach, we could simply tell our users it's their responsibility to always give us the data LV, but I think it's better to hide these internal LVM details for them where possible and there's no harm in trying to be a little bit smarter in libblockdev.