### PR TITLE
crypto: Fix default key size for non XTS ciphers

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -774,8 +774,15 @@ static gboolean luks_format (const gchar *device, const gchar *cipher, guint64 k
         return FALSE;
     }
 
-    /* resolve requested/default key_size (should be in bytes) */
-    key_size = (key_size != 0) ? (key_size / 8) : (DEFAULT_LUKS_KEYSIZE_BITS / 8);
+    if (key_size == 0) {
+        if (g_str_has_prefix (cipher_specs[1], "xts-"))
+            key_size = DEFAULT_LUKS_KEYSIZE_BITS * 2;
+        else
+            key_size = DEFAULT_LUKS_KEYSIZE_BITS;
+    }
+
+    /* key_size should be in bytes */
+    key_size = key_size / 8;
 
     /* wait for enough random data entropy (if requested) */
     if (min_entropy > 0) {

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -36,7 +36,7 @@ typedef enum {
 /* 20 chars * 6 bits per char (64-item charset) = 120 "bits of security" */
 #define BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH 20
 
-#define DEFAULT_LUKS_KEYSIZE_BITS 512
+#define DEFAULT_LUKS_KEYSIZE_BITS 256
 #define DEFAULT_LUKS_CIPHER "aes-xts-plain64"
 #define DEFAULT_LUKS2_SECTOR_SIZE 512
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -236,6 +236,42 @@ class CryptoTestFormat(CryptoTestCase):
             self.fail("Failed to get pbkdf information from:\n%s %s" % (out, err))
         self.assertEqual(int(m.group(1)), 5)
 
+    def _get_luks1_key_size(self, device):
+        _ret, out, err = run_command("cryptsetup luksDump %s" % device)
+        m = re.search(r"MK bits:\s*(\S+)\s*", out)
+        if not m or len(m.groups()) != 1:
+            self.fail("Failed to get key size information from:\n%s %s" % (out, err))
+        key_size = m.group(1)
+        if not key_size.isnumeric():
+            self.fail("Failed to get key size information from: %s" % key_size)
+        return int(key_size)
+
+    @tag_test(TestTags.SLOW, TestTags.CORE)
+    def test_luks_format_key_size(self):
+        """Verify that formating device as LUKS works"""
+
+        # aes-xts: key size should default to 512
+        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, PASSWD, None, 0)
+        self.assertTrue(succ)
+
+        key_size = self._get_luks1_key_size(self.loop_dev)
+        self.assertEqual(key_size, 512)
+
+        # aes-cbc: key size should default to 256
+        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-cbc-essiv:sha256", 0, PASSWD, None, 0)
+        self.assertTrue(succ)
+
+        key_size = self._get_luks1_key_size(self.loop_dev)
+        self.assertEqual(key_size, 256)
+
+        # try specifying key size for aes-xts
+        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 256, PASSWD, None, 0)
+        self.assertTrue(succ)
+
+        key_size = self._get_luks1_key_size(self.loop_dev)
+        self.assertEqual(key_size, 256)
+
+
 class CryptoTestResize(CryptoTestCase):
 
     def _get_key_location(self, device):


### PR DESCRIPTION
512 bits should be default only for AES-XTS which needs two keys,
default for other modes must be 256 bits.

resolves: rhbz#1931847