### PR TITLE
vfat: Add check for invalid characters in bd_fs_vfat_check_label()

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1840,6 +1840,8 @@ gboolean bd_fs_xfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraA
  *                                                 passed to the 'mkfs.vfat' utility)
  * @error: (out): place to store error (if any)
  *
+ * Please remember that FAT labels should always be uppercase.
+ *
  * Returns: whether a new vfat fs was successfully created on @device or not
  *
  * Tech category: %BD_FS_TECH_VFAT-%BD_FS_TECH_MODE_MKFS

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -288,11 +288,25 @@ gboolean bd_fs_vfat_set_label (const gchar *device, const gchar *label, GError *
  * Tech category: always available
  */
 gboolean bd_fs_vfat_check_label (const gchar *label, GError **error) {
+    const gchar *forbidden = "\"*/:<>?\\|";
+    guint n;
+
     if (strlen (label) > 11) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
                      "Label for VFAT filesystem must be at most 11 characters long.");
         return FALSE;
     }
+
+    /* VFAT does not allow some characters; as dosfslabel does not enforce this,
+     * check in advance; also, VFAT only knows upper-case characters, dosfslabel
+     * enforces this */
+    for (n = 0; forbidden[n] != 0; n++)
+        if (strchr (label, forbidden[n]) != NULL) {
+            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                         "Invalid label: character '%c' not supported in VFAT labels.",
+                         forbidden[n]);
+            return FALSE;
+        }
 
     return TRUE;
 }


### PR DESCRIPTION
Backported from UDisks: udiskslinuxfilesystem.c:handle_set_label()