### PR TITLE
Fix typo in bd_nvdimm_namepace_get_supported_sector_sizes

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -658,6 +658,7 @@ bd_nvdimm_namespace_info
 bd_nvdimm_list_namespaces
 bd_nvdimm_namespace_reconfigure
 bd_nvdimm_namepace_get_supported_sector_sizes
+bd_nvdimm_namespace_get_supported_sector_sizes
 BDNVDIMMTech
 BDNVDIMMTechMode
 bd_nvdimm_is_tech_avail

--- a/src/lib/plugin_apis/nvdimm.api
+++ b/src/lib/plugin_apis/nvdimm.api
@@ -225,6 +225,17 @@ BDNVDIMMNamespaceInfo** bd_nvdimm_list_namespaces (const gchar *bus, const gchar
 gboolean bd_nvdimm_namespace_reconfigure (const gchar* namespace, BDNVDIMMNamespaceMode mode, gboolean force, const BDExtraArg **extra, GError** error);
 
 /**
+ * bd_nvdimm_namespace_get_supported_sector_sizes:
+ * @mode: namespace mode
+ * @error: (out): place to store error if any
+ *
+ * Returns: (transfer none) (array zero-terminated=1): list of supported sector sizes for @mode
+ *
+ * Tech category: %BD_NVDIMM_TECH_NAMESPACE-%BD_NVDIMM_TECH_MODE_QUERY
+ */
+const guint64 *bd_nvdimm_namespace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error);
+
+/**
  * bd_nvdimm_namepace_get_supported_sector_sizes:
  * @mode: namespace mode
  * @error: (out): place to store error if any
@@ -232,6 +243,8 @@ gboolean bd_nvdimm_namespace_reconfigure (const gchar* namespace, BDNVDIMMNamesp
  * Returns: (transfer none) (array zero-terminated=1): list of supported sector sizes for @mode
  *
  * Tech category: %BD_NVDIMM_TECH_NAMESPACE-%BD_NVDIMM_TECH_MODE_QUERY
+ *
+ * Deprecated: 2.25: Use %bd_nvdimm_namespace_get_supported_sector_sizes integration instead.
  */
 const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error);
 

--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -643,7 +643,7 @@ static guint64 pmem_sector_sizes[] = { 512, 4096, 0 };
 static guint64 io_sector_sizes[] = { 0 };
 
 /**
- * bd_nvdimm_namepace_get_supported_sector_sizes:
+ * bd_nvdimm_namespace_get_supported_sector_sizes:
  * @mode: namespace mode
  * @error: (out): place to store error if any
  *
@@ -651,7 +651,7 @@ static guint64 io_sector_sizes[] = { 0 };
  *
  * Tech category: %BD_NVDIMM_TECH_NAMESPACE-%BD_NVDIMM_TECH_MODE_QUERY
  */
-const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error) {
+const guint64 *bd_nvdimm_namespace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error) {
     switch (mode) {
         case BD_NVDIMM_NAMESPACE_MODE_RAW:
         case BD_NVDIMM_NAMESPACE_MODE_MEMORY:
@@ -670,4 +670,19 @@ const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceM
                          "Invalid/unknown mode specified.");
             return NULL;
     }
+}
+
+/**
+ * bd_nvdimm_namepace_get_supported_sector_sizes:
+ * @mode: namespace mode
+ * @error: (out): place to store error if any
+ *
+ * Returns: (transfer none) (array zero-terminated=1): list of supported sector sizes for @mode
+ *
+ * Tech category: %BD_NVDIMM_TECH_NAMESPACE-%BD_NVDIMM_TECH_MODE_QUERY
+ *
+ * Deprecated: 2.25: Use %bd_nvdimm_namespace_get_supported_sector_sizes integration instead.
+ */
+const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error) {
+    return bd_nvdimm_namespace_get_supported_sector_sizes (mode, error);
 }

--- a/src/plugins/nvdimm.h
+++ b/src/plugins/nvdimm.h
@@ -78,5 +78,6 @@ BDNVDIMMNamespaceInfo** bd_nvdimm_list_namespaces (const gchar *bus, const gchar
 gboolean bd_nvdimm_namespace_reconfigure (const gchar* namespace, BDNVDIMMNamespaceMode mode, gboolean force, const BDExtraArg **extra, GError** error);
 
 const guint64 *bd_nvdimm_namepace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error);
+const guint64 *bd_nvdimm_namespace_get_supported_sector_sizes (BDNVDIMMNamespaceMode mode, GError **error);
 
 #endif  /* BD_CRYPTO */

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -224,3 +224,12 @@ class NVDIMMNoDevTest(NVDIMMTestCase):
 
         sizes = BlockDev.nvdimm_namepace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.FSDAX)
         self.assertListEqual(sizes, [512, 4096])
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.nvdimm_namespace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.UNKNOWN)
+
+        sizes = BlockDev.nvdimm_namespace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.SECTOR)
+        self.assertListEqual(sizes, [512, 520, 528, 4096, 4104, 4160, 4224])
+
+        sizes = BlockDev.nvdimm_namespace_get_supported_sector_sizes(BlockDev.NVDIMMNamespaceMode.FSDAX)
+        self.assertListEqual(sizes, [512, 4096])


### PR DESCRIPTION
A candidate for API change in 3.0.

I blame @vpodzime for not catching this during the code review, definitely not my fault :grin: 