### PR TITLE
configure.ac: Avoid bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AC_ARG_WITH([python3],
 AC_SUBST(WITH_PYTHON3, 0)
 if test "x$with_python3" != "xno"; then
     AC_PATH_PROG([python3], [python3], [no])
-    AS_IF([test "x$python3" == "xno"],
+    AS_IF([test "x$python3" = "xno"],
     [if test "x$with_python3" = "xyes"; then
       LIBBLOCKDEV_SOFT_FAILURE([Python3 support requested, but python3 is not available])
       fi],
@@ -77,7 +77,7 @@ AC_ARG_WITH([gtk-doc],
 AC_SUBST(WITH_GTK_DOC, 0)
 if test "x$with_gtk_doc" != "xno"; then
     AC_PATH_PROG([gtkdoc_scan], [gtkdoc-scan], [no])
-    AS_IF([test "x$gtkdoc_scan" == "xno"],
+    AS_IF([test "x$gtkdoc_scan" = "xno"],
     [if test "x$with_gtk_doc" = "xyes"; then
       LIBBLOCKDEV_SOFT_FAILURE([Building documentation with gtk-doc requested, but not available])
       fi],


### PR DESCRIPTION
or else we get unpredictable results with shells != /bin/bash like:

```
checking for gobject-introspection... no (disabled, use --enable-introspection to enable)
./configure: 13672: test: xno: unexpected operator
checking for python3... /var/tmp/portage/sys-libs/libblockdev-2.23-r1/temp/python3.8/bin/python3
./configure: 13838: test: x/var/tmp/portage/sys-libs/libblockdev-2.23-r1/temp/python3.8/bin/python3: unexpected operator
```

Reported-by: Matt Whitlock <gentoo@mattwhitlock.name>
Gentoo-bug: https://bugs.gentoo.org/719442
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>