### PR TITLE
crypto: Remove bd_crypto_luks_uuid function

### DIFF
--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -28,6 +28,14 @@
 
   </simplesect>
 
+  <simplesect><title>Crypto plugin</title>
+
+  <para>
+    <literal>bd_crypto_luks_uuid()</literal> has been removed, use <literal>uuid</literal> from <link linkend="BDCryptoLUKSInfo">BDCryptoLUKSInfo</link> instead.
+  </para>
+
+  </simplesect>
+
   <simplesect><title>NVDIMM plugin</title>
   <para>
     <literal>bd_nvdimm_namepace_get_supported_sector_sizes</literal> has been removed, use <literal>bd_nvdimm_namespace_get_supported_sector_sizes</literal> instead.

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -65,7 +65,6 @@ BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH
 bd_crypto_generate_backup_passphrase
 bd_crypto_device_is_luks
 bd_crypto_device_seems_encrypted
-bd_crypto_luks_uuid
 bd_crypto_luks_get_metadata_size
 bd_crypto_luks_status
 bd_crypto_luks_format

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -609,18 +609,6 @@ gchar* bd_crypto_generate_backup_passphrase(GError **error);
 gboolean bd_crypto_device_is_luks (const gchar *device, GError **error);
 
 /**
- * bd_crypto_luks_uuid:
- * @device: the queried device
- * @error: (out) (optional): place to store error (if any)
- *
- * Returns: UUID of the @device or %NULL if failed to determine (@error
- * is populated with the error in such cases)
- *
- * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_QUERY
- */
-gchar* bd_crypto_luks_uuid (const gchar *device, GError **error);
-
-/**
  * bd_crypto_luks_get_metadata_size:
  * @device: the queried device
  * @error: (out) (optional): place to store error (if any)

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -583,42 +583,6 @@ gboolean bd_crypto_device_is_luks (const gchar *device, GError **error) {
 }
 
 /**
- * bd_crypto_luks_uuid:
- * @device: the queried device
- * @error: (out) (optional): place to store error (if any)
- *
- * Returns: (transfer full): UUID of the @device or %NULL if failed to determine (@error
- * is populated with the error in such cases)
- *
- * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_QUERY
- */
-gchar* bd_crypto_luks_uuid (const gchar *device, GError **error) {
-    struct crypt_device *cd = NULL;
-    gint ret_num;
-    gchar *ret;
-
-    ret_num = crypt_init (&cd, device);
-    if (ret_num != 0) {
-        g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
-                     "Failed to initialize device: %s", strerror_l(-ret_num, c_locale));
-        return NULL;
-    }
-
-    ret_num = crypt_load (cd, CRYPT_LUKS, NULL);
-    if (ret_num != 0) {
-        g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
-                     "Failed to load device: %s", strerror_l(-ret_num, c_locale));
-        crypt_free (cd);
-        return NULL;
-    }
-
-    ret = g_strdup (crypt_get_uuid (cd));
-    crypt_free (cd);
-
-    return ret;
-}
-
-/**
  * bd_crypto_get_luks_metadata_size:
  * @device: the queried device
  * @error: (out) (optional): place to store error (if any)

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -224,7 +224,6 @@ gboolean bd_crypto_is_tech_avail (BDCryptoTech tech, guint64 mode, GError **erro
 
 gchar* bd_crypto_generate_backup_passphrase(GError **error);
 gboolean bd_crypto_device_is_luks (const gchar *device, GError **error);
-gchar* bd_crypto_luks_uuid (const gchar *device, GError **error);
 guint64 bd_crypto_luks_get_metadata_size (const gchar *device, GError **error);
 gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint64 key_size, const gchar *passphrase, const gchar *key_file, guint64 min_entropy, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -1091,6 +1091,12 @@ def loop_get_backing_file(dev_name):
 __all__.append("loop_get_backing_file")
 
 
+def crypto_luks_uuid(device):
+    info = BlockDev.crypto_luks_info(device)
+    return info.uuid
+__all__.append("crypto_luks_uuid")
+
+
 XRule = namedtuple("XRule", ["orig_exc", "regexp", "code", "new_exc"])
 # XXX: how to document namedtuple fields?
 """

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -570,28 +570,6 @@ class CryptoTestLuksStatus(CryptoTestCase):
     def test_luks2_status(self):
         self._luks_status(self._luks2_format)
 
-class CryptoTestGetUUID(CryptoTestCase):
-    def _get_uuid(self, create_fn):
-        """Verify that getting LUKS device UUID works"""
-
-        succ = create_fn(self.loop_dev, PASSWD, None)
-        self.assertTrue(succ)
-
-        uuid = BlockDev.crypto_luks_uuid(self.loop_dev)
-        self.assertTrue(uuid)
-
-        with self.assertRaises(GLib.GError):
-            uuid = BlockDev.crypto_luks_uuid(self.loop_dev2)
-
-    @tag_test(TestTags.SLOW)
-    def test_luks_get_uuid(self):
-        self._get_uuid(self._luks_format)
-
-    @tag_test(TestTags.SLOW)
-    @unittest.skipUnless(HAVE_LUKS2, "LUKS 2 not supported")
-    def test_luks2_get_uuid(self):
-        self._get_uuid(self._luks2_format)
-
 class CryptoTestGetMetadataSize(CryptoTestCase):
 
     @tag_test(TestTags.SLOW)
@@ -717,7 +695,8 @@ class CryptoTestEscrow(CryptoTestCase):
         self.assertTrue(succ)
 
         # Find the escrow packet
-        escrow_packet_file = '%s/%s-escrow' % (escrow_dir, BlockDev.crypto_luks_uuid(self.loop_dev))
+        info = BlockDev.crypto_luks_info(self.loop_dev)
+        escrow_packet_file = '%s/%s-escrow' % (escrow_dir, info.uuid)
         self.assertTrue(os.path.isfile(escrow_packet_file))
 
         # Use the volume_key utility (see note in setUp about why not python)
@@ -760,7 +739,8 @@ class CryptoTestEscrow(CryptoTestCase):
         self.assertTrue(succ)
 
         # Find the backup passphrase
-        escrow_backup_passphrase = "%s/%s-escrow-backup-passphrase" % (escrow_dir, BlockDev.crypto_luks_uuid(self.loop_dev))
+        info = BlockDev.crypto_luks_info(self.loop_dev)
+        escrow_backup_passphrase = "%s/%s-escrow-backup-passphrase" % (escrow_dir, info.uuid)
         self.assertTrue(os.path.isfile(escrow_backup_passphrase))
 
         # Check that the encrypted file contains what we put in


### PR DESCRIPTION
Users should use bd_crypto_luks_info instead.

Separated from #614 so we can merge it without API change.