### PR TITLE
dm: Fix comparing DM RAID member devices UUID

### DIFF
--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -482,7 +482,7 @@ static gboolean raid_dev_matches_spec (struct raid_dev *raid_dev, const gchar *n
 
     context = udev_new ();
     device = udev_device_new_from_subsystem_sysname (context, "block", dev_name);
-    dev_uuid = udev_device_get_property_value (device, "UUID");
+    dev_uuid = udev_device_get_property_value (device, "ID_FS_UUID");
     major_str = udev_device_get_property_value (device, "MAJOR");
     minor_str = udev_device_get_property_value (device, "MINOR");
 


### PR DESCRIPTION
There is no "UUID" property in UDev we must use the "ID_FS_UUID"
one.
This comparison works only because most DM RAID members don't have
UUID so the check is skipped, but it fails for DDF RAID members
which have a special GUID/UUID in UDev database.