### PR TITLE
Fix some more private symbols in the API

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -168,6 +168,8 @@ bd_utils_mute_prog_reporting_thread
 bd_utils_report_finished
 bd_utils_report_progress
 bd_utils_report_started
+bd_utils_get_next_task_id
+bd_utils_log_task_status
 bd_utils_log
 bd_utils_log_format
 bd_utils_log_stdout

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -109,7 +109,8 @@ static gboolean can_check_f2fs_version (UtilDep dep, GError **error) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_fs_f2fs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+gboolean __attribute__ ((visibility ("hidden")))
+bd_fs_f2fs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -72,7 +72,7 @@ typedef struct BDFSInfo {
     const gchar *uuid_util;
 } BDFSInfo;
 
-const BDFSInfo fs_info[] = {
+static const BDFSInfo fs_info[] = {
     {"xfs", "xfs_db", "xfs_repair", "xfs_growfs", BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW, "xfs_admin", "xfs_admin", "xfs_admin"},
     {"ext2", "e2fsck", "e2fsck", "resize2fs", BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK, "tune2fs", "dumpe2fs", "tune2fs"},
     {"ext3", "e2fsck", "e2fsck", "resize2fs", BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK, "tune2fs", "dumpe2fs", "tune2fs"},

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -69,10 +69,6 @@ static gchar *global_config_str = NULL;
 
 static GDBusConnection *bus = NULL;
 
-/* "friend" functions from the utils library */
-guint64 get_next_task_id (void);
-void log_task_status (guint64 task_id, const gchar *msg);
-
 /**
  * SECTION: lvm
  * @short_description: plugin for operations with LVM
@@ -623,10 +619,10 @@ static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gch
 
     params_str = g_variant_print (all_params, FALSE);
 
-    *task_id = get_next_task_id ();
+    *task_id = bd_utils_get_next_task_id ();
     log_msg = g_strdup_printf ("Calling the '%s.%s' method on the '%s' object with the following parameters: '%s'",
                                intf, method, obj, params_str);
-    log_task_status (*task_id, log_msg);
+    bd_utils_log_task_status (*task_id, log_msg);
     g_free (log_msg);
 
     /* now do the call with all the parameters */
@@ -662,15 +658,15 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
     gchar *error_msg = NULL;
 
     ret = call_lvm_method (obj, intf, method, params, extra_params, extra_args, &log_task_id, &prog_id, lock_config, error);
-    log_task_status (log_task_id, "Done.");
+    bd_utils_log_task_status (log_task_id, "Done.");
     if (!ret) {
         if (*error) {
             log_msg = g_strdup_printf ("Got error: %s", (*error)->message);
-            log_task_status (log_task_id, log_msg);
+            bd_utils_log_task_status (log_task_id, log_msg);
             bd_utils_report_finished (prog_id, log_msg);
             g_free (log_msg);
         } else {
-            log_task_status (log_task_id, "Got unknown error");
+            bd_utils_log_task_status (log_task_id, "Got unknown error");
             bd_utils_report_finished (prog_id, "Got unknown error");
         }
         return;
@@ -679,7 +675,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
         g_variant_get (ret, "((oo))", &obj_path, &task_path);
         if (g_strcmp0 (obj_path, "/") != 0) {
             log_msg = g_strdup_printf ("Got result: %s", obj_path);
-            log_task_status (log_task_id, log_msg);
+            bd_utils_log_task_status (log_task_id, log_msg);
             g_free (log_msg);
             /* got a valid result, just return */
             g_variant_unref (ret);
@@ -696,7 +692,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
         if (g_strcmp0 (task_path, "/") != 0) {
             g_variant_unref (ret);
         } else {
-            log_task_status (log_task_id, "No result, no job started");
+            bd_utils_log_task_status (log_task_id, "No result, no job started");
             g_free (task_path);
             bd_utils_report_finished (prog_id, "Completed");
             g_variant_unref (ret);
@@ -704,7 +700,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
         }
     } else {
         g_variant_unref (ret);
-        log_task_status (log_task_id, "Failed to parse the returned value!");
+        bd_utils_log_task_status (log_task_id, "Failed to parse the returned value!");
         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_PARSE,
                      "Failed to parse the returned value!");
         bd_utils_report_finished (prog_id, (*error)->message);
@@ -712,7 +708,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
     }
 
     log_msg = g_strdup_printf ("Waiting for job '%s' to finish", task_path);
-    log_task_status (log_task_id, log_msg);
+    bd_utils_log_task_status (log_task_id, log_msg);
     g_free (log_msg);
 
     ret = NULL;
@@ -737,13 +733,13 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
                 g_clear_error (error);
             }
             log_msg = g_strdup_printf ("Still waiting for job '%s' to finish", task_path);
-            log_task_status (log_task_id, log_msg);
+            bd_utils_log_task_status (log_task_id, log_msg);
             g_free (log_msg);
         }
 
     }
     log_msg = g_strdup_printf ("Job '%s' finished", task_path);
