### PR TITLE
Btrfs support in filesystem plugin

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -704,6 +704,19 @@ bd_fs_exfat_repair
 bd_fs_exfat_set_label
 bd_fs_exfat_check_label
 bd_fs_exfat_wipe
+BDFSBtrfsInfo
+bd_fs_btrfs_get_info
+bd_fs_btrfs_info_copy
+bd_fs_btrfs_info_free
+bd_fs_btrfs_mkfs
+bd_fs_btrfs_wipe
+bd_fs_btrfs_check
+bd_fs_btrfs_repair
+bd_fs_btrfs_set_label
+bd_fs_btrfs_check_label
+bd_fs_btrfs_set_uuid
+bd_fs_btrfs_check_uuid
+bd_fs_btrfs_resize
 </SECTION>
 
 <SECTION>

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -516,6 +516,7 @@ typedef enum {
     BD_FS_TECH_REISERFS,
     BD_FS_TECH_NILFS2,
     BD_FS_TECH_EXFAT,
+    BD_FS_TECH_BTRFS,
 } BDFSTech;
 
 typedef enum {
@@ -725,6 +726,67 @@ GType bd_fs_exfat_info_get_type () {
         type = g_boxed_type_register_static("BDFSExfatInfo",
                                             (GBoxedCopyFunc) bd_fs_exfat_info_copy,
                                             (GBoxedFreeFunc) bd_fs_exfat_info_free);
+    }
+
+    return type;
+}
+
+/**
+ * BDFSBtrfsInfo:
+ * @label: label of the filesystem
+ * @uuid: uuid of the filesystem
+ * @size: size of the filesystem in bytes
+ * @free_space: free space on the filesystem in bytes
+ */
+typedef struct BDFSBtrfsInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 free_space;
+} BDFSBtrfsInfo;
+
+/**
+ * bd_fs_btrfs_info_copy: (skip)
+ * @data: (allow-none): %BDFSBtrfsInfo to copy
+ *
+ * Creates a new copy of @data.
+ */
+BDFSBtrfsInfo* bd_fs_btrfs_info_copy (BDFSBtrfsInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSBtrfsInfo *ret = g_new0 (BDFSBtrfsInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->free_space = data->free_space;
+
+    return ret;
+}
+
+/**
+ * bd_fs_btrfs_info_free: (skip)
+ * @data: (allow-none): %BDFSBtrfsInfo to free
+ *
+ * Frees @data.
+ */
+void bd_fs_btrfs_info_free (BDFSBtrfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+GType bd_fs_btrfs_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDFSBtrfsInfo",
+                                            (GBoxedCopyFunc) bd_fs_btrfs_info_copy,
+                                            (GBoxedFreeFunc) bd_fs_btrfs_info_free);
     }
 
     return type;
@@ -2314,5 +2376,152 @@ gboolean bd_fs_exfat_check_label (const gchar *label, GError **error);
  * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_QUERY
  */
 BDFSExfatInfo* bd_fs_exfat_get_info (const gchar *device, GError **error);
+
+/**
+ * bd_fs_btrfs_mkfs:
+ * @device: the device to create a new btrfs fs on
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
+ *                                                 passed to the 'mkfs.btrfs' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a new btrfs fs was successfully created on @device or not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_MKFS
+ *
+ */
+gboolean bd_fs_btrfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_btrfs_wipe:
+ * @device: the device to wipe a Btrfs signature from
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the Btrfs signature was successfully wiped from the @device or
+ *          not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_btrfs_wipe (const gchar *device, GError **error);
+
+/**
+ * bd_fs_btrfs_check:
+ * @device: the device containing the file system to check
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the check (right now
+ *                                                 passed to the 'btrfsck' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the filesystem was successfully checked or not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_CHECK
+ */
+gboolean bd_fs_btrfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_btrfs_repair:
+ * @device: the device containing the file system to repair
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the repair (right now
+ *                                                 passed to the 'btrfs' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the filesystem was successfully checked and repaired or not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_REPAIR
+ */
+gboolean bd_fs_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_btrfs_set_label:
+ * @mpoint: the mount point of the file system to resize
+ * @label: label to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the label of Btrfs file system on the @mpoint was
+ *          successfully set or not
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_SET_LABEL
+ */
+gboolean bd_fs_btrfs_set_label (const gchar *mpoint, const gchar *label, GError **error);
+
+/**
+ * bd_fs_btrfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the Btrfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_btrfs_check_label (const gchar *label, GError **error);
+
+/**
+ * bd_fs_btrfs_set_uuid:
+ * @device: the device containing the file system to set the UUID (serial number) for
+ * @uuid: (allow-none): UUID to set or %NULL to generate a new one
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the UUID of the Btrfs file system on the @device was
+ *          successfully set or not
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_SET_UUID
+ */
+gboolean bd_fs_btrfs_set_uuid (const gchar *device, const gchar *uuid, GError **error);
+
+/**
+ * bd_fs_btrfs_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID for the Btrfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_btrfs_check_uuid (const gchar *uuid, GError **error);
+
+/**
+ * bd_fs_btrfs_get_info:
+ * @mpoint: a mountpoint of the btrfs filesystem to get information about
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the file system on @device or
+ *                           %NULL in case of error
+ *
+ * Note: This function WON'T WORK for multi device btrfs filesystems,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSBtrfsInfo* bd_fs_btrfs_get_info (const gchar *mpoint, GError **error);
+
+/**
+ * bd_fs_btrfs_resize:
+ * @mpoint: a mountpoint of the to be resized btrfs filesystem
+ * @new_size: requested new size
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the volume resize (right now
+ *                                                 passed to the 'btrfs' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @mpoint filesystem was successfully resized to @new_size
+ * or not
+ *
+ * Note: This function WON'T WORK for multi device btrfs filesystems,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_BTRFS_TECH_FS-%BD_BTRFS_TECH_MODE_MODIFY
+ */
+gboolean bd_fs_btrfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error);
 
 #endif  /* BD_FS_API */

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -39,6 +39,7 @@ extern gboolean bd_fs_f2fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **
 extern gboolean bd_fs_reiserfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_nilfs2_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_exfat_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
