### PR TITLE
tests: Remove some old/obsolete rules to skip tests

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -24,58 +24,22 @@
 
 ---
 
-- test: crypto_test.CryptoTestEscrow.test_escrow_packet
-  skip_on:
-    - distro: ["centos", "enterprise_linux"]
-      version: "7"
-      reason: "volume_key asks for password in non-interactive mode on this release"
-
-    - distro: "debian"
-      version: "9"
-      reason: "volume_key asks for password in non-interactive mode on this release"
-
 - test: fs_test.MountTest.test_mount_ntfs_ro
   skip_on:
     - distro: "debian"
-      version: ["9", "10", "testing"]
+      version: ["10", "testing"]
       reason: "NTFS mounting of read-only devices doesn't work as expected on Debian"
 
 - test: kbd_test.KbdZRAM*
   skip_on:
     - distro: "debian"
-      version: ["9", "10"]
+      version: "10"
       reason: "loading zram module is broken on Debian"
 
 - test: kbd_test.KbdBcache*
   skip_on:
     - distro: "debian"
       reason: "running bcache tests causes system to run out of kernel memory on Debian"
-
-- test: lvm_test.LvmTestVGcreateRemove.test_vgcreate_vgremove
-  skip_on:
-    - distro: "debian"
-      version: "9"
-      arch: "i686"
-      reason: "vgremove is broken on 32bit Debian stable"
-
-- test: lvm_test.LvmTestVGs.test_vgs
-  skip_on:
-    - distro: "debian"
-      version: "9"
-      arch: "i686"
-      reason: "vgremove is broken on 32bit Debian stable"
-
-- test: lvm_test.LvmTestLVcreateType.test_lvcreate_type
-  skip_on:
-    - distro: ["centos", "enterprise_linux"]
-      version: "7"
-      reason: "creating raid1 LV is broken on CentOS 7"
-
-- test: lvm_test.LvmPVVGLVcachePoolCreateRemoveTestCase.test_cache_pool_create_remove
-  skip_on:
-    - distro: ["centos", "enterprise_linux"]
-      version: "7"
-      reason: "creating raid1 LV is broken on CentOS 7"
 
 - test: mdraid_test.MDTestAddRemove.test_add_remove
   skip_on:
@@ -92,32 +56,10 @@
     - arch: "i686"
       reason: "Lists of 64bit integers are broken on i686 with GI"
 
-- test: part_test.PartGetDiskFreeRegions.test_get_disk_free_regions
-  skip_on:
-    - distro: ["centos", "enterprise_linux"]
-      version: "7"
-      reason: "libparted provides weird values here"
-
-- test: part_test.PartGetDiskFreeRegions.test_get_disk_free_regions
-  skip_on:
-    - distro: "debian"
-      reason: "libparted provides weird values here"
-
-- test: part_test.PartGetBestFreeRegion.test_get_best_free_region
-  skip_on:
-    - distro: ["centos", "enterprise_linux"]
-      version: "7"
-      reason: "libparted provides weird values here"
-
-- test: part_test.PartGetBestFreeRegion.test_get_best_free_region
-  skip_on:
-    - distro: "debian"
-      reason: "libparted provides weird values here"
-
 - test: (lvm_test|lvm_dbus_tests).LvmTestLVsnapshots.test_snapshotcreate_lvorigin_snapshotmerge
   skip_on:
     - distro: "fedora"
-      version: ["31", "32"]
+      version: "32"
       reason: "working with old-style LVM snapshots leads to deadlock in LVM tools"
 
 - test: fs_test.MountTest.test_mount_ntfs


### PR DESCRIPTION
We are no longer running tests on Debian 9 and CentOS/RHEL 7 and
we are also no longer using (lib)parted in the part plugin.