### PR TITLE
configure: Fix libuuid requirement for FS plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -231,7 +231,8 @@ AS_IF([test "x$with_part" != "xno" -o "x$with_fs" != "xno"],
       [])
 
 AS_IF([test "x$with_fs" != "xno"],
-      [LIBBLOCKDEV_PKG_CHECK_MODULES([MOUNT], [mount >= 2.23.0])
+      [LIBBLOCKDEV_PKG_CHECK_MODULES([UUID], [uuid])
+       LIBBLOCKDEV_PKG_CHECK_MODULES([MOUNT], [mount >= 2.23.0])
        # new versions of libmount has some new functions we can use
        AS_IF([$PKG_CONFIG --atleast-version=2.30.0 mount],
              [AC_DEFINE([LIBMOUNT_NEW_ERR_API])], [])
@@ -244,8 +245,7 @@ AS_IF([test "x$with_fs" != "xno"],
       [])
 
 AS_IF([test "x$with_fs" != "xno" -o "x$with_crypto" != "xno" -o "x$with_swap" != "xno"],
-      [LIBBLOCKDEV_PKG_CHECK_MODULES([UUID], [uuid])
-       LIBBLOCKDEV_PKG_CHECK_MODULES([BLKID], [blkid >= 2.23.0])
+      [LIBBLOCKDEV_PKG_CHECK_MODULES([BLKID], [blkid >= 2.23.0])
       # older versions of libblkid don't support BLKID_SUBLKS_BADCSUM so let's just
       # define it as 0 (neutral value for bit combinations of flags)
       AS_IF([$PKG_CONFIG --atleast-version=2.27.0 blkid], [],


### PR DESCRIPTION
It's needed only for FS plugin, not for crypto or swap.
Added to a wrong condition in 4e96ceebc7dc51a728c80c29a606a6a37269efe7