+extern gboolean bd_fs_btrfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 
 /**
  * bd_fs_error_quark: (skip)
@@ -142,6 +143,17 @@ gboolean bd_fs_check_deps (void) {
         g_clear_error (&error);
     }
 
+    ret = ret && bd_fs_btrfs_is_tech_avail (BD_FS_TECH_BTRFS,
+                                            BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                            BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                            BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY |
+                                            BD_FS_TECH_MODE_RESIZE | BD_FS_TECH_MODE_SET_UUID,
+                                            &error);
+    if (!ret && error) {
+        bd_utils_log_format (BD_UTILS_LOG_WARNING, "%s", error->message);
+        g_clear_error (&error);
+    }
+
     return ret;
 }
 
@@ -206,6 +218,8 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error) {
             return bd_fs_nilfs2_is_tech_avail (tech, mode, error);
         case BD_FS_TECH_EXFAT:
             return bd_fs_exfat_is_tech_avail (tech, mode, error);
+        case BD_FS_TECH_BTRFS:
+            return bd_fs_btrfs_is_tech_avail (tech, mode, error);
         /* coverity[dead_error_begin] */
         default:
             /* this should never be reached (see the comparison with LAST_FS

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -22,7 +22,7 @@ typedef enum {
 
 /* XXX: where the file systems start at the enum of technologies */
 #define BD_FS_OFFSET 2
