### PR TITLE
NILFS2 support

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -686,6 +686,17 @@ bd_fs_reiserfs_check_label
 bd_fs_reiserfs_set_uuid
 bd_fs_reiserfs_check_uuid
 bd_fs_reiserfs_wipe
+BDFSNILFS2Info
+bd_fs_nilfs2_get_info
+bd_fs_nilfs2_info_copy
+bd_fs_nilfs2_info_free
+bd_fs_nilfs2_mkfs
+bd_fs_nilfs2_resize
+bd_fs_nilfs2_set_label
+bd_fs_nilfs2_check_label
+bd_fs_nilfs2_set_uuid
+bd_fs_nilfs2_check_uuid
+bd_fs_nilfs2_wipe
 </SECTION>
 
 <SECTION>

--- a/features.rst
+++ b/features.rst
@@ -25,7 +25,7 @@ filesystems
 ------------
 
 :supported technologies:
-   * DONE: ext2, ext3, ext4, xfs, vfat, ntfs, f2fs
+   * DONE: ext2, ext3, ext4, xfs, vfat, ntfs, f2fs, reiserfs, nilfs2
 
 :functions:
    * make_FSTYPE

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -451,6 +451,7 @@ typedef enum {
     BD_FS_TECH_NTFS,
     BD_FS_TECH_F2FS,
     BD_FS_TECH_REISERFS,
+    BD_FS_TECH_NILFS2,
 } BDFSTech;
 
 typedef enum {
@@ -525,6 +526,73 @@ GType bd_fs_reiserfs_info_get_type () {
         type = g_boxed_type_register_static("BDFSReiserFSInfo",
                                             (GBoxedCopyFunc) bd_fs_reiserfs_info_copy,
                                             (GBoxedFreeFunc) bd_fs_reiserfs_info_free);
+    }
+
+    return type;
+}
+
+#define BD_FS_TYPE_NILFS_INFO (bd_fs_nilfs2_info_get_type ())
+GType bd_fs_nilfs2_info_get_type();
+
+/**
+ * BDFSNILFS2Info:
+ * @label: label of the filesystem
+ * @uuid: uuid of the filesystem
+ * @block_size: block size used by the filesystem
+ * @size: size of the filesystem
+ * @free_blocks: number of free blocks in the filesystem
+ */
+typedef struct BDFSNILFS2Info {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 block_size;
+    guint64 free_blocks;
+} BDFSNILFS2Info;
+
+/**
+ * bd_fs_nilfs2_info_copy: (skip)
+ * @data: (allow-none): %BDFSNILFS2Info to copy
+ *
+ * Creates a new copy of @data.
+ */
+BDFSNILFS2Info* bd_fs_nilfs2_info_copy (BDFSNILFS2Info *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSNILFS2Info *ret = g_new0 (BDFSNILFS2Info, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->block_size = data->block_size;
+    ret->free_blocks = data->free_blocks;
+
+    return ret;
+}
+
+/**
+ * bd_fs_nilfs2_info_free: (skip)
+ * @data: (allow-none): %BDFSNILFS2Info to free
+ *
+ * Frees @data.
+ */
+void bd_fs_nilfs2_info_free (BDFSNILFS2Info *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+GType bd_fs_nilfs2_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDFSNILFS2Info",
+                                            (GBoxedCopyFunc) bd_fs_nilfs2_info_copy,
+                                            (GBoxedFreeFunc) bd_fs_nilfs2_info_free);
     }
 
     return type;
@@ -1871,5 +1939,105 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error);
  * Tech category: %BD_FS_TECH_REISERFS-%BD_FS_TECH_MODE_RESIZE
  */
 gboolean bd_fs_reiserfs_resize (const gchar *device, guint64 new_size, GError **error);
