### PR TITLE
Add functions to check filesystem label validity

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -594,6 +594,7 @@ bd_fs_ext2_mkfs
 bd_fs_ext2_repair
 bd_fs_ext2_resize
 bd_fs_ext2_set_label
+bd_fs_ext2_check_label
 bd_fs_ext2_set_uuid
 bd_fs_ext2_wipe
 bd_fs_ext3_check
@@ -604,6 +605,7 @@ bd_fs_ext3_mkfs
 bd_fs_ext3_repair
 bd_fs_ext3_resize
 bd_fs_ext3_set_label
+bd_fs_ext3_check_label
 bd_fs_ext3_set_uuid
 bd_fs_ext3_wipe
 bd_fs_ext4_check
@@ -614,6 +616,7 @@ bd_fs_ext4_mkfs
 bd_fs_ext4_repair
 bd_fs_ext4_resize
 bd_fs_ext4_set_label
+bd_fs_ext4_check_label
 bd_fs_ext4_set_uuid
 bd_fs_ext4_wipe
 BDFSXfsInfo
@@ -625,6 +628,7 @@ bd_fs_xfs_mkfs
 bd_fs_xfs_repair
 bd_fs_xfs_resize
 bd_fs_xfs_set_label
+bd_fs_xfs_check_label
 bd_fs_xfs_set_uuid
 bd_fs_xfs_wipe
 BDFSVfatInfo
@@ -636,6 +640,7 @@ bd_fs_vfat_mkfs
 bd_fs_vfat_repair
 bd_fs_vfat_resize
 bd_fs_vfat_set_label
+bd_fs_vfat_check_label
 bd_fs_vfat_wipe
 BDFSTech
 BDFSTechMode
@@ -648,6 +653,7 @@ bd_fs_ntfs_mkfs
 bd_fs_ntfs_repair
 bd_fs_ntfs_resize
 bd_fs_ntfs_set_label
+bd_fs_ntfs_check_label
 bd_fs_ntfs_wipe
 bd_fs_ntfs_info_copy
 bd_fs_ntfs_info_free
@@ -671,6 +677,7 @@ bd_fs_reiserfs_mkfs
 bd_fs_reiserfs_repair
 bd_fs_reiserfs_resize
 bd_fs_reiserfs_set_label