-#define BD_FS_LAST_FS 11
+#define BD_FS_LAST_FS 13
 typedef enum {
     BD_FS_TECH_GENERIC  = 0,
     BD_FS_TECH_MOUNT    = 1,
@@ -35,7 +35,8 @@ typedef enum {
     BD_FS_TECH_F2FS     = 8,
     BD_FS_TECH_REISERFS = 9,
     BD_FS_TECH_NILFS2   = 10,
-    BD_FS_TECH_EXFAT    = 11
+    BD_FS_TECH_EXFAT    = 11,
+    BD_FS_TECH_BTRFS    = 12
 } BDFSTech;
 
 /* XXX: number of the highest bit of all modes */
@@ -79,3 +80,4 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 #include "fs/reiserfs.h"
 #include "fs/nilfs.h"
 #include "fs/exfat.h"
+#include "fs/btrfs.h"

--- a/src/plugins/fs/Makefile.am
+++ b/src/plugins/fs/Makefile.am
@@ -18,7 +18,8 @@ libbd_fs_la_SOURCES  = ../check_deps.c ../check_deps.h \
 						f2fs.c     f2fs.h     \
 						reiserfs.c reiserfs.h \
 						nilfs.c    nilfs.h    \
-						exfat.c    exfat.h
+						exfat.c    exfat.h    \
+						btrfs.c    btrfs.h
 
 libincludefsdir = $(includedir)/blockdev/fs/
 libincludefs_HEADERS = ext.h     \
@@ -30,4 +31,5 @@ libincludefs_HEADERS = ext.h     \
 					f2fs.h	   \
 					reiserfs.h \
 					nilfs.h    \
-					exfat.h
+					exfat.h    \
+					btrfs.h

--- a/src/plugins/fs/btrfs.c
+++ b/src/plugins/fs/btrfs.c
@@ -1,0 +1,469 @@
+/*
+ * Copyright (C) 2020  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vojtech Trefny <vtrefny@redhat.com>
+ */
+
+#include <blockdev/utils.h>
+#include <check_deps.h>
+#include <stdio.h>
+
+#include "btrfs.h"
+#include "fs.h"
+#include "common.h"
+
+static volatile guint avail_deps = 0;
+static GMutex deps_check_lock;
+
+#define DEPS_MKFSBTRFS 0
+#define DEPS_MKFSBTRFS_MASK (1 << DEPS_MKFSBTRFS)
+#define DEPS_BTRFSCK 1
+#define DEPS_BTRFSCK_MASK (1 <<  DEPS_BTRFSCK)
+#define DEPS_BTRFS 2
+#define DEPS_BTRFS_MASK (1 <<  DEPS_BTRFS)
+#define DEPS_BTRFSTUNE 3
+#define DEPS_BTRFSTUNE_MASK (1 <<  DEPS_BTRFSTUNE)
+
+#define DEPS_LAST 4
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"mkfs.btrfs", NULL, NULL, NULL},
+    {"btrfsck", NULL, NULL, NULL},
+    {"btrfs", NULL, NULL, NULL},
+    {"btrfstune", NULL, NULL, NULL},
+};
+
+static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
+    DEPS_MKFSBTRFS_MASK,    /* mkfs */
+    0,                      /* wipe */
+    DEPS_BTRFSCK_MASK,      /* check */
+    DEPS_BTRFSCK_MASK,      /* repair */
+    DEPS_BTRFS_MASK,        /* set-label */
+    DEPS_BTRFS_MASK,        /* query */
+    DEPS_BTRFS_MASK,        /* resize */
+    DEPS_BTRFSTUNE_MASK,    /* set-uuid */
+};
+
+#define UNUSED __attribute__((unused))
+
+/**
+ * bd_fs_btrfs_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDFSTechMode) for @tech
+ * @error: (out): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- supported by the
+ *          plugin implementation and having all the runtime dependencies available
+ */
+gboolean __attribute__ ((visibility ("hidden")))
+bd_fs_btrfs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+    guint32 required = 0;
+    guint i = 0;
+
+    for (i = 0; i <= BD_FS_MODE_LAST; i++)
+        if (mode & (1 << i))
+            required |= fs_mode_util[i];
+
+    return check_deps (&avail_deps, required, deps, DEPS_LAST, &deps_check_lock, error);
+}
+
+/**
+ * bd_fs_btrfs_info_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDFSBtrfsInfo* bd_fs_btrfs_info_copy (BDFSBtrfsInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSBtrfsInfo *ret = g_new0 (BDFSBtrfsInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->size = data->size;
+    ret->free_space = data->free_space;
+
+    return ret;
+}
+
+/**
+ * bd_fs_btrfs_info_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_fs_btrfs_info_free (BDFSBtrfsInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+BDExtraArg __attribute__ ((visibility ("hidden")))
+**bd_fs_btrfs_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg **extra) {
+    GPtrArray *options_array = g_ptr_array_new ();
+    const BDExtraArg **extra_p = NULL;
+
+    if (options->label)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
+
+    if (options->uuid)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
+
+    if (options->no_discard)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
+
+    if (extra) {
+        for (extra_p = extra; *extra_p; extra_p++)
+            g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));
+    }
+
+    g_ptr_array_add (options_array, NULL);
+
+    return (BDExtraArg **) g_ptr_array_free (options_array, FALSE);
+}
+
+/**
+ * bd_fs_btrfs_mkfs:
+ * @device: the device to create a new btrfs fs on
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
+ *                                                 passed to the 'mkfs.btrfs' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a new btrfs fs was successfully created on @device or not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_MKFS
+ *
+ */
+gboolean bd_fs_btrfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[4] = {"mkfs.btrfs", "-f", device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_MKFSBTRFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}
+
+/**
+ * bd_fs_btrfs_wipe:
+ * @device: the device to wipe a Btrfs signature from
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the Btrfs signature was successfully wiped from the @device or
+ *          not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_btrfs_wipe (const gchar *device, GError **error) {
+    return wipe_fs (device, "btrfs", FALSE, error);
+}
+
+/**
+ * bd_fs_btrfs_check:
+ * @device: the device containing the file system to check
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the check (right now
+ *                                                 passed to the 'btrfsck' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the filesystem was successfully checked or not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_CHECK
+ */
+gboolean bd_fs_btrfs_check (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[4] = {"btrfsck", device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_BTRFSCK_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (argv, extra, error);
+}
+
+/**
+ * bd_fs_btrfs_repair:
+ * @device: the device containing the file system to repair
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the repair (right now
+ *                                                 passed to the 'btrfsck' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the filesystem was successfully checked and repaired or not
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_REPAIR
+ */
+gboolean bd_fs_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[5] = {"btrfsck", "--repair", device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_BTRFSCK_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (argv, extra, error);
+}
+
+/**
+ * bd_fs_btrfs_set_label:
+ * @mpoint: the mount point of the file system to resize
+ * @label: label to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the label of btrfs file system on the @mpoint was
+ *          successfully set or not
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_SET_LABEL
+ */
+gboolean bd_fs_btrfs_set_label (const gchar *mpoint, const gchar *label, GError **error) {
+    const gchar *argv[6] = {"btrfs", "filesystem", "label", mpoint, label, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_BTRFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (argv, NULL, error);
+}
+
+/**
+ * bd_fs_btrfs_check_label:
+ * @label: label to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @label is a valid label for the btrfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_btrfs_check_label (const gchar *label, GError **error) {
+    if (strlen (label) > 256) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for btrfs filesystem must be at most 256 characters long.");
+        return FALSE;
+    }
+
+    if (strchr (label, '\n') != NULL) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for btrfs filesystem cannot contain new lines.");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * bd_fs_btrfs_set_uuid:
+ * @device: the device containing the file system to set the UUID (serial number) for
+ * @uuid: (allow-none): UUID to set or %NULL to generate a new one
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the UUID of the btrfs file system on the @device was
+ *          successfully set or not
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_SET_UUID
+ */
+gboolean bd_fs_btrfs_set_uuid (const gchar *device, const gchar *uuid, GError **error) {
+    const gchar *args[5] = {"btrfstune", NULL, NULL, NULL, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_BTRFSTUNE_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    if (!uuid) {
+        args[1] = "-u";
+        args[2] = device;
+    } else {
+        args[1] = "-U";
+        args[2] = uuid;
+        args[3] = device;
+    }
+
+    return bd_utils_exec_with_input (args, "y\n", NULL, error);
+}
+
+/**
+ * bd_fs_btrfs_check_uuid:
+ * @uuid: UUID to check
+ * @error: (out) (allow-none): place to store error
+ *
+ * Returns: whether @uuid is a valid UUID for the btrfs file system or not
+ *          (reason is provided in @error)
+ *
+ * Note: This function is intended to be used for btrfs filesystem on a single device,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_btrfs_check_uuid (const gchar *uuid, GError **error) {
+    return check_uuid (uuid, error);
+}
+
+/**
+ * bd_fs_btrfs_get_info:
+ * @mpoint: a mountpoint of the btrfs filesystem to get information about
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the file system on @device or
+ *                           %NULL in case of error
+ *
+ * Note: This function WON'T WORK for multi device btrfs filesystems,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_FS_TECH_BTRFS-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSBtrfsInfo* bd_fs_btrfs_get_info (const gchar *mpoint, GError **error) {
+    const gchar *argv[6] = {"btrfs", "filesystem", "show", "--raw", mpoint, NULL};
+    gchar *output = NULL;
+    gboolean success = FALSE;
+    gchar const * const pattern = "Label:\\s+(none|'(?P<label>.+)')\\s+" \
+                                  "uuid:\\s+(?P<uuid>\\S+)\\s+" \
+                                  "Total\\sdevices\\s+(?P<num_devices>\\d+)\\s+" \
+                                  "FS\\sbytes\\sused\\s+(?P<used>\\S+)\\s+" \
+                                  "devid\\s+1\\s+size\\s+(?P<size>\\S+)\\s+\\S+";
+    GRegex *regex = NULL;
+    GMatchInfo *match_info = NULL;
+    BDFSBtrfsInfo *ret = NULL;
+    gchar *item = NULL;
+    guint64 num_devices = 0;
+    guint64 min_size = 0;
+    gint scanned = 0;
+
+    if (!check_deps (&avail_deps, DEPS_BTRFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    regex = g_regex_new (pattern, G_REGEX_EXTENDED, 0, error);
+    if (!regex) {
+        bd_utils_log_format (BD_UTILS_LOG_WARNING, "Failed to create new GRegex");
+        /* error is already populated */
+        return NULL;
+    }
+
+    success = bd_utils_exec_and_capture_output (argv, NULL, &output, error);
+    if (!success) {
+        /* error is already populated from the call above or just empty
+           output */
+        g_regex_unref (regex);
+        return NULL;
+    }
+
+    success = g_regex_match (regex, output, 0, &match_info);
+    if (!success) {
+        g_regex_unref (regex);
+        g_match_info_free (match_info);
+        g_free (output);
+        return NULL;
+    }
+
+    ret = g_new (BDFSBtrfsInfo, 1);
+
+    ret->label = g_match_info_fetch_named (match_info, "label");
+    ret->uuid = g_match_info_fetch_named (match_info, "uuid");
+
+    item = g_match_info_fetch_named (match_info, "num_devices");
+    num_devices = g_ascii_strtoull (item, NULL, 0);
+    g_free (item);
+    if (num_devices != 1) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Btrfs filesystem mounted on %s spans multiple devices (%"G_GUINT64_FORMAT")." \
+                     "Filesystem plugin is not suitable for multidevice Btrfs volumes, please use " \
+                     "Btrfs plugin instead.", mpoint, num_devices);
+        g_match_info_free (match_info);
+        g_regex_unref (regex);
+        g_free (output);
+        bd_fs_btrfs_info_free (ret);
+        return NULL;
+    }
+
+    item = g_match_info_fetch_named (match_info, "size");
+    ret->size = g_ascii_strtoull (item, NULL, 0);
+    g_free (item);
+
+    g_match_info_free (match_info);
+    g_regex_unref (regex);
+    g_free (output);
+
+    argv[1] = "inspect-internal";
+    argv[2] = "min-dev-size";
+    argv[3] = mpoint;
+    argv[4] = NULL;
+
+    success = bd_utils_exec_and_capture_output (argv, NULL, &output, error);
+    if (!success) {
+        /* error is already populated from the call above or just empty
+           output */
+        bd_fs_btrfs_info_free (ret);
+        return NULL;
+    }
+
+    /* 114032640 bytes (108.75MiB) */
+    scanned = sscanf (output, " %" G_GUINT64_FORMAT " bytes", &min_size);
+    if (scanned != 1) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_PARSE,
+                     "Failed to parse btrfs filesystem min size.");
+        g_free (output);
+        bd_fs_btrfs_info_free (ret);
+        return NULL;
+    }
+
+    g_free (output);
+    ret->free_space = ret->size - min_size;
+
+    return ret;
+}
+
+/**
+ * bd_fs_btrfs_resize:
+ * @mpoint: a mountpoint of the to be resized btrfs filesystem
+ * @new_size: requested new size
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the volume resize (right now
+ *                                                 passed to the 'btrfs' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @mpoint filesystem was successfully resized to @new_size
+ * or not
+ *
+ * Note: This function WON'T WORK for multi device btrfs filesystems,
+ *       for more complicated setups use the btrfs plugin instead.
+ *
+ * Tech category: %BD_BTRFS_TECH_FS-%BD_BTRFS_TECH_MODE_MODIFY
+ */
+gboolean bd_fs_btrfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[6] = {"btrfs", "filesystem", "resize", NULL, mpoint, NULL};
+    gboolean ret = FALSE;
+    BDFSBtrfsInfo *info = NULL;
+
+    if (!check_deps (&avail_deps, DEPS_BTRFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    /* we don't want to allow resizing multidevice btrfs volumes and get_info
+       returns error for these so just try to get the info here */
+    info = bd_fs_btrfs_get_info (mpoint, error);
+    if (!info)
+        return FALSE;
+    bd_fs_btrfs_info_free (info);
+
+    if (new_size == 0)
+        argv[3] = g_strdup ("max");
+    else
+        argv[3] = g_strdup_printf ("%"G_GUINT64_FORMAT, new_size);
+
+    ret = bd_utils_exec_and_report_error (argv, extra, error);
+    g_free ((gchar *) argv[3]);
+
+    return ret;
+}

--- a/src/plugins/fs/btrfs.h
+++ b/src/plugins/fs/btrfs.h
@@ -1,0 +1,28 @@
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_FS_BTRFS
+#define BD_FS_BTRFS
+
+typedef struct BDFSBtrfsInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 size;
+    guint64 free_space;
+} BDFSBtrfsInfo;
+
+BDFSBtrfsInfo* bd_fs_btrfs_info_copy (BDFSBtrfsInfo *data);
+void bd_fs_btrfs_info_free (BDFSBtrfsInfo *data);
+
+gboolean bd_fs_btrfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_btrfs_wipe (const gchar *device, GError **error);
+gboolean bd_fs_btrfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_btrfs_set_label (const gchar *mpoint, const gchar *label, GError **error);
+gboolean bd_fs_btrfs_check_label (const gchar *label, GError **error);
+gboolean bd_fs_btrfs_set_uuid (const gchar *device, const gchar *uuid, GError **error);
+gboolean bd_fs_btrfs_check_uuid ( const gchar *uuid, GError **error);
+BDFSBtrfsInfo* bd_fs_btrfs_get_info (const gchar *mpoint, GError **error);
+gboolean bd_fs_btrfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error);
+
+#endif  /* BD_FS_BTRFS */

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -557,6 +557,35 @@ def fs_exfat_repair(device, extra=None, **kwargs):
     return _fs_exfat_repair(device, extra)
 __all__.append("fs_exfat_repair")
 