+
+/**
+ * bd_fs_nilfs2_mkfs:
+ * @device: the device to create a new nilfs fs on
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
+ *                                                 passed to the 'mkfs.nilfs2' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a new nilfs fs was successfully created on @device or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_MKFS
+ */
+gboolean bd_fs_nilfs2_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_nilfs2_wipe:
+ * @device: the device to wipe a nilfs signature from
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the nilfs signature was successfully wiped from the @device or
+ *          not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_nilfs2_wipe (const gchar *device, GError **error);
+
+/**
+ * bd_fs_nilfs2_set_label:
+ * @device: the device containing the file system to set label for
+ * @label: label to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the label of nilfs file system on the @device was
+ *          successfully set or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_SET_LABEL
+ */
+gboolean bd_fs_nilfs2_set_label (const gchar *device, const gchar *label, GError **error);
+
+/**
+ * bd_fs_nilfs2_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the nilfs2 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_nilfs2_check_label (const gchar *label, GError **error);
+
+/**
+ * bd_fs_nilfs2_set_uuid:
+ * @device: the device containing the file system to set UUID for
+ * @uuid: (allow-none): UUID to set or %NULL to generate a new one
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the uuid of nilfs file system on the @device was
+ *          successfully set or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_SET_UUID
+ */
+gboolean bd_fs_nilfs2_set_uuid (const gchar *device, const gchar *uuid, GError **error);
+
+/**
+ * bd_fs_nilfs2_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID for the nilfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_nilfs2_check_uuid (const gchar *uuid, GError **error);
+
+/**
+ * bd_fs_nilfs2_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the file system on @device or
+ *                           %NULL in case of error
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSNILFS2Info* bd_fs_nilfs2_get_info (const gchar *device, GError **error);
+
+/**
+ * bd_fs_nilfs2_resize:
+ * @device: the device the file system of which to resize
+ * @new_size: new requested size for the file system (if 0, the file system is
+ *            adapted to the underlying block device)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the file system on @device was successfully resized or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_RESIZE
+ */
+gboolean bd_fs_nilfs2_resize (const gchar *device, guint64 new_size, GError **error);
 
 #endif  /* BD_FS_API */

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -40,6 +40,7 @@ extern gboolean bd_fs_vfat_is_tech_avail (BDFSTech tech, guint64 mode, GError **
 extern gboolean bd_fs_ntfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_f2fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_reiserfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
+extern gboolean bd_fs_nilfs2_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 
 /**
  * bd_fs_error_quark: (skip)
@@ -123,6 +124,15 @@ gboolean bd_fs_check_deps (void) {
         bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
         g_clear_error (&error);
     }
+    ret = ret && bd_fs_nilfs2_is_tech_avail (BD_FS_TECH_NILFS2,
+                                             BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                             BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                             BD_FS_TECH_MODE_RESIZE | BD_FS_TECH_MODE_SET_UUID,
+                                             &error);
+    if (!ret && error) {
+        bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
+        g_clear_error (&error);
+    }
     return ret;
 }
 
@@ -184,6 +194,8 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error) {
             return bd_fs_f2fs_is_tech_avail (tech, mode, error);
         case BD_FS_TECH_REISERFS:
             return bd_fs_reiserfs_is_tech_avail (tech, mode, error);
+        case BD_FS_TECH_NILFS2:
+            return bd_fs_nilfs2_is_tech_avail (tech, mode, error);
         /* coverity[dead_error_begin] */
         default:
             /* this should never be reached (see the comparison with LAST_FS

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -22,7 +22,7 @@ typedef enum {
 
 /* XXX: where the file systems start at the enum of technologies */
 #define BD_FS_OFFSET 2
-#define BD_FS_LAST_FS 9
+#define BD_FS_LAST_FS 10
 typedef enum {
     BD_FS_TECH_GENERIC  = 0,
     BD_FS_TECH_MOUNT    = 1,
@@ -33,7 +33,8 @@ typedef enum {
     BD_FS_TECH_VFAT     = 6,
     BD_FS_TECH_NTFS     = 7,
     BD_FS_TECH_F2FS     = 8,
-    BD_FS_TECH_REISERFS = 9
+    BD_FS_TECH_REISERFS = 9,
+    BD_FS_TECH_NILFS2   = 10
 } BDFSTech;
 
 /* XXX: number of the highest bit of all modes */
@@ -75,3 +76,4 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 #include "fs/vfat.h"
 #include "fs/xfs.h"
 #include "fs/reiserfs.h"
+#include "fs/nilfs.h"

--- a/src/plugins/fs/Makefile.am
+++ b/src/plugins/fs/Makefile.am
@@ -16,7 +16,8 @@ libbd_fs_la_SOURCES  = ../check_deps.c ../check_deps.h \
 						vfat.c     vfat.h     \
 						xfs.c      xfs.h      \
 						f2fs.c     f2fs.h     \
-						reiserfs.c reiserfs.h
+						reiserfs.c reiserfs.h \
+						nilfs.c    nilfs.h
 
 libincludefsdir = $(includedir)/blockdev/fs/
 libincludefs_HEADERS = ext.h     \
@@ -26,4 +27,5 @@ libincludefs_HEADERS = ext.h     \
 					vfat.h     \
 					xfs.h      \
 					f2fs.h	   \
-					reiserfs.h
+					reiserfs.h \
+					nilfs.h

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2020  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vojtech Trefny <vtrefny@redhat.com>
+ */
+
+#include <blockdev/utils.h>
+#include <check_deps.h>
+#include <uuid.h>
+
+#include "nilfs.h"
+#include "fs.h"
+#include "common.h"
+
+static volatile guint avail_deps = 0;
+static GMutex deps_check_lock;
+
+#define DEPS_MKFSNILFS2 0
+#define DEPS_MKFSNILFS2_MASK (1 << DEPS_MKFSNILFS2)
+#define DEPS_NILFSTUNE 1
+#define DEPS_NILFSTUNE_MASK (1 <<  DEPS_NILFSTUNE)
+#define DEPS_NILFSRESIZE 2
+#define DEPS_NILFSRESIZE_MASK (1 << DEPS_NILFSRESIZE)
+
+#define DEPS_LAST 3
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"mkfs.nilfs2", NULL, NULL, NULL},
+    {"nilfs-tune", NULL, NULL, NULL},
+    {"nilfs-resize", NULL, NULL, NULL},
+};
+
+static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
+    DEPS_MKFSNILFS2_MASK,       /* mkfs */
+    0,                          /* wipe */
+    0,                          /* check */
+    0,                          /* repair */
+    DEPS_NILFSTUNE_MASK,        /* set-label */
+    DEPS_NILFSTUNE_MASK,        /* query */
+    DEPS_NILFSRESIZE_MASK,      /* resize */
+    DEPS_NILFSTUNE_MASK,        /* set-uuid */
+};
+
+#define UNUSED __attribute__((unused))
+
+#ifdef __clang__
+#define ZERO_INIT {}
+#else
+#define ZERO_INIT {0}
+#endif
+
+/**
+ * bd_fs_nilfs2_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDFSTechMode) for @tech
+ * @error: (out): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- supported by the
+ *          plugin implementation and having all the runtime dependencies available
+ */
+gboolean __attribute__ ((visibility ("hidden")))
+bd_fs_nilfs2_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+    guint32 required = 0;
+    guint i = 0;
+
+    if (mode & BD_FS_TECH_MODE_CHECK) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "NILFS2 doesn't support filesystem check.");
+        return FALSE;
+    }
+
+    if (mode & BD_FS_TECH_MODE_REPAIR) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "NILFS2 doesn't support filesystem repair.");
+        return FALSE;
+    }
+
+    for (i = 0; i <= BD_FS_MODE_LAST; i++)
+        if (mode & (1 << i))
+            required |= fs_mode_util[i];
+
+    return check_deps (&avail_deps, required, deps, DEPS_LAST, &deps_check_lock, error);
+}
+
+/**
+ * bd_fs_nilfs2_info_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDFSNILFS2Info* bd_fs_nilfs2_info_copy (BDFSNILFS2Info *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSNILFS2Info *ret = g_new0 (BDFSNILFS2Info, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->block_size = data->block_size;
+    ret->free_blocks = data->free_blocks;
+
+    return ret;
+}
+
+/**
+ * bd_fs_nilfs2_info_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_fs_nilfs2_info_free (BDFSNILFS2Info *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+/**
+ * bd_fs_nilfs2_mkfs:
+ * @device: the device to create a new nilfs fs on
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
+ *                                                 passed to the 'mkfs.nilfs2' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a new nilfs fs was successfully created on @device or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_MKFS
+ */
+gboolean bd_fs_nilfs2_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"mkfs.nilfs2", "-f", "-q", device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_MKFSNILFS2_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}
+
+/**
+ * bd_fs_nilfs2_wipe:
+ * @device: the device to wipe a nilfs signature from
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the nilfs signature was successfully wiped from the @device or
+ *          not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_nilfs2_wipe (const gchar *device, GError **error) {
+    return wipe_fs (device, "nilfs2", TRUE, error);
+}
+
+/**
+ * bd_fs_nilfs2_set_label:
+ * @device: the device containing the file system to set label for
+ * @label: label to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the label of nilfs file system on the @device was
+ *          successfully set or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_SET_LABEL
+ */
+gboolean bd_fs_nilfs2_set_label (const gchar *device, const gchar *label, GError **error) {
+    const gchar *args[5] = {"nilfs-tune", "-L", label, device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_NILFSTUNE_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (args, NULL, error);
+}
+
+/**
+ * bd_fs_nilfs2_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the nilfs2 file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_nilfs2_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 80) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for nilfs2 filesystem must be at most 80 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_nilfs2_set_uuid:
+ * @device: the device containing the file system to set UUID for
+ * @uuid: (allow-none): UUID to set or %NULL to generate a new one
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the uuid of nilfs file system on the @device was
+ *          successfully set or not
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_SET_UUID
+ */
+gboolean bd_fs_nilfs2_set_uuid (const gchar *device, const gchar *uuid, GError **error) {
+    const gchar *args[5] = {"nilfs-tune", "-U", uuid, device, NULL};
+    uuid_t uu;
+    gchar uuidbuf[37] = {0};
+
+    if (!uuid) {
+        uuid_generate (uu);
+        uuid_unparse (uu, uuidbuf);
+        args[2] = uuidbuf;
+    }
+
+    if (!check_deps (&avail_deps, DEPS_NILFSTUNE_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (args, NULL, error);
+}
+
+/**
+ * bd_fs_nilfs2_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID for the nilfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_nilfs2_check_uuid (const gchar *uuid, GError **error) {
+    return check_uuid (uuid, error);
+}
+
+/**
+ * bd_fs_nilfs2_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the file system on @device or
+ *                           %NULL in case of error
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSNILFS2Info* bd_fs_nilfs2_get_info (const gchar *device, GError **error) {
+    const gchar *args[4] = {"nilfs-tune", "-l", device, NULL};
+    gboolean success = FALSE;
+    gchar *output = NULL;
+    BDFSNILFS2Info *ret = NULL;
+    gchar **lines = NULL;
+    gchar **line_p = NULL;
+    gchar *val_start = NULL;
+
+    if (!check_deps (&avail_deps, DEPS_NILFSTUNE_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return NULL;
+
+    ret = g_new0 (BDFSNILFS2Info, 1);
+
+    success = get_uuid_label (device, &(ret->uuid), &(ret->label), error);
+    if (!success) {
+        /* error is already populated */
+        bd_fs_nilfs2_info_free (ret);
+        return NULL;
+    }
+
+    success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
+    if (!success) {
+        /* error is already populated */
+        bd_fs_nilfs2_info_free (ret);
+        return NULL;
+    }
+
+    lines = g_strsplit (output, "\n", 0);
+    g_free (output);
+    line_p = lines;
+
+    while (line_p && *line_p && !g_str_has_prefix (*line_p, "Block size:"))
+        line_p++;
+    if (!line_p || !(*line_p)) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NILFS2 file system information");
+        g_strfreev (lines);
+        bd_fs_nilfs2_info_free (ret);
+        return NULL;
+    }
+
+    /* * extract data from something like this: "Block size: 4096" */
+    val_start = strchr (*line_p, ':');
+    val_start++;
+    ret->block_size = g_ascii_strtoull (val_start, NULL, 0);
+
+    line_p = lines;
+    while (line_p && *line_p && !g_str_has_prefix (*line_p, "Device size"))
+        line_p++;
+    if (!line_p || !(*line_p)) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NILFS2 file system information");
+        g_strfreev (lines);
+        bd_fs_nilfs2_info_free (ret);
+        return NULL;
+    }
+
+    /* extract data from something like this: "Device size: 167772160" */
+    val_start = strchr (*line_p, ':');
+    val_start++;
+    ret->size = g_ascii_strtoull (val_start, NULL, 0);
+
+    line_p = lines;
+    while (line_p && *line_p && !g_str_has_prefix (*line_p, "Free blocks count"))
+        line_p++;
+    if (!line_p || !(*line_p)) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NILFS2 file system information");
+        g_strfreev (lines);
+        bd_fs_nilfs2_info_free (ret);
+        return NULL;
+    }
+
+    /* extract data from something like this: "Free blocks count: 389120" */
+    val_start = strchr (*line_p, ':');
+    val_start++;
+    ret->free_blocks = g_ascii_strtoull (val_start, NULL, 0);
+
+    g_strfreev (lines);
+
+    return ret;
+}
+
+/**
+ * bd_fs_nilfs2_resize:
+ * @device: the device the file system of which to resize
+ * @new_size: new requested size for the file system (if 0, the file system is
+ *            adapted to the underlying block device)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the file system on @device was successfully resized or not
+ *
+ * Note: Filesystem must be mounted for the resize operation.
+ *
+ * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_RESIZE
+ */
+gboolean bd_fs_nilfs2_resize (const gchar *device, guint64 new_size, GError **error) {
+    const gchar *args[5] = {"nilfs-resize", "-y", device, NULL, NULL};
+    gboolean ret = FALSE;
+
+    if (!check_deps (&avail_deps, DEPS_NILFSRESIZE_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    if (new_size != 0)
+        args[3] = g_strdup_printf ("%"G_GUINT64_FORMAT, new_size);
+
+    ret = bd_utils_exec_and_report_error (args, NULL, error);
+
+    g_free ((gchar *) args[3]);
+    return ret;
+}

--- a/src/plugins/fs/nilfs.h
+++ b/src/plugins/fs/nilfs.h
@@ -1,0 +1,27 @@
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_FS_NILFS
+#define BD_FS_NILFS
+
+typedef struct BDFSNILFS2Info {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 block_size;
+    guint64 free_blocks;
+} BDFSNILFS2Info;
+
+BDFSNILFS2Info* bd_fs_nilfs2_info_copy (BDFSNILFS2Info *data);
+void bd_fs_nilfs2_info_free (BDFSNILFS2Info *data);
+
+gboolean bd_fs_nilfs2_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_nilfs2_wipe (const gchar *device, GError **error);
+gboolean bd_fs_nilfs2_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_nilfs2_check_label (const gchar *label, GError **error);
+gboolean bd_fs_nilfs2_set_uuid (const gchar *device, const gchar *uuid, GError **error);
+gboolean bd_fs_nilfs2_check_uuid (const gchar *uuid, GError **error);
+BDFSNILFS2Info* bd_fs_nilfs2_get_info (const gchar *device, GError **error);
+gboolean bd_fs_nilfs2_resize (const gchar *device, guint64 new_size, GError **error);
+
+#endif  /* BD_FS_NILFS */

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -380,7 +380,7 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
     success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
     if (!success)
         /* error is already populated */
-        return FALSE;
+        return NULL;
 
     lines = g_strsplit (output, "\n", 0);
     g_free (output);
@@ -392,7 +392,7 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NTFS file system information");
         g_strfreev (lines);
         bd_fs_ntfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     /* extract data from something like this: "bytes per volume        : 998240256" */
@@ -406,7 +406,7 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse NTFS file system information");
         g_strfreev (lines);
         bd_fs_ntfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     /* extract data from something like this: "bytes of free space     : 992759808" */

--- a/src/plugins/fs/reiserfs.c
+++ b/src/plugins/fs/reiserfs.c
@@ -325,9 +325,11 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
     }
 
     success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
-    if (!success)
+    if (!success) {
         /* error is already populated */
+        bd_fs_reiserfs_info_free (ret);
         return FALSE;
+    }
 
     lines = g_strsplit (output, "\n", 0);
     g_free (output);
@@ -374,6 +376,8 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
     val_start = strchr (*line_p, ':');
     val_start++;
     ret->free_blocks = g_ascii_strtoull (val_start, NULL, 0);
+
+    g_strfreev (lines);
 
     return ret;
 }

