### PR TITLE
tests: Remove MDTestNominateDenominateActive test case

### DIFF
--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -347,34 +347,6 @@ class MDTestNominateDenominate(MDTestCase):
             succ = BlockDev.md_deactivate(BlockDev.md_node_from_name("bd_test_md"))
             self.assertTrue(succ)
 
-class MDTestNominateDenominateActive(MDTestCase):
-    # slow and leaking an MD array because with a nominated spare device, it
-    # cannot be deactivated in the end (don't ask me why)
-    @tag_test(TestTags.SLOW, TestTags.UNSAFE, TestTags.UNSTABLE)
-    def test_nominate_denominate_active(self):
-        """Verify that nominate and denominate deivice works as expected on (de)activated MD RAID"""
-
-        with wait_for_action("resync"):
-            succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, False)
-            self.assertTrue(succ)
-
-        # can not re-add in incremental mode because the array is active
-        with self.assertRaises(GLib.GError):
-            BlockDev.md_nominate(self.loop_dev3)
-
-        succ = BlockDev.md_deactivate("bd_test_md");
-        self.assertTrue(succ)
-
-        # once the array is deactivated, can add in incremental mode
-        succ = BlockDev.md_nominate(self.loop_dev3)
-        self.assertTrue(succ)
-
-        # cannot re-add twice
-        with self.assertRaises(GLib.GError):
-            succ = BlockDev.md_nominate(self.loop_dev3)
-            self.assertTrue(succ)
 
 class MDTestAddRemove(MDTestCase):
     @tag_test(TestTags.SLOW)


### PR DESCRIPTION
This test never worked correctly. It creates array with a spare,
stops the array and then tries to activate it by adding only the
spare to it. The result is a "half active" array that can't be
stopped using its name which means the array is not properly
removed during cleanup and causes other tests to fail.
Basic (de)nominate functionallity is already covered by the
MDTestNominateDenominate test case so this can be safely removed.