### PR TITLE
Bump version to be always ahead of 2.x-branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac for libblockdev
 
-AC_INIT([libblockdev], [2.23], [vpodzime@redhat.com])
+AC_INIT([libblockdev], [2.99], [vpodzime@redhat.com])
 
 # Disable building static libraries.
 # This needs to be set before initializing automake

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -124,7 +124,7 @@
 %define configure_opts %{?python2_copts} %{?python3_copts} %{?bcache_copts} %{?lvm_dbus_copts} %{?btrfs_copts} %{?crypto_copts} %{?dm_copts} %{?loop_copts} %{?lvm_copts} %{?lvm_dbus_copts} %{?mdraid_copts} %{?mpath_copts} %{?swap_copts} %{?kbd_copts} %{?part_copts} %{?fs_copts} %{?nvdimm_copts} %{?vdo_copts} %{?tools_copts} %{?gi_copts}
 
 Name:        libblockdev
-Version:     2.23
+Version:     2.99
 Release:     1%{?dist}
 Summary:     A library for low-level manipulation with block devices
 License:     LGPLv2+


### PR DESCRIPTION
I don't expect a new 2.x release before 3.0 but it's possible it will happen again so let's just bump master version to 2.99 to be always ahead for the daily builds.