--- a/src/plugins/fs/reiserfs.c
+++ b/src/plugins/fs/reiserfs.c
@@ -313,7 +313,7 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
     gchar *val_start = NULL;
 
     if (!check_deps (&avail_deps, DEPS_DEBUGREISERFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
-        return FALSE;
+        return NULL;
 
     ret = g_new0 (BDFSReiserFSInfo, 1);
 
@@ -328,7 +328,7 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
     if (!success) {
         /* error is already populated */
         bd_fs_reiserfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     lines = g_strsplit (output, "\n", 0);
@@ -341,7 +341,7 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse ReiserFS file system information");
         g_strfreev (lines);
         bd_fs_reiserfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     /* extract data from something like this: "Count of blocks on the device: 127744" */
@@ -355,7 +355,7 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse ReiserFS file system information");
         g_strfreev (lines);
         bd_fs_reiserfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     /* extract data from something like this: "Blocksize: 4096" */
@@ -369,7 +369,7 @@ BDFSReiserFSInfo* bd_fs_reiserfs_get_info (const gchar *device, GError **error) 
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse ReiserFS file system information");
         g_strfreev (lines);
         bd_fs_reiserfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     /* extract data from something like this: "Free blocks (count of blocks - used [journal, bitmaps, data, reserved] blocks): 119529" */

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -347,7 +347,7 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
     if (!success) {
         /* error is already populated */
         bd_fs_xfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     lines = g_strsplit (output, "\n", 0);
@@ -361,7 +361,7 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse xfs file system information");
         g_strfreev (lines);
         bd_fs_xfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
 
     /* extract data from something like this: "data     =      bsize=4096   blocks=262400, imaxpct=25" */
@@ -378,7 +378,7 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse xfs file system information");
         g_strfreev (lines);
         bd_fs_xfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
     while (isdigit (*val_start) || isspace(*val_start))
         val_start++;
@@ -391,7 +391,7 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE, "Failed to parse xfs file system information");
         g_strfreev (lines);
         bd_fs_xfs_info_free (ret);
-        return FALSE;
+        return NULL;
     }
     g_strfreev (lines);
 

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1025,17 +1025,16 @@ class VfatResize(FSTestCase):
         self.assertTrue(succ)
 
         # shrink
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 80 * 1024**2)
+        succ = BlockDev.fs_vfat_resize(self.loop_dev, 130 * 1024**2)
         self.assertTrue(succ)
 
         # grow
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 100 * 1024**2)
+        succ = BlockDev.fs_vfat_resize(self.loop_dev, 140 * 1024**2)
         self.assertTrue(succ)
 
         # shrink again
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 80 * 1024**2)
+        succ = BlockDev.fs_vfat_resize(self.loop_dev, 130 * 1024**2)
         self.assertTrue(succ)