+_fs_btrfs_mkfs = BlockDev.fs_btrfs_mkfs
+@override(BlockDev.fs_btrfs_mkfs)
+def fs_btrfs_mkfs(device, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_btrfs_mkfs(device, extra)
+__all__.append("fs_btrfs_mkfs")
+
+_fs_btrfs_check = BlockDev.fs_btrfs_check
+@override(BlockDev.fs_btrfs_check)
+def fs_btrfs_check(device, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_btrfs_check(device, extra)
+__all__.append("fs_btrfs_check")
+
+_fs_btrfs_repair = BlockDev.fs_btrfs_repair
+@override(BlockDev.fs_btrfs_repair)
+def fs_btrfs_repair(device, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_btrfs_repair(device, extra)
+__all__.append("fs_btrfs_repair")
+
+_fs_btrfs_resize = BlockDev.fs_btrfs_resize
+@override(BlockDev.fs_btrfs_resize)
+def fs_btrfs_resize(mpoint, new_size, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_btrfs_resize(mpoint, new_size, extra)
+__all__.append("fs_btrfs_resize")
+
+
 try:
     _kbd_bcache_create = BlockDev.kbd_bcache_create
     @override(BlockDev.kbd_bcache_create)

--- a/tests/fs_tests/btrfs_test.py
+++ b/tests/fs_tests/btrfs_test.py
@@ -1,0 +1,262 @@
+import tempfile
+import six
+
+from .fs_test import FSTestCase, mounted
+
+import overrides_hack
+import utils
+from utils import TestTags, tag_test
+
+from gi.repository import BlockDev, GLib
+
+
+class BtrfsTestCase(FSTestCase):
+
+    loop_size = 500 * 1024**2
+
+    def setUp(self):
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+
+        super(BtrfsTestCase, self).setUp()
+
+        self.mount_dir = tempfile.mkdtemp(prefix="libblockdev.", suffix="btrfs_test")
+
+
+class BtrfsTestMkfs(BtrfsTestCase):
+    def test_btrfs_mkfs(self):
+        """Verify that it is possible to create a new btrfs file system"""
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_btrfs_mkfs("/non/existing/device", None)
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev)
+        self.assertTrue(succ)
+
+        # just try if we can mount the file system
+        with mounted(self.loop_dev, self.mount_dir):
+            pass
+
+        # check the fstype
+        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        self.assertEqual(fstype, "btrfs")
+
+        BlockDev.fs_wipe(self.loop_dev, True)
+
+
+class BtrfsMkfsWithLabel(BtrfsTestCase):
+    def test_btrfs_mkfs_with_label(self):
+        """Verify that it is possible to create a btrfs file system with label"""
+
+        ea = BlockDev.ExtraArg.new("-L", "test_label")
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, [ea])
+        self.assertTrue(succ)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "test_label")
+
+
+class BtrfsTestWipe(BtrfsTestCase):
+    def test_btrfs_wipe(self):
+        """Verify that it is possible to wipe an exfat file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_btrfs_wipe(self.loop_dev)
+        self.assertTrue(succ)
+
+        # already wiped, should fail this time
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_btrfs_wipe(self.loop_dev)
+
+        utils.run("pvcreate -ff -y %s >/dev/null" % self.loop_dev)
+
+        # LVM PV signature, not a btrfs file system
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_btrfs_wipe(self.loop_dev)
+
+        BlockDev.fs_wipe(self.loop_dev, True)
+
+        utils.run("mkfs.ext2 -F %s >/dev/null 2>&1" % self.loop_dev)
+
+        # ext2, not a btrfs file system
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_btrfs_wipe(self.loop_dev)
+
+        BlockDev.fs_wipe(self.loop_dev, True)
+
+
+class BtrfsTestCheck(BtrfsTestCase):
+    def test_btrfs_check(self):
+        """Verify that it is possible to check an btrfs file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_btrfs_check(self.loop_dev, None)
+        self.assertTrue(succ)
+
+
+class BtrfsTestRepair(BtrfsTestCase):
+    def test_btrfs_repair(self):
+        """Verify that it is possible to repair a btrfs file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_btrfs_repair(self.loop_dev, None)
+        self.assertTrue(succ)
+
+
+class BtrfsGetInfo(BtrfsTestCase):
+    def test_btrfs_get_info(self):
+        """Verify that it is possible to get info about a btrfs file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "")
+        # should be an non-empty string
+        self.assertTrue(fi.uuid)
+        self.assertGreater(fi.size, 0)
+        self.assertGreater(fi.free_space, 0)
+        self.assertGreater(fi.size, fi.free_space)
+
+
+class BtrfsSetLabel(BtrfsTestCase):
+    def test_btrfs_set_label(self):
+        """Verify that it is possible to set label of a btrfs file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertTrue(fi)
+            self.assertEqual(fi.label, "")
+
+            succ = BlockDev.fs_btrfs_set_label(self.mount_dir, "test_label")
+            self.assertTrue(succ)
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertTrue(fi)
+            self.assertEqual(fi.label, "test_label")
+
+            succ = BlockDev.fs_btrfs_set_label(self.mount_dir, "test_label2")
+            self.assertTrue(succ)
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertTrue(fi)
+            self.assertEqual(fi.label, "test_label2")
+
+            succ = BlockDev.fs_btrfs_set_label(self.mount_dir, "")
+            self.assertTrue(succ)
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertTrue(fi)
+            self.assertEqual(fi.label, "")
+
+        succ = BlockDev.fs_btrfs_check_label("test_label")
+        self.assertTrue(succ)
+
+        with six.assertRaisesRegex(self, GLib.GError, "at most 256 characters long."):
+            BlockDev.fs_btrfs_check_label(257 * "a")
+
+        with six.assertRaisesRegex(self, GLib.GError, "cannot contain new lines."):
+            BlockDev.fs_btrfs_check_label("a\nb")
+
+
+class BtrfsSetUUID(BtrfsTestCase):
+
+    test_uuid = "4d7086c4-a4d3-432f-819e-73da03870df9"
+
+    def test_btrfs_set_uuid(self):
+        """Verify that it is possible to set UUID of an btrfs file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_btrfs_set_uuid(self.loop_dev, self.test_uuid)
+        self.assertTrue(succ)
+        with mounted(self.loop_dev, self.mount_dir):
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+        self.assertTrue(fi)
+        self.assertEqual(fi.uuid, self.test_uuid)
+
+        # no uuid -> random
+        succ = BlockDev.fs_btrfs_set_uuid(self.loop_dev, None)
+        self.assertTrue(succ)
+        with mounted(self.loop_dev, self.mount_dir):
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+        self.assertTrue(fi)
+        self.assertNotEqual(fi.uuid, "")
+        self.assertNotEqual(fi.uuid, self.test_uuid)
+
+        succ = BlockDev.fs_btrfs_check_uuid(self.test_uuid)
+        self.assertTrue(succ)
+
+        with six.assertRaisesRegex(self, GLib.GError, "not a valid RFC-4122 UUID"):
+            BlockDev.fs_btrfs_check_uuid("aaaaaaa")
+
+
+class BtrfsResize(BtrfsTestCase):
+    def test_btrfs_resize(self):
+        """Verify that it is possible to resize a btrfs file system"""
+
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev)
+        self.assertTrue(succ)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            succ = BlockDev.fs_btrfs_resize(self.mount_dir, 300 * 1024**2)
+            self.assertTrue(succ)
+
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertEqual(fi.size, 300 * 1024**2)
+
+            # grow
+            succ = BlockDev.fs_btrfs_resize(self.mount_dir, 350 * 1024**2)
+            self.assertTrue(succ)
+
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertEqual(fi.size, 350 * 1024**2)
+
+            # shrink again
+            succ = BlockDev.fs_btrfs_resize(self.mount_dir, 300 * 1024**2)
+            self.assertTrue(succ)
+
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertEqual(fi.size, 300 * 1024**2)
+
+            # resize to maximum size
+            succ = BlockDev.fs_btrfs_resize(self.mount_dir, 0)
+            self.assertTrue(succ)
+
+            fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            self.assertEqual(fi.size, self.loop_size)
+
+
+class BtrfsMultiDevice(BtrfsTestCase):
+
+    def _clean_up(self):
+        utils.umount(self.mount_dir)
+        BlockDev.fs_btrfs_wipe(self.loop_dev2)
+
+        super(BtrfsMultiDevice, self)._clean_up()
+
+    def test_btrfs_multidevice(self):
+        """Verify that filesystem plugin returns errors when used on multidevice volumes"""
+
+        ret, _out, _err = utils.run_command("mkfs.btrfs %s %s" % (self.loop_dev, self.loop_dev2))
+        self.assertEqual(ret, 0)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            with six.assertRaisesRegex(self, GLib.GError, "Filesystem plugin is not suitable for multidevice Btrfs volumes"):
+                    BlockDev.fs_btrfs_get_info(self.mount_dir)
+
+        with mounted(self.loop_dev, self.mount_dir):
+            with six.assertRaisesRegex(self, GLib.GError, "Filesystem plugin is not suitable for multidevice Btrfs volumes"):
+                BlockDev.fs_btrfs_resize(self.mount_dir, 0)

