### PR TITLE
WIP: Add function for running mkfs with extra options

### DIFF
--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -237,6 +237,26 @@ void bd_fs_ext4_info_free (BDFSExt4Info *data) {
     bd_fs_ext2_info_free ((BDFSExt2Info*) data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_ext2_mkfs_options (BDFsMkfsOptions *options) {
+    BDExtraArg **ret = g_new0 (BDExtraArg*, 5);
+    guint next_arg = 0;
+
+    if (options->label)
+        ret[next_arg++] = bd_extra_arg_new ("-L", options->label);
+
+    if (options->uuid)
+        ret[next_arg++] = bd_extra_arg_new ("-U", options->uuid);
+
+    if (options->dry_run)
+        ret[next_arg++] = bd_extra_arg_new ("-n", "");
+
+    if (options->no_discard)
+        ret[next_arg++] = bd_extra_arg_new ("-E", "nodiscard");
+
+    return ret;
+}
+
 static gboolean ext_mkfs (const gchar *device, const BDExtraArg **extra, const gchar *ext_version, GError **error) {
     const gchar *args[6] = {"mke2fs", "-t", ext_version, "-F", device, NULL};
 

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -10,6 +10,22 @@ gchar* bd_fs_get_fstype (const gchar *device,  GError **error);
 gboolean bd_fs_freeze (const gchar *mountpoint, GError **error);
 gboolean bd_fs_unfreeze (const gchar *mountpoint, GError **error);
 
+typedef enum {
+    BD_FS_MKFS_LABEL     = 1 << 0,
+    BD_FS_MKFS_UUID      = 1 << 1,
+    BD_FS_MKFS_DRY_RUN   = 1 << 2,
+    BD_FS_MKFS_NODISCARD = 1 << 3,
+} BDFsMkfsOptionsFlags;
+
+typedef struct BDFsMkfsOptions {
+    gchar *label;
+    gchar *uuid;
+    gboolean dry_run;
+    gboolean no_discard;
+} BDFsMkfsOptions;
+
+gboolean bd_fs_mkfs (const gchar *device, const gchar *fsname, BDFsMkfsOptions *options, GError **error);
+
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
 gboolean bd_fs_repair (const gchar *device, GError **error);
 gboolean bd_fs_check (const gchar *device, GError **error);
@@ -25,6 +41,7 @@ typedef enum {
     BD_FS_ONLINE_GROW = 1 << 4
 } BDFsResizeFlags;
 
+gboolean bd_fs_can_mkfs (const gchar *type, BDFsMkfsOptionsFlags *options, gchar **required_utility, GError **error);
 gboolean bd_fs_can_resize (const gchar *type, BDFsResizeFlags *mode, gchar **required_utility, GError **error);
 gboolean bd_fs_can_check (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError **error);


### PR DESCRIPTION
This is not even remotely finished, but I'd like to hear your opinions about the API. The goal here is to provide mkfs API for UDisks and Blivet -- both need to be able to run mkfs with extra options (to set label, UUID etc.) but it doesn't really make sense for them to keep list of command line options for all filesystems to run mkfs with. So this API should provide a simple way to run mkfs with these extra options.

Please take a look at the proposed solution and feel free to come up with other/better ideas :-) I'll add some inline comments for parts where I was not sure how to handle something.

Don't bother reviewing the code too closely, I just made sure it compiles, everything else is most likely broken, it's just about the API design.