-
 
         # resize to maximum size
         succ = BlockDev.fs_vfat_resize(self.loop_dev, 0)

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -35,6 +35,7 @@ def mounted(device, where, ro=False):
 class FSTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("fs", "loop"))
+    loop_size = 150 * 1024**2
 
     @classmethod
     def setUpClass(cls):
@@ -72,8 +73,8 @@ class FSTestCase(unittest.TestCase):
 
     def setUp(self):
         self.addCleanup(self._clean_up)
-        self.dev_file = utils.create_sparse_tempfile("fs_test", 100 * 1024**2)
-        self.dev_file2 = utils.create_sparse_tempfile("fs_test", 100 * 1024**2)
+        self.dev_file = utils.create_sparse_tempfile("fs_test", self.loop_size)
+        self.dev_file2 = utils.create_sparse_tempfile("fs_test", self.loop_size)
         try:
             self.loop_dev = utils.create_lio_device(self.dev_file)
         except RuntimeError as e:
@@ -389,9 +390,9 @@ class ExtGetInfo(FSTestCase):
         fi = BlockDev.fs_ext4_get_info(self.loop_dev)
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
-        self.assertEqual(fi.block_count, 100 * 1024**2 / 1024)
+        self.assertEqual(fi.block_count, self.loop_size / 1024)
         # at least 90 % should be available, so it should be reported
