### PR TITLE
crypto: Fix default key size for non XTS ciphers

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -50,7 +50,7 @@
 
 #define SECTOR_SIZE 512
 
-#define DEFAULT_LUKS_KEYSIZE_BITS 512
+#define DEFAULT_LUKS_KEYSIZE_BITS 256
 #define DEFAULT_LUKS_CIPHER "aes-xts-plain64"
 #define DEFAULT_LUKS2_SECTOR_SIZE 512
 
@@ -797,8 +797,15 @@ static gboolean luks_format (const gchar *device, const gchar *cipher, guint64 k
         return FALSE;
     }
 
-    /* resolve requested/default key_size (should be in bytes) */
-    key_size = (key_size != 0) ? (key_size / 8) : (DEFAULT_LUKS_KEYSIZE_BITS / 8);
+    if (key_size == 0) {
+        if (g_str_has_prefix (cipher_specs[1], "xts-"))
+            key_size = DEFAULT_LUKS_KEYSIZE_BITS * 2;
+        else
+            key_size = DEFAULT_LUKS_KEYSIZE_BITS;
+    }
+
+    /* key_size should be in bytes */
+    key_size = key_size / 8;
 
     /* wait for enough random data entropy (if requested) */
     if (min_entropy > 0) {


### PR DESCRIPTION
512 bits should be default only for AES-XTS which needs two keys,
default for other modes must be 256 bits.

resolves: rhbz#1931847