### PR TITLE
tests: Temporarily skip test_snapshotcreate_lvorigin_snapshotmerge

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -67,3 +67,9 @@
     - distro: "debian"
       version: "testing"
       reason: "mount.ntfs-3g randomly hangs on Debian testing"
+
+- test: lvm_dbus_tests.LvmTestLVsnapshots.test_snapshotcreate_lvorigin_snapshotmerge
+  skip_on:
+    - distro: "centos"
+      version: "9"
+      reason: "snapshot merge doesn't work on CentOS 9 Stream with LVM DBus API"


### PR DESCRIPTION
With LVM DBus API the lvconvert job is never finished which means
the test run never finishes in our CI.