### PR TITLE
remove unused variable and fix build with LLVM/clang

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -249,7 +249,6 @@ static gboolean setup_dbus_connection (GError **error) {
     return TRUE;
 }
 
-static volatile guint avail_deps = 0;
 static volatile guint avail_dbus_deps = 0;
 static volatile guint avail_features = 0;
 static volatile guint avail_module_deps = 0;


### PR DESCRIPTION
lvm-dbus.c:244:23: error: unused variable 'avail_deps' [-Werror,-Wunused-variable]