### PR TITLE
Do not check VDO saving percent value in LVM DBus tests

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1669,9 +1669,9 @@ class LVMVDOTest(LVMTestCase):
         self.assertTrue(vdo_info.deduplication)
 
         vdo_stats = BlockDev.lvm_vdo_get_stats("testVDOVG", "vdoPool")
-        self.assertEqual(vdo_info.saving_percent, vdo_stats.saving_percent)
 
         # just sanity check
+        self.assertNotEqual(vdo_stats.saving_percent, -1)
         self.assertNotEqual(vdo_stats.used_percent, -1)
         self.assertNotEqual(vdo_stats.block_size, -1)
         self.assertNotEqual(vdo_stats.logical_block_size, -1)


### PR DESCRIPTION
Unfortunately the value of the SavingPercent property on DBus is
never updated so we can't use it to check the value from VDO stats.