-        self.assertGreater(fi.free_blocks, 0.90 * 100 * 1024**2 / 1024)
+        self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
         self.assertEqual(fi.label, "")
         # should be an non-empty string
         self.assertTrue(fi.uuid)
@@ -400,9 +401,9 @@ class ExtGetInfo(FSTestCase):
         with mounted(self.loop_dev, self.mount_dir):
             fi = BlockDev.fs_ext4_get_info(self.loop_dev)
             self.assertEqual(fi.block_size, 1024)
-            self.assertEqual(fi.block_count, 100 * 1024**2 / 1024)
+            self.assertEqual(fi.block_count, self.loop_size / 1024)
             # at least 90 % should be available, so it should be reported
-            self.assertGreater(fi.free_blocks, 0.90 * 100 * 1024**2 / 1024)
+            self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
             self.assertEqual(fi.label, "")
             # should be an non-empty string
             self.assertTrue(fi.uuid)
@@ -488,9 +489,9 @@ class ExtResize(FSTestCase):
         fi = info_function(self.loop_dev)
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
-        self.assertEqual(fi.block_count, 100 * 1024**2 / 1024)
+        self.assertEqual(fi.block_count, self.loop_size / 1024)
         # at least 90 % should be available, so it should be reported
-        self.assertGreater(fi.free_blocks, 0.90 * 100 * 1024**2 / 1024)
+        self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
         succ = resize_function(self.loop_dev, 50 * 1024**2, None)
         self.assertTrue(succ)
