### PR TITLE
tests: Adjust sizes in generic FS resize test for VFAT resize

### DIFF
--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -2145,10 +2145,10 @@ class GenericResize(FSTestCase):
         size = BlockDev.fs_get_size(self.loop_dev)
 
         # shrink
-        succ = BlockDev.fs_resize(self.loop_dev, 100 * 1024**2)
+        succ = BlockDev.fs_resize(self.loop_dev, 130 * 1024**2)
         self.assertTrue(succ)
         new_size = BlockDev.fs_get_size(self.loop_dev)
-        self.assertAlmostEqual(new_size, 100 * 1024**2, delta=size_delta)
+        self.assertAlmostEqual(new_size, 130 * 1024**2, delta=size_delta)
 
         # resize to maximum size
         succ = BlockDev.fs_resize(self.loop_dev, 0)


### PR DESCRIPTION
Similar change to e75820f36a5fc6881722f1690f9bbe1d41a33014 -- when
shrinking, libparted can change FAT from FAT32 to FAT16 but it
can't change from FAT16 to FAT32 when growing so we can't shrink
(V)FAT below FAT32 minimal size in our tests if we want to grow it
back.