### PR TITLE
fs: Add generic mkfs function with extra options

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -24,6 +24,69 @@ typedef enum {
     BD_FS_ERROR_UUID_INVALID,
 } BDFsError;
 
+/**
+ * BDFSMkfsOptions:
+ * @label: label of the filesystem
+ * @uuid: uuid of the filesystem
+ * @dry_run: whether to run mkfs in dry run mode (no changes written to the device)
+ * @no_discard: whether to avoid discarding blocks at mkfs time
+ * @reserve: reserve for future expansion
+ */
+typedef struct BDFSMkfsOptions {
+    const gchar *label;
+    const gchar *uuid;
+    gboolean dry_run;
+    gboolean no_discard;
+    guint8 reserve[32];
+} BDFSMkfsOptions;
+
+/**
+ * bd_fs_mkfs_options_copy: (skip)
+ * @data: (allow-none): %BDFSMkfsOptions to copy
+ *
+ * Creates a new copy of @data.
+ */
+BDFSMkfsOptions* bd_fs_mkfs_options_copy (BDFSMkfsOptions *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSMkfsOptions *ret = g_new0 (BDFSMkfsOptions, 1);
+
+    ret->label = data->label;
+    ret->uuid = data->uuid;
+    ret->dry_run = data->dry_run;
+    ret->no_discard = data->no_discard;
+
+    return ret;
+}
+
+/**
+ * bd_fs_mkfs_options_free: (skip)
+ * @data: (allow-none): %BDFSMkfsOptions to free
+ *
+ * Frees @data.
+ */
+void bd_fs_mkfs_options_free (BDFSMkfsOptions *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data);
+}
+
+#define BD_FS_MKFS_OPTIONS (bd_fs_mkfs_options_get_type ())
+
+GType bd_fs_mkfs_options_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDFSMkfsOptions",
+                                            (GBoxedCopyFunc) bd_fs_mkfs_options_copy,
+                                            (GBoxedFreeFunc) bd_fs_mkfs_options_free);
+    }
+
+    return type;
+}
+
 #define BD_FS_TYPE_EXT2_INFO (bd_fs_ext2_info_get_type ())
 GType bd_fs_ext2_info_get_type();
 #define BD_FS_TYPE_EXT3_INFO (bd_fs_ext3_info_get_type ())
@@ -930,6 +993,34 @@ guint64 bd_fs_get_size (const gchar *device, GError **error);
 guint64 bd_fs_get_free_space (const gchar *device, GError **error);
 
 /**
+ * BDFSMkfsOptionsFlags:
+ * Flags indicating mkfs options are available for given filesystem type.
+ */
+typedef enum {
+    BD_FS_MKFS_LABEL     = 1 << 0,
+    BD_FS_MKFS_UUID      = 1 << 1,
+    BD_FS_MKFS_DRY_RUN   = 1 << 2,
+    BD_FS_MKFS_NODISCARD = 1 << 3,
+} BDFSMkfsOptionsFlags;
+
+/**
+ * bd_fs_can_mkfs:
+ * @type: the filesystem type to be tested for installed mkfs support
+ * @options: (out): flags for allowed mkfs options (i.e. support for setting label or UUID when creating the filesystem)
+ * @required_utility: (out) (transfer full): the utility binary which is required for creating (if missing returns %FALSE but no @error)
+ * @error: (out): place to store error (if any)
+ *
+ * Searches for the required utility to create the given filesystem and returns whether
+ * it is installed. The options flags indicate what additional options can be specified for @type.
+ * Unknown filesystems result in errors.
+ *
+ * Returns: whether filesystem mkfs tool is available
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_QUERY
+ */
+gboolean bd_fs_can_mkfs (const gchar *type, BDFSMkfsOptionsFlags *options, gchar **required_utility, GError **error);
+
+/**
  * BDFsResizeFlags:
  * Flags indicating whether a filesystem resize action supports growing and/or
  * shrinking if mounted or unmounted.
@@ -1056,6 +1147,33 @@ gboolean bd_fs_can_get_size (const gchar *type, gchar **required_utility, GError
  * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_QUERY
  */
 gboolean bd_fs_can_get_free_space (const gchar *type, gchar **required_utility, GError **error);