+bd_fs_reiserfs_check_label
 bd_fs_reiserfs_set_uuid
 bd_fs_reiserfs_wipe
 </SECTION>

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1107,6 +1107,42 @@ gboolean bd_fs_ext3_set_label (const gchar *device, const gchar *label, GError *
 gboolean bd_fs_ext4_set_label (const gchar *device, const gchar *label, GError **error);
 
 /**
+ * bd_fs_ext2_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the ext2 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ext2_check_label (const gchar *label, GError **error);
+
+/**
+ * bd_fs_ext3_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error (if any)
+ *
+ * Returns: whether @label is a valid label for the ext3 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ext3_check_label (const gchar *label, GError **error);
+
+/**
+ * bd_fs_ext4_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error (if any)
+ *
+ * Returns: whether @label is a valid label for the ext4 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ext4_check_label (const gchar *label, GError **error);
+
+/**
  * bd_fs_ext2_set_uuid:
  * @device: the device the file system on which to set UUID for
  * @uuid: (allow-none): UUID to set %NULL to generate a new one
@@ -1300,6 +1336,18 @@ gboolean bd_fs_xfs_repair (const gchar *device, const BDExtraArg **extra, GError
 gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **error);
 
 /**
+ * bd_fs_xfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the xfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_xfs_check_label (const gchar *label, GError **error);
+
+/**
  * bd_fs_xfs_set_uuid:
  * @device: the device containing the file system to set uuid for
  * @uuid: (allow-none): UUID to set %NULL to generate a new one
@@ -1409,6 +1457,18 @@ gboolean bd_fs_vfat_repair (const gchar *device, const BDExtraArg **extra, GErro
 gboolean bd_fs_vfat_set_label (const gchar *device, const gchar *label, GError **error);
 
 /**
+ * bd_fs_vfat_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the vfat file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_vfat_check_label (const gchar *label, GError **error);
+
+/**
  * bd_fs_vfat_get_info:
  * @device: the device containing the file system to get info for
  * @error: (out): place to store error (if any)
@@ -1492,6 +1552,18 @@ gboolean bd_fs_ntfs_repair (const gchar *device, GError **error);
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_SET_LABEL
  */
 gboolean bd_fs_ntfs_set_label (const gchar *device, const gchar *label, GError **error);
+
+/**
+ * bd_fs_ntfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the ntfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ntfs_check_label (const gchar *label, GError **error);
 
 /**
  * bd_fs_ntfs_set_uuid:
@@ -1677,6 +1749,18 @@ gboolean bd_fs_reiserfs_repair (const gchar *device, const BDExtraArg **extra, G
  * Tech category: %BD_FS_TECH_REISERFS-%BD_FS_TECH_MODE_SET_LABEL
  */
 gboolean bd_fs_reiserfs_set_label (const gchar *device, const gchar *label, GError **error);
+
+/**
+ * bd_fs_reiserfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the reiserfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_reiserfs_check_label (const gchar *label, GError **error);
 
 /**
  * bd_fs_reiserfs_set_uuid:

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -298,10 +298,14 @@ GType bd_fs_vfat_info_get_type () {
 
 /**
  * BDFSNtfsInfo:
+ * @label: label of the filesystem
+ * @uuid: uuid of the filesystem
  * @size: size of the filesystem in bytes
  * @free_space: number of free space in the filesystem in bytes
  */
 typedef struct BDFSNtfsInfo {
+    gchar *label;
+    gchar *uuid;
     guint64 size;
     guint64 free_space;
 } BDFSNtfsInfo;
@@ -318,6 +322,8 @@ BDFSNtfsInfo* bd_fs_ntfs_info_copy (BDFSNtfsInfo *data) {
 
     BDFSNtfsInfo *ret = g_new0 (BDFSNtfsInfo, 1);
 
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
     ret->size = data->size;
     ret->free_space = data->free_space;
 
@@ -331,6 +337,11 @@ BDFSNtfsInfo* bd_fs_ntfs_info_copy (BDFSNtfsInfo *data) {
  * Frees @data.
  */
 void bd_fs_ntfs_info_free (BDFSNtfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
     g_free (data);
 }
 

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -16,6 +16,7 @@ typedef enum {
     BD_FS_ERROR_NOT_MOUNTED,
     BD_FS_ERROR_AUTH, // keep this entry last (XXX?)
     BD_FS_ERROR_TECH_UNAVAIL,
+    BD_FS_ERROR_LABEL_INVALID,
 } BDFsError;
 
 /* XXX: where the file systems start at the enum of technologies */

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -526,6 +526,54 @@ gboolean bd_fs_ext4_set_label (const gchar *device, const gchar *label, GError *
     return ext_set_label (device, label, error);
 }
 
+/**
+ * bd_fs_ext2_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the ext2 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ext2_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 16) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for ext filesystem must be at most 16 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_ext3_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error (if any)
+ *
+ * Returns: whether @label is a valid label for the ext3 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ext3_check_label (const gchar *label, GError **error) {
+    return bd_fs_ext2_check_label (label, error);
+}
+
+/**
+ * bd_fs_ext4_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error (if any)
+ *
+ * Returns: whether @label is a valid label for the ext4 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ext4_check_label (const gchar *label, GError **error) {
+    return bd_fs_ext2_check_label (label, error);
+}
+
 static gboolean ext_set_uuid (const gchar *device, const gchar *uuid, GError **error) {
     const gchar *args[5] = {"tune2fs", "-U", NULL, device, NULL};
 

--- a/src/plugins/fs/ext.h
+++ b/src/plugins/fs/ext.h
@@ -31,6 +31,7 @@ gboolean bd_fs_ext2_wipe (const gchar *device, GError **error);
 gboolean bd_fs_ext2_check (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext2_repair (const gchar *device, gboolean unsafe, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext2_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_ext2_check_label (const gchar *label, GError **error);
 gboolean bd_fs_ext2_set_uuid (const gchar *device, const gchar *uuid, GError **error);
 BDFSExt2Info* bd_fs_ext2_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ext2_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
@@ -41,6 +42,7 @@ gboolean bd_fs_ext3_check (const gchar *device, const BDExtraArg **extra, GError
 gboolean bd_fs_ext3_repair (const gchar *device, gboolean unsafe, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext3_set_uuid (const gchar *device, const gchar *uuid, GError **error);
 gboolean bd_fs_ext3_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_ext3_check_label (const gchar *label, GError **error);
 BDFSExt3Info* bd_fs_ext3_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ext3_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
 
@@ -50,6 +52,7 @@ gboolean bd_fs_ext4_check (const gchar *device, const BDExtraArg **extra, GError
 gboolean bd_fs_ext4_repair (const gchar *device, gboolean unsafe, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext4_set_label (const gchar *device, const gchar *label, GError **error);
 gboolean bd_fs_ext4_set_uuid (const gchar *device, const gchar *uuid, GError **error);
+gboolean bd_fs_ext4_check_label (const gchar *label, GError **error);
 BDFSExt4Info* bd_fs_ext4_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ext4_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
 

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -213,6 +213,26 @@ gboolean bd_fs_ntfs_set_label (const gchar *device, const gchar *label, GError *
 }
 
 /**
+ * bd_fs_ntfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the ntfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_ntfs_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 128) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for NTFS filesystem must be at most 128 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
  * bd_fs_ntfs_set_uuid:
  * @device: the device containing the file system to set the UUID (serial number) for
  * @uuid: (allow-none): UUID to set or %NULL to generate a new one

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -93,6 +93,8 @@ BDFSNtfsInfo* bd_fs_ntfs_info_copy (BDFSNtfsInfo *data) {
 
     BDFSNtfsInfo *ret = g_new0 (BDFSNtfsInfo, 1);
 
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
     ret->size = data->size;
     ret->free_space = data->free_space;
 
@@ -105,6 +107,11 @@ BDFSNtfsInfo* bd_fs_ntfs_info_copy (BDFSNtfsInfo *data) {
  * Frees @data.
  */
 void bd_fs_ntfs_info_free (BDFSNtfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
     g_free (data);
 }
 
@@ -309,12 +316,20 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
         }
     }
 
+    ret = g_new0 (BDFSNtfsInfo, 1);
+
+    success = get_uuid_label (device, &(ret->uuid), &(ret->label), error);
+    if (!success) {
+        /* error is already populated */
+        bd_fs_ntfs_info_free (ret);
+        return NULL;
+    }
+
     success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
     if (!success)
         /* error is already populated */
         return FALSE;
 
-    ret = g_new0 (BDFSNtfsInfo, 1);
     lines = g_strsplit (output, "\n", 0);
     g_free (output);
     line_p = lines;

--- a/src/plugins/fs/ntfs.h
+++ b/src/plugins/fs/ntfs.h
@@ -5,6 +5,8 @@
 #define BD_FS_NTFS
 
 typedef struct BDFSNtfsInfo {
+    gchar *label;
+    gchar *uuid;
     guint64 size;
     guint64 free_space;
 } BDFSNtfsInfo;

--- a/src/plugins/fs/ntfs.h
+++ b/src/plugins/fs/ntfs.h
@@ -19,6 +19,7 @@ gboolean bd_fs_ntfs_wipe (const gchar *device, GError **error);
 gboolean bd_fs_ntfs_check (const gchar *device, GError **error);
 gboolean bd_fs_ntfs_repair (const gchar *device, GError **error);
 gboolean bd_fs_ntfs_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_ntfs_check_label (const gchar *label, GError **error);
 gboolean bd_fs_ntfs_set_uuid (const gchar *device, const gchar *uuid, GError **error);
 BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ntfs_resize (const gchar *device, guint64 new_size, GError **error);

--- a/src/plugins/fs/reiserfs.c
+++ b/src/plugins/fs/reiserfs.c
@@ -237,6 +237,26 @@ gboolean bd_fs_reiserfs_set_label (const gchar *device, const gchar *label, GErr
 }
 
 /**
+ * bd_fs_reiserfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the reiserfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_reiserfs_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 16) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for ReiserFS filesystem must be at most 16 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
  * bd_fs_reiserfs_set_uuid:
  * @device: the device containing the file system to set UUID for
  * @uuid: (allow-none): UUID to set or %NULL to generate a new one

--- a/src/plugins/fs/reiserfs.h
+++ b/src/plugins/fs/reiserfs.h
@@ -20,6 +20,7 @@ gboolean bd_fs_reiserfs_wipe (const gchar *device, GError **error);
 gboolean bd_fs_reiserfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_reiserfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_reiserfs_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_reiserfs_check_label (const gchar *label, GError **error);
 gboolean bd_fs_reiserfs_set_uuid (const gchar *device, const gchar *uuid, GError **error);
 BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error);
 gboolean bd_fs_reiserfs_resize (const gchar *device, guint64 new_size, GError **error);

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -267,6 +267,26 @@ gboolean bd_fs_vfat_set_label (const gchar *device, const gchar *label, GError *
 }
 
 /**
+ * bd_fs_vfat_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the vfat file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_vfat_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 11) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for VFAT filesystem must be at most 11 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
  * bd_fs_vfat_get_info:
  * @device: the device containing the file system to get info for
  * @error: (out): place to store error (if any)

--- a/src/plugins/fs/vfat.h
+++ b/src/plugins/fs/vfat.h
@@ -20,6 +20,7 @@ gboolean bd_fs_vfat_wipe (const gchar *device, GError **error);
 gboolean bd_fs_vfat_check (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_vfat_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_vfat_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_vfat_check_label (const gchar *label, GError **error);
 BDFSVfatInfo* bd_fs_vfat_get_info (const gchar *device, GError **error);
 gboolean bd_fs_vfat_resize (const gchar *device, guint64 new_size, GError **error);
 

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -228,6 +228,35 @@ gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **
 }
 
 /**
+ * bd_fs_xfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the xfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_xfs_check_label (const gchar *label, GError **error) {
+    size_t len = 0;
+
+    len = strlen (label);
+    if (len > 12) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for XFS filesystem must be at most 12 characters long.");
+        return FALSE;
+    }
+
+    if (strchr (label, ' ') != NULL) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for XFS filesystem cannot contain spaces.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
  * bd_fs_xfs_set_uuid:
  * @device: the device containing the file system to set uuid for
  * @uuid: (allow-none): UUID to set %NULL to generate a new one

--- a/src/plugins/fs/xfs.h
+++ b/src/plugins/fs/xfs.h
@@ -19,6 +19,7 @@ gboolean bd_fs_xfs_wipe (const gchar *device, GError **error);
 gboolean bd_fs_xfs_check (const gchar *device, GError **error);
 gboolean bd_fs_xfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_xfs_check_label (const gchar *label, GError **error);
 gboolean bd_fs_xfs_set_uuid (const gchar *device, const gchar *uuid, GError **error);
 BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error);
 gboolean bd_fs_xfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error);


### PR DESCRIPTION
One of the missing filesystem functionality needed by Blivet. Related: #509 