### PR TITLE
fs: Fix bd_fs_can_get_free_space name in declaration

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -583,7 +583,6 @@ bd_fs_can_repair
 bd_fs_can_set_label
 bd_fs_can_get_size
 bd_fs_can_get_free_space
-bd_fs_can_free_space
 bd_fs_can_set_uuid
 bd_fs_set_uuid
 bd_fs_ext2_check

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -31,6 +31,6 @@ gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError *
 gboolean bd_fs_can_set_label (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_set_uuid (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_get_size (const gchar *type, gchar **required_utility, GError **error);
-gboolean bd_fs_can_free_space (const gchar *type, gchar **required_utility, GError **error);
+gboolean bd_fs_can_get_free_space (const gchar *type, gchar **required_utility, GError **error);
 
 #endif  /* BD_FS_GENERIC */


### PR DESCRIPTION
Fortunately #518 is not released yet so it's not an API break. I can't believe I missed this. And also can't believe gcc is ok with this.