-    log_task_status (log_task_id, log_msg);
+    bd_utils_log_task_status (log_task_id, log_msg);
     g_free (log_msg);
 
     obj_path = NULL;
@@ -760,7 +756,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
             g_variant_unref (ret);
             if (g_strcmp0 (obj_path, "/") != 0) {
                 log_msg = g_strdup_printf ("Got result: %s", obj_path);
-                log_task_status (log_task_id, log_msg);
+                bd_utils_log_task_status (log_task_id, log_msg);
                 g_free (log_msg);
             } else {
                 ret = get_object_property (task_path, JOB_INTF, "GetError", error);
@@ -768,7 +764,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
                 if (error_code != 0) {
                     if (error_msg) {
                         log_msg = g_strdup_printf ("Got error: %s", error_msg);
-                        log_task_status (log_task_id, log_msg);
+                        bd_utils_log_task_status (log_task_id, log_msg);
                         bd_utils_report_finished (prog_id, log_msg);
                         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
                                      "Running '%s' method on the '%s' object failed: %s",
@@ -776,7 +772,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
                         g_free (log_msg);
                         g_free (error_msg);
                     } else {
-                        log_task_status (log_task_id, "Got unknown error");
+                        bd_utils_log_task_status (log_task_id, "Got unknown error");
                         bd_utils_report_finished (prog_id, "Got unknown error");
                         g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
                                      "Got unknown error when running '%s' method on the '%s' object.",
@@ -784,7 +780,7 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
                     }
 
                 } else
-                    log_task_status (log_task_id, "No result");
+                    bd_utils_log_task_status (log_task_id, "No result");
             }
             bd_utils_report_finished (prog_id, "Completed");
             g_free (obj_path);

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -52,9 +52,9 @@ GQuark bd_utils_exec_error_quark (void)
 }
 
 /**
- * get_next_task_id: (skip)
+ * bd_utils_get_next_task_id:
  */
-guint64 get_next_task_id (void) {
+guint64 bd_utils_get_next_task_id (void) {
     guint64 task_id = 0;
 
     g_mutex_lock (&id_counter_lock);
@@ -66,11 +66,11 @@ guint64 get_next_task_id (void) {
 }
 
 /**
- * log_task_status: (skip)
+ * bd_utils_log_task_status:
  * @task_id: ID of the task the status of which is being logged
  * @msg: log message
  */
-void log_task_status (guint64 task_id, const gchar *msg) {
+void bd_utils_log_task_status (guint64 task_id, const gchar *msg) {
     gchar *log_msg = NULL;
 
     log_msg = g_strdup_printf ("[%"G_GUINT64_FORMAT"] %s", task_id, msg);
@@ -88,7 +88,7 @@ static guint64 log_running (const gchar **argv) {
     gchar *str_argv = NULL;
     gchar *log_msg = NULL;
 
-    task_id = get_next_task_id ();
+    task_id = bd_utils_get_next_task_id ();
 
     str_argv = g_strjoinv (" ", (gchar **) argv);
     log_msg = g_strdup_printf ("Running [%"G_GUINT64_FORMAT"] %s ...", task_id, str_argv);

--- a/src/utils/exec.h
+++ b/src/utils/exec.h
@@ -59,6 +59,9 @@ guint64 bd_utils_report_started (const gchar *msg);
 void bd_utils_report_progress (guint64 task_id, guint64 completion, const gchar *msg);
 void bd_utils_report_finished (guint64 task_id, const gchar *msg);
 
+guint64 bd_utils_get_next_task_id (void);
+void bd_utils_log_task_status (guint64 task_id, const gchar *msg);
+
 gboolean bd_utils_echo_str_to_file (const gchar *str, const gchar *file_path, GError **error);
 
 #endif  /* BD_UTILS_EXEC */


### PR DESCRIPTION
Fixes: #366 

This should cover the last private symbols that are public, except for the part-err symbols which will be dealt with in the parted->libfdisk migration.