### PR TITLE
crypto: Add function to get information about LUKS2 tokens

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -111,6 +111,10 @@ BDCryptoIntegrityInfo
 bd_crypto_integrity_info_free
 bd_crypto_integrity_info_copy
 bd_crypto_integrity_info
+BDCryptoLUKSTokenInfo
+bd_crypto_luks_token_info_free
+bd_crypto_luks_token_info_copy
+bd_crypto_luks_token_info
 bd_crypto_tc_open
 bd_crypto_tc_open_full
 bd_crypto_tc_close

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -399,6 +399,66 @@ GType bd_crypto_integrity_info_get_type () {
     return type;
 }
 
+#define BD_CRYPTO_TYPE_LUKS_TOKEN_INFO (bd_crypto_luks_token_info_get_type ())
+GType bd_crypto_luks_token_info_get_type();
+
+/**
+ * BDCryptoLUKSTokenInfo:
+ * @id: ID of the token
+ * @type: type of the token
+ * @keyslot: keyslot this token is assigned to or -1 for inactive/unassigned tokens
+ */
+typedef struct BDCryptoLUKSTokenInfo {
+    guint id;
+    gchar *type;
+    gint keyslot;
+} BDCryptoLUKSTokenInfo;
+
+/**
+ * bd_crypto_luks_token_info_free: (skip)
+ * @info: (allow-none): %BDCryptoLUKSTokenInfo to free
+ *
+ * Frees @info.
+ */
+void bd_crypto_luks_token_info_free (BDCryptoLUKSTokenInfo *info) {
+    if (info == NULL)
+        return;
+
+    g_free (info->type);
+    g_free (info);
+}
+
+/**
+ * bd_crypto_luks_token_info_copy: (skip)
+ * @info: (allow-none): %BDCryptoLUKSTokenInfo to copy
+ *
+ * Creates a new copy of @info.
+ */
+BDCryptoLUKSTokenInfo* bd_crypto_luks_token_info_copy (BDCryptoLUKSTokenInfo *info) {
+    if (info == NULL)
+        return NULL;
+
+    BDCryptoLUKSTokenInfo *new_info = g_new0 (BDCryptoLUKSTokenInfo, 1);
+
+    new_info->id = info->id;
+    new_info->type = g_strdup (info->type);
+    new_info->keyslot = info->keyslot;
+
+    return new_info;
+}
+
+GType bd_crypto_luks_token_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDCryptoLUKSTokenInfo",
+                                            (GBoxedCopyFunc) bd_crypto_luks_token_info_copy,
+                                            (GBoxedFreeFunc) bd_crypto_luks_token_info_free);
+    }
+
+    return type;
+}
+
 /**
  * bd_crypto_is_tech_avail:
  * @tech: the queried tech
@@ -864,6 +924,17 @@ BDCryptoLUKSInfo* bd_crypto_luks_info (const gchar *luks_device, GError **error)
  * Tech category: %BD_CRYPTO_TECH_INTEGRITY-%BD_CRYPTO_TECH_MODE_QUERY
  */
 BDCryptoIntegrityInfo* bd_crypto_integrity_info (const gchar *device, GError **error);
+
+/**
+ * bd_crypto_luks_token_info:
+ * @device: a device to get LUKS2 token information about
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (array zero-terminated=1): information about tokens on @device
+ *
+ * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_QUERY
+ */
+BDCryptoLUKSTokenInfo** bd_crypto_luks_token_info (const gchar *device, GError **error);
 
 /**
  * bd_crypto_device_seems_encrypted:

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -159,6 +159,21 @@ typedef struct BDCryptoIntegrityInfo {
 void bd_crypto_integrity_info_free (BDCryptoIntegrityInfo *info);
 BDCryptoIntegrityInfo* bd_crypto_integrity_info_copy (BDCryptoIntegrityInfo *info);
 
+/**
+ * BDCryptoLUKSTokenInfo:
+ * @id: ID of the token
+ * @type: type of the token
+ * @keyslot: keyslot this token is assigned to or -1 for inactive/unassigned tokens
+ */
+typedef struct BDCryptoLUKSTokenInfo {
+    guint id;
+    gchar *type;
+    gint keyslot;
+} BDCryptoLUKSTokenInfo;
+
+void bd_crypto_luks_token_info_free (BDCryptoLUKSTokenInfo *info);
+BDCryptoLUKSTokenInfo* bd_crypto_luks_token_info_copy (BDCryptoLUKSTokenInfo *info);
+
 /*
  * If using the plugin as a standalone library, the following functions should
  * be called to:
@@ -204,6 +219,7 @@ gboolean bd_crypto_luks_header_restore (const gchar *device, const gchar *backup
 
 BDCryptoLUKSInfo* bd_crypto_luks_info (const gchar *luks_device, GError **error);
 BDCryptoIntegrityInfo* bd_crypto_integrity_info (const gchar *device, GError **error);
+BDCryptoLUKSTokenInfo** bd_crypto_luks_token_info (const gchar *device, GError **error);
 
 gboolean bd_crypto_device_seems_encrypted (const gchar *device, GError **error);
 gboolean bd_crypto_tc_open (const gchar *device, const gchar *name, const guint8* pass_data, gsize data_len, gboolean read_only, GError **error);


### PR DESCRIPTION
Blivet needs this for Stratis support (https://github.com/storaged-project/blivet/pull/915). Encrypted Stratis pools must be unlocked using Stratis API and only way to check whether a LUKS device is actually a "Stratis LUKS device" is by checking tokens (Stratis has a special "stratis" type token).