--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -86,6 +86,16 @@ class FSTestCase(unittest.TestCase):
         except:
             cls.exfat_avail = False
 
+        try:
+            cls.btrfs_avail = BlockDev.fs_is_tech_avail(BlockDev.FSTech.BTRFS,
+                                                        BlockDev.FSTechMode.MKFS |
+                                                        BlockDev.FSTechMode.RESIZE |
+                                                        BlockDev.FSTechMode.REPAIR |
+                                                        BlockDev.FSTechMode.CHECK |
+                                                        BlockDev.FSTechMode.SET_LABEL)
+        except:
+            cls.btrfs_avail = False
+
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.dev_file = utils.create_sparse_tempfile("fs_test", self.loop_size)

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -366,6 +366,20 @@ class GenericMkfs(GenericTestCase):
 
         self._test_ext_generic_mkfs("xfs", _xfs_info, label, uuid)
 
+    def test_btrfs_generic_mkfs(self):
+        """ Test generic mkfs with Btrfs """
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+        label = "label"
+        uuid = "8802574c-587b-43b9-a6be-9de77759d2c5"
+
+        def _btrfs_info(device):
+            with mounted(device, self.mount_dir):
+                info = BlockDev.fs_btrfs_get_info(self.mount_dir)
+            return info
+
+        self._test_ext_generic_mkfs("btrfs", _btrfs_info, label, uuid)
+
     def test_can_mkfs(self):
         """ Test checking whether mkfs is supported """
         # lets pick a filesystem that supports everything and is always available
