### PR TITLE
Fix skipping tests on Debian testing

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -27,7 +27,7 @@
 - test: fs_tests.mount_test.MountTestCase.test_mount_ntfs_ro
   skip_on:
     - distro: "debian"
-      version: ["10", "testing"]
+      version: ["10", "11", "testing"]
       reason: "NTFS mounting of read-only devices doesn't work as expected on Debian"
 
 - test: kbd_test.KbdZRAM*
@@ -65,5 +65,5 @@
 - test: fs_tests.mount_test.MountTestCase.test_mount_ntfs
   skip_on:
     - distro: "debian"
-      version: "testing"
+      version: ["11", "testing"]
       reason: "mount.ntfs-3g randomly hangs on Debian testing"


### PR DESCRIPTION
Testing now identifies itself as "Debian GNU/Linux 11 (bullseye)"
so the tests that should be skipped on testing needs to be skipped
on "11" too.