### PR TITLE
lvm: Fix bd_lvm_vdopooldata_* symbols

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -360,8 +360,8 @@ GType bd_lvm_lvdata_get_type () {
     return type;
 }
 
-#define BD_LVM_TYPE_VDODATA (bd_lvm_vdodata_get_type ())
-GType bd_lvm_vdodata_get_type();
+#define BD_LVM_TYPE_VDOPOOLDATA (bd_lvm_vdopooldata_get_type ())
+GType bd_lvm_vdopooldata_get_type();
 
 /**
  * BDLVMVDOPooldata:
@@ -388,11 +388,11 @@ typedef struct BDLVMVDOPooldata {
 } BDLVMVDOPooldata;
 
 /**
- * bd_lvm_vdodata_copy: (skip)
+ * bd_lvm_vdopooldata_copy: (skip)
  *
  * Creates a new copy of @data.
  */
-BDLVMVDOPooldata* bd_lvm_vdodata_copy (BDLVMVDOPooldata *data) {
+BDLVMVDOPooldata* bd_lvm_vdopooldata_copy (BDLVMVDOPooldata *data) {
     if (data == NULL)
         return NULL;
 
@@ -411,24 +411,24 @@ BDLVMVDOPooldata* bd_lvm_vdodata_copy (BDLVMVDOPooldata *data) {
 }
 
 /**
- * bd_lvm_vdodata_free: (skip)
+ * bd_lvm_vdopooldata_free: (skip)
  *
  * Frees @data.
  */
-void bd_lvm_vdodata_free (BDLVMVDOPooldata *data) {
+void bd_lvm_vdopooldata_free (BDLVMVDOPooldata *data) {
     if (data == NULL)
         return;
 
     g_free (data);
 }
 
-GType bd_lvm_vdodata_get_type () {
+GType bd_lvm_vdopooldata_get_type () {
     static GType type = 0;
 
     if (G_UNLIKELY(type == 0)) {
         type = g_boxed_type_register_static("BDLVMVDOPooldata",
-                                            (GBoxedCopyFunc) bd_lvm_vdodata_copy,
-                                            (GBoxedFreeFunc) bd_lvm_vdodata_free);
+                                            (GBoxedCopyFunc) bd_lvm_vdopooldata_copy,
+                                            (GBoxedFreeFunc) bd_lvm_vdopooldata_free);
     }
 
     return type;

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -155,7 +155,7 @@ void bd_lvm_lvdata_free (BDLVMLVdata *data) {
     g_free (data);
 }
 
-BDLVMVDOPooldata* bd_lvm_vdodata_copy (BDLVMVDOPooldata *data) {
+BDLVMVDOPooldata* bd_lvm_vdopooldata_copy (BDLVMVDOPooldata *data) {
     if (data == NULL)
         return NULL;
 
@@ -164,14 +164,16 @@ BDLVMVDOPooldata* bd_lvm_vdodata_copy (BDLVMVDOPooldata *data) {
     new_data->operating_mode = data->operating_mode;
     new_data->compression_state = data->compression_state;
     new_data->index_state = data->index_state;
+    new_data->write_policy = data->write_policy;
     new_data->used_size = data->used_size;
     new_data->saving_percent = data->saving_percent;
+    new_data->index_memory_size = data->index_memory_size;
     new_data->deduplication = data->deduplication;
     new_data->compression = data->compression;
     return new_data;
 }
 
-void bd_lvm_vdodata_free (BDLVMVDOPooldata *data) {
+void bd_lvm_vdopooldata_free (BDLVMVDOPooldata *data) {
     if (data == NULL)
         return;
 


### PR DESCRIPTION
There was a discrepancy around struct BDLVMVDOPooldata related functions
between the API file, C header and C source code, likely a typo with
bd_lvm_vdodata_ name prefix. The public API lvm.h that is shipped publicly
defines the correct bd_lvm_vdopooldata_ symbol prefix however any call
to this function results in an unresolved symbol in runtime.

------

#592 cherry picked to 2.x-branch