@@ -463,6 +477,12 @@ class GenericCheck(GenericTestCase):
             self.skipTest("skipping exFAT: not available")
         self._test_generic_check(mkfs_function=BlockDev.fs_exfat_mkfs)
 
+    def test_btrfs_generic_check(self):
+        """Test generic check function with an btrfs file system"""
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+        self._test_generic_check(mkfs_function=BlockDev.fs_btrfs_mkfs)
+
 
 class GenericRepair(GenericTestCase):
     def _test_generic_repair(self, mkfs_function):
@@ -516,6 +536,12 @@ class GenericRepair(GenericTestCase):
             self.skipTest("skipping exFAT: not available")
         self._test_generic_repair(mkfs_function=BlockDev.fs_exfat_mkfs)
 
+    def test_btrfs_generic_repair(self):
+        """Test generic repair function with an btrfs file system"""
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+        self._test_generic_repair(mkfs_function=BlockDev.fs_btrfs_mkfs)
+
 
 class GenericSetLabel(GenericTestCase):
     def _test_generic_set_label(self, mkfs_function):
@@ -568,6 +594,12 @@ class GenericSetLabel(GenericTestCase):
         if not self.exfat_avail:
             self.skipTest("skipping exFAT: not available")
         self._test_generic_set_label(mkfs_function=BlockDev.fs_exfat_mkfs)