+
+/**
+ * bd_fs_mkfs:
+ * @device: the device to create the new filesystem on
+ * @fstype: name of the filesystem to create (e.g. "ext4")
+ * @options: additional options like label or UUID for the filesystem
+ * @extra: (allow-none) (array zero-terminated=1): extra mkfs options not provided in @options
+ * @error: (out): place to store error (if any)
+ *
+ * This is a helper function for creating filesystems with extra options.
+ * This is the same as running a filesystem-specific function like %bd_fs_ext4_mkfs
+ * and manually specifying the extra command line options. %BDFsMkfsOptions
+ * removes the need to specify supported options for selected filesystems,
+ * make sure to check whether @fstype supports these options (see %bd_fs_can_mkfs)
+ * for details.
+ *
+ * When specifying additional mkfs options using @extra, it's caller's
+ * responsibility to make sure these options do not conflict with options
+ * specified using @options. Extra options are added after the @options and
+ * there are no additional checks for duplicate and/or conflicting options.
+ *
+ * Returns: whether @fstype was successfully created on @device or not.
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_CREATE
+ *
+ */
+gboolean bd_fs_mkfs (const gchar *device, const gchar *fstype, BDFSMkfsOptions *options, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_ext2_mkfs:

--- a/src/plugins/fs/exfat.c
+++ b/src/plugins/fs/exfat.c
@@ -130,6 +130,24 @@ void bd_fs_exfat_info_free (BDFSExfatInfo *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_exfat_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 /**
  * bd_fs_exfat_mkfs:
  * @device: the device to create a new exfat fs on

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -237,6 +237,47 @@ void bd_fs_ext4_info_free (BDFSExt4Info *data) {
     bd_fs_ext2_info_free ((BDFSExt2Info*) data);
 }
 
+static BDExtraArg **ext_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
+
+    if (options->uuid)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
+
+    if (options->dry_run)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-n", ""));
+
+    if (options->no_discard)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-E", "nodiscard"));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_ext2_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    return ext_mkfs_options (options, extra);
+}
+
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_ext3_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    return ext_mkfs_options (options, extra);
+}
+
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_ext4_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    return ext_mkfs_options (options, extra);
+}
+
 static gboolean ext_mkfs (const gchar *device, const BDExtraArg **extra, const gchar *ext_version, GError **error) {
     const gchar *args[6] = {"mke2fs", "-t", ext_version, "-F", device, NULL};
 

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -172,6 +172,27 @@ void bd_fs_f2fs_info_free (BDFSF2FSInfo *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_f2fs_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-l", options->label));
+
+    if (options->no_discard)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-t", "nodiscard"));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 
 /**
  * bd_fs_f2fs_mkfs:

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -10,6 +10,23 @@ gchar* bd_fs_get_fstype (const gchar *device,  GError **error);
 gboolean bd_fs_freeze (const gchar *mountpoint, GError **error);
 gboolean bd_fs_unfreeze (const gchar *mountpoint, GError **error);
 
+typedef enum {
+    BD_FS_MKFS_LABEL     = 1 << 0,
+    BD_FS_MKFS_UUID      = 1 << 1,
+    BD_FS_MKFS_DRY_RUN   = 1 << 2,
+    BD_FS_MKFS_NODISCARD = 1 << 3,
+} BDFSMkfsOptionsFlags;
+
+typedef struct BDFSMkfsOptions {
+    const gchar *label;
+    const gchar *uuid;
+    gboolean dry_run;
+    gboolean no_discard;
+    guint8 reserve[32];
+} BDFSMkfsOptions;
+
+gboolean bd_fs_mkfs (const gchar *device, const gchar *fstype, BDFSMkfsOptions *options, const BDExtraArg **extra, GError **error);
+
 gboolean bd_fs_resize (const gchar *device, guint64 new_size, GError **error);
 gboolean bd_fs_repair (const gchar *device, GError **error);
 gboolean bd_fs_check (const gchar *device, GError **error);
@@ -25,6 +42,7 @@ typedef enum {
     BD_FS_ONLINE_GROW = 1 << 4
 } BDFsResizeFlags;
 
+gboolean bd_fs_can_mkfs (const gchar *type, BDFSMkfsOptionsFlags *options, gchar **required_utility, GError **error);
 gboolean bd_fs_can_resize (const gchar *type, BDFsResizeFlags *mode, gchar **required_utility, GError **error);
 gboolean bd_fs_can_check (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_repair (const gchar *type, gchar **required_utility, GError **error);

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -129,6 +129,30 @@ void bd_fs_nilfs2_info_free (BDFSNILFS2Info *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_nilfs2_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
+
+    if (options->uuid)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
+
+    if (options->no_discard)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 /**
  * bd_fs_nilfs2_mkfs:
  * @device: the device to create a new nilfs fs on

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -115,6 +115,27 @@ void bd_fs_ntfs_info_free (BDFSNtfsInfo *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_ntfs_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
+
+    if (options->dry_run)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-n", ""));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 /**
  * bd_fs_ntfs_mkfs:
  * @device: the device to create a new ntfs fs on

--- a/src/plugins/fs/reiserfs.c
+++ b/src/plugins/fs/reiserfs.c
@@ -121,6 +121,27 @@ void bd_fs_reiserfs_info_free (BDFSReiserFSInfo *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_reiserfs_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-l", options->label));
+
+    if (options->uuid)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-u", options->uuid));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 /**
  * bd_fs_reiserfs_mkfs:
  * @device: the device to create a new reiserfs fs on

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -129,6 +129,27 @@ void bd_fs_vfat_info_free (BDFSVfatInfo *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_vfat_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-n", options->label));
+
+    if (options->uuid)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-i", options->uuid));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 /**
  * bd_fs_vfat_mkfs:
  * @device: the device to create a new vfat fs on

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -122,6 +122,37 @@ void bd_fs_xfs_info_free (BDFSXfsInfo *data) {
     g_free (data);
 }
 
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_xfs_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+    gchar *uuid_option = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
+
+    if (options->uuid) {
+        uuid_option = g_strdup_printf ("uuid=%s", options->uuid);
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-m", uuid_option));
+        g_free (uuid_option);
+    }
+
+    if (options->dry_run)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-N", ""));
+
+    if (options->no_discard)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
 
 /**
  * bd_fs_xfs_mkfs:

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -114,6 +114,21 @@ def _get_extra(extra, kwargs, cmd_extra=True):
     return ea
 
 
+class FSMkfsOptions(BlockDev.FSMkfsOptions):
+    def __new__(cls, label="", uuid="", dry_run=False, no_discard=False):
+        ret = BlockDev.FSMkfsOptions()
+        ret.__class__ = cls
+
+        ret.label = label
+        ret.uuid = uuid
+        ret.dry_run = dry_run
+        ret.no_discard = no_discard
+
+        return ret
+FSMkfsOptions = override(FSMkfsOptions)
+__all__.append("FSMkfsOptions")
+
+
 _init = BlockDev.init
 @override(BlockDev.init)
 def init(require_plugins=None, log_func=None):
@@ -338,6 +353,13 @@ def fs_mount(device=None, mountpoint=None, fstype=None, options=None, extra=None
     extra = _get_extra(extra, kwargs, False)
     return _fs_mount(device, mountpoint, fstype, options, extra)
 __all__.append("fs_mount")
+
+_fs_mkfs = BlockDev.fs_mkfs
+@override(BlockDev.fs_mkfs)
+def fs_mkfs(device, fstype, options=0, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_mkfs(device, fstype, options, extra)
+__all__.append("fs_mkfs")
 
 _fs_ext2_mkfs = BlockDev.fs_ext2_mkfs
 @override(BlockDev.fs_ext2_mkfs)


### PR DESCRIPTION
The idea here is the users will use bd_fs_mkfs with BDFSMkfsOptions
instead of filesystem specific functions like bd_fs_ext4_mkfs
where they need to manually list all the options.
The list of "generic" options in BDFSMkfsOptions is relatively
short but we add more in the future.

--------

This replaces #578. Main difference is `bd_fs_mkfs` can now be also called with extra options, `BDFSMkfsOptions` has a reserve for future expansion and of course all filesystems are covered, not only ext2. I kept the `bd_fs_can_mkfs` the same, with the out parameter for supported options. I'm still not sure if this makes sense, but I plan to rework the whole "filesystem features" feature in the future (near future I hope), so I'll keep this as it is for now. It is consistent with the other "can" functions and we can always remove it later.