### PR TITLE
fs: Add function to validate exFAT label

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -704,6 +704,7 @@ bd_fs_exfat_info_free
 bd_fs_exfat_mkfs
 bd_fs_exfat_repair
 bd_fs_exfat_set_label
+bd_fs_exfat_check_label
 bd_fs_exfat_wipe
 </SECTION>
 

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -2174,6 +2174,18 @@ gboolean bd_fs_exfat_repair (const gchar *device, const BDExtraArg **extra, GErr
 gboolean bd_fs_exfat_set_label (const gchar *device, const gchar *label, GError **error);
 
 /**
+ * bd_fs_exfat_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the exfat file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_exfat_check_label (const gchar *label, GError **error);
+
+/**
  * bd_fs_exfat_get_info:
  * @device: the device containing the file system to get info for
  * @error: (out): place to store error (if any)

--- a/src/plugins/fs/exfat.c
+++ b/src/plugins/fs/exfat.c
@@ -242,6 +242,26 @@ gboolean bd_fs_exfat_set_label (const gchar *device, const gchar *label, GError 
 }
 
 /**
+ * bd_fs_exfat_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the exfat file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_exfat_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 11) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for exFAT filesystem must be at most 11 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
  * bd_fs_exfat_get_info:
  * @device: the device containing the file system to get info for
  * @error: (out): place to store error (if any)

--- a/src/plugins/fs/exfat.h
+++ b/src/plugins/fs/exfat.h
@@ -20,6 +20,7 @@ gboolean bd_fs_exfat_wipe (const gchar *device, GError **error);
 gboolean bd_fs_exfat_check (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_exfat_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_exfat_set_label (const gchar *device, const gchar *label, GError **error);
+gboolean bd_fs_exfat_check_label (const gchar *label, GError **error);
 BDFSExfatInfo* bd_fs_exfat_get_info (const gchar *device, GError **error);
 
 #endif  /* BD_FS_EXFAT */

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1648,6 +1648,12 @@ class ExfatSetLabel(ExfatTestCase):
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
+        succ = BlockDev.fs_exfat_check_label("TEST_LABEL")
+        self.assertTrue(succ)
+
+        with six.assertRaisesRegex(self, GLib.GError, "at most 11 characters long."):
+            BlockDev.fs_exfat_check_label(12 * "a")
+
 class CanResizeRepairCheckLabel(FSTestCase):
     def test_can_resize(self):
         """Verify that tooling query works for resize"""


### PR DESCRIPTION
The exFAT PR was opened for so long I completely forgot we merged #553 in the meantime and added support for label validity check.