@@ -500,14 +501,14 @@ class ExtResize(FSTestCase):
         self.assertEqual(fi.block_count, 50 * 1024**2 / 1024)
 
         # resize back
-        succ = resize_function(self.loop_dev, 100 * 1024**2, None)
+        succ = resize_function(self.loop_dev, self.loop_size, None)
         self.assertTrue(succ)
         fi = info_function(self.loop_dev)
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
-        self.assertEqual(fi.block_count, 100 * 1024**2 / 1024)
+        self.assertEqual(fi.block_count, self.loop_size / 1024)
         # at least 90 % should be available, so it should be reported
-        self.assertGreater(fi.free_blocks, 0.90 * 100 * 1024**2 / 1024)
+        self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
         # resize again
         succ = resize_function(self.loop_dev, 50 * 1024**2, None)
@@ -523,9 +524,9 @@ class ExtResize(FSTestCase):
         fi = info_function(self.loop_dev)
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
-        self.assertEqual(fi.block_count, 100 * 1024**2 / 1024)
+        self.assertEqual(fi.block_count, self.loop_size / 1024)
         # at least 90 % should be available, so it should be reported
-        self.assertGreater(fi.free_blocks, 0.90 * 100 * 1024**2 / 1024)
+        self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
     def test_ext2_resize(self):
         """Verify that it is possible to resize an ext2 file system"""