+
+    def test_btrfs_generic_set_label(self):
+        """Test generic set_label function with a btrfs file system"""
+        if not self.btrfs_avail:
+            self.skipTest("skipping btrfs: not available")
+        self._test_generic_set_label(mkfs_function=BlockDev.fs_btrfs_mkfs)
 
 
 class GenericSetUUID(GenericTestCase):
@@ -633,9 +665,15 @@ class GenericSetUUID(GenericTestCase):
             # exfat doesn't support setting UUID
             self._test_generic_set_uuid(mkfs_function=BlockDev.fs_exfat_mkfs)
 
+    def test_btrfs_generic_set_uuid(self):
+        """Test generic set_uuid function with a btrfs file system"""
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+        self._test_generic_set_uuid(mkfs_function=BlockDev.fs_btrfs_mkfs)
+
 
 class GenericResize(GenericTestCase):
-    def _test_generic_resize(self, mkfs_function, size_delta=0):
+    def _test_generic_resize(self, mkfs_function, size_delta=0, min_size=130*1024**2):
         # clean the device
         succ = BlockDev.fs_clean(self.loop_dev)
 
@@ -644,10 +682,10 @@ class GenericResize(GenericTestCase):
         size = BlockDev.fs_get_size(self.loop_dev)
 
         # shrink