@@ -720,7 +721,7 @@ class XfsGetInfo(FSTestCase):
             fi = BlockDev.fs_xfs_get_info(self.loop_dev)
 
         self.assertEqual(fi.block_size, 4096)
-        self.assertEqual(fi.block_count, 100 * 1024**2 / 4096)
+        self.assertEqual(fi.block_count, self.loop_size / 4096)
         self.assertEqual(fi.label, "")
         # should be an non-empty string
         self.assertTrue(fi.uuid)
@@ -1418,7 +1419,7 @@ class F2FSResize(F2FSTestCase):
         self.assertTrue(succ)
 
         fi = BlockDev.fs_f2fs_get_info(self.loop_dev)
-        self.assertEqual(fi.sector_count * fi.sector_size, 100 * 1024**2)
+        self.assertEqual(fi.sector_count * fi.sector_size, self.loop_size)
 
 
 class NTFSSetLabel(FSTestCase):
@@ -2106,10 +2107,10 @@ class GenericResize(FSTestCase):
         size = BlockDev.fs_get_size(self.loop_dev)
 
         # shrink
-        succ = BlockDev.fs_resize(self.loop_dev, 80 * 1024**2)
+        succ = BlockDev.fs_resize(self.loop_dev, 100 * 1024**2)
         self.assertTrue(succ)
         new_size = BlockDev.fs_get_size(self.loop_dev)
-        self.assertAlmostEqual(new_size, 80 * 1024**2, delta=size_delta)
+        self.assertAlmostEqual(new_size, 100 * 1024**2, delta=size_delta)
 
         # resize to maximum size
         succ = BlockDev.fs_resize(self.loop_dev, 0)

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -71,6 +71,15 @@ class FSTestCase(unittest.TestCase):
         except:
             cls.reiserfs_avail = False
 
+        try:
+            cls.nilfs2_avail = BlockDev.fs_is_tech_avail(BlockDev.FSTech.NILFS2,
+                                                         BlockDev.FSTechMode.MKFS |
+                                                         BlockDev.FSTechMode.RESIZE |
+                                                         BlockDev.FSTechMode.SET_LABEL)
+        except Exception as e:
+            print(e)
+            cls.nilfs2_avail = False
+
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.dev_file = utils.create_sparse_tempfile("fs_test", self.loop_size)
@@ -1969,6 +1978,14 @@ class GenericCheck(FSTestCase):
             self.skipTest("skipping ReiserFS: not available")
         self._test_generic_check(mkfs_function=BlockDev.fs_reiserfs_mkfs)
 
+    def test_nilfs2_generic_check(self):
+        """Test generic check function with an nilfs2 file system"""
+        if not self.nilfs2_avail:
+            self.skipTest("skipping NILFS2: not available")
+        with self.assertRaises(GLib.GError):
+            # nilfs2 doesn't support check
+            self._test_generic_check(mkfs_function=BlockDev.fs_nilfs2_mkfs)
+
 class GenericRepair(FSTestCase):
     def _test_generic_repair(self, mkfs_function):
         # clean the device
@@ -2006,6 +2023,15 @@ class GenericRepair(FSTestCase):
         if not self.reiserfs_avail:
             self.skipTest("skipping ReiserFS: not available")
         self._test_generic_repair(mkfs_function=BlockDev.fs_reiserfs_mkfs)
+
+    def test_nilfs2_generic_repair(self):
+        """Test generic repair function with an nilfs2 file system"""
+        if not self.nilfs2_avail:
+            self.skipTest("skipping NILFS2: not available")
+        with self.assertRaises(GLib.GError):
+            # nilfs2 doesn't support repair
+            self._test_generic_repair(mkfs_function=BlockDev.fs_nilfs2_mkfs)
+
 
 class GenericSetLabel(FSTestCase):
     def _test_generic_set_label(self, mkfs_function):
@@ -2046,6 +2072,13 @@ class GenericSetLabel(FSTestCase):
         if not self.reiserfs_avail:
             self.skipTest("skipping ReiserFS: not available")
         self._test_generic_set_label(mkfs_function=BlockDev.fs_reiserfs_mkfs)