-        succ = BlockDev.fs_resize(self.loop_dev, 130 * 1024**2)
+        succ = BlockDev.fs_resize(self.loop_dev, min_size)
         self.assertTrue(succ)
         new_size = BlockDev.fs_get_size(self.loop_dev)
-        self.assertAlmostEqual(new_size, 130 * 1024**2, delta=size_delta)
+        self.assertAlmostEqual(new_size, min_size, delta=size_delta)
 
         # resize to maximum size
         succ = BlockDev.fs_resize(self.loop_dev, 0)
@@ -825,6 +863,12 @@ class GenericResize(GenericTestCase):
         with six.assertRaisesRegex(self, GLib.GError, "Resizing filesystem 'exfat' is not supported."):
             BlockDev.fs_resize(self.loop_dev, 80 * 1024**2)
 
+    def test_btrfs_generic_resize(self):
+        """Test generic resize function with an btrfs file system"""
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+        self._test_generic_resize(mkfs_function=BlockDev.fs_btrfs_mkfs, min_size=300*1024**2)
+
 
 class GenericGetFreeSpace(GenericTestCase):
     def _test_get_free_space(self, mkfs_function, size_delta=0):
@@ -871,6 +915,12 @@ class GenericGetFreeSpace(GenericTestCase):
         if not self.nilfs2_avail:
             self.skipTest("skipping NILFS2: not available")
         self._test_get_free_space(mkfs_function=BlockDev.fs_nilfs2_mkfs)
+
+    def test_btrfs_get_free_space(self):
+        """Test generic resize function with an btrfs file system"""
+        if not self.btrfs_avail:
+            self.skipTest("skipping Btrfs: not available")
+        self._test_get_free_space(mkfs_function=BlockDev.fs_btrfs_mkfs)
 
 
 class FSFreezeTest(GenericTestCase):

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -17,6 +17,9 @@ from gi.repository import BlockDev, GLib
 
 
 class GenericTestCase(FSTestCase):
+
+    loop_size = 500 * 1024**2
+
     def setUp(self):
         super(GenericTestCase, self).setUp()
 


### PR DESCRIPTION
First two commits are from #583 and #585.

The idea here is to provide functions for users that want to use btrfs as a filesystem and not as a volume manager. This implementation also uses only the command line tools so there are no compile time dependencies (as opposed to the btrfs plugin which we plan to rewrite to use libbtrfsutil library, see #552).

Few highlights:
- `resize` and `get_info` functions will fail when called on filesystem that is part of a multidevice btrfs volume. This is indented and we want users to use btrfs plugin for these. Other functions do not check number of btrfs devices and should generally work, but we'll encourage people to not use these on multidevice btrfs volumes.
- Some functions (`resize`, `set_label`...) take moutpoint as an argument and not the device. We already do this for some xfs functions and it probably makes more sense than taking device that must be mounted. The generic functions for resize and other actions that require the device to be mounted will temporarily mount the device if necessary.