+
+    def test_nilfs2_generic_set_label(self):
+        """Test generic set_label function with a nilfs2 file system"""
+        if not self.nilfs2_avail:
+            self.skipTest("skipping NILFS2: not available")
+        self._test_generic_set_label(mkfs_function=BlockDev.fs_nilfs2_mkfs)
+
 
 class GenericSetUUID(FSTestCase):
     def _test_generic_set_uuid(self, mkfs_function, test_uuid="4d7086c4-a4d3-432f-819e-73da03870df9"):
@@ -2095,6 +2128,12 @@ class GenericSetUUID(FSTestCase):
         if not self.reiserfs_avail:
             self.skipTest("skipping ReiserFS: not available")
         self._test_generic_set_uuid(mkfs_function=BlockDev.fs_reiserfs_mkfs)
+
+    def test_nilfs2_generic_set_uuid(self):
+        """Test generic set_uuid function with a nilfs2 file system"""
+        if not self.nilfs2_avail:
+            self.skipTest("skipping NILFS2: not available")
+        self._test_generic_set_uuid(mkfs_function=BlockDev.fs_nilfs2_mkfs)
 
 class GenericResize(FSTestCase):
     def _test_generic_resize(self, mkfs_function, size_delta=0):
@@ -2266,6 +2305,12 @@ class GenericResize(FSTestCase):
             self.skipTest("skipping ReiserFS: not available")
         self._test_generic_resize(mkfs_function=BlockDev.fs_reiserfs_mkfs)
 
+    def test_nilfs2_generic_resize(self):
+        """Test generic resize function with an nilfs2 file system"""
+        if not self.nilfs2_avail:
+            self.skipTest("skipping NILFS2: not available")
+        self._test_generic_resize(mkfs_function=BlockDev.fs_nilfs2_mkfs)
+
 
 class GenericGetFreeSpace(FSTestCase):
     def _test_get_free_space(self, mkfs_function, size_delta=0):
@@ -2306,6 +2351,12 @@ class GenericGetFreeSpace(FSTestCase):
         if not self.reiserfs_avail:
             self.skipTest("skipping ReiserFS: not available")
         self._test_get_free_space(mkfs_function=BlockDev.fs_reiserfs_mkfs)
+
+    def test_nilfs2_get_free_space(self):
+        """Test generic resize function with an nilfs2 file system"""
+        if not self.nilfs2_avail:
+            self.skipTest("skipping NILFS2: not available")
+        self._test_get_free_space(mkfs_function=BlockDev.fs_nilfs2_mkfs)
 
 
 class FSFreezeTest(FSTestCase):

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1517,7 +1517,7 @@ class CanResizeRepairCheckLabel(FSTestCase):
         self.assertTrue(avail)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.fs_can_resize("nilfs2")
+            BlockDev.fs_can_resize("non-existing-fs")
 
     def test_can_repair(self):
         """Verify that tooling query works for repair"""
@@ -1574,7 +1574,7 @@ class CanResizeRepairCheckLabel(FSTestCase):
         self.assertEqual(util, "xfs_admin")
 
         with self.assertRaises(GLib.GError):
-            BlockDev.fs_can_set_label("nilfs2")
+            BlockDev.fs_can_set_label("non-existing-fs")
 
     def test_can_get_size(self):
         """Verify that tooling query works for getting size"""
@@ -1591,7 +1591,7 @@ class CanResizeRepairCheckLabel(FSTestCase):
         self.assertEqual(util, "xfs_admin")
 
         with self.assertRaises(GLib.GError):
-            BlockDev.fs_can_get_size("nilfs2")
+            BlockDev.fs_can_get_size("non-existing-fs")
 
     def test_can_get_free_space(self):
         """Verify that tooling query works for getting free space"""
@@ -1611,7 +1611,7 @@ class CanResizeRepairCheckLabel(FSTestCase):
             BlockDev.fs_can_get_free_space("xfs")
 
         with self.assertRaises(GLib.GError):
-            BlockDev.fs_can_get_free_space("nilfs2")
+            BlockDev.fs_can_get_free_space("non-existing-fs")
 
 class MountTest(FSTestCase):
 


### PR DESCRIPTION
This contains only basic functionality for UDisks and Blivet. None of the advanced features of nilfs2 are supported.
Related: #509

First commit is from #554, second commit will be removed after #553 is merged.

Note: `test_ntfs_set_uuid` will fail because the commit adding UUID to NTFS info is not part of this PR. (I didn't want to deal with conflicts in `fs.api` twice. I will of course merge #554 (and #553) first and rebase this.)