### PR TITLE
lvm-dbus: Report error when function returns no object and no job

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -690,6 +690,17 @@ static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gch
         } else {
             g_variant_unref (ret);
             g_free (obj_path);
+            if (g_strcmp0 (task_path, "/") == 0) {
+                log_msg = g_strdup_printf ("Task finished without result and without job started");
+                g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_FAIL,
+                             "Running '%s' method on the '%s' object failed: %s",
+                             method, obj, log_msg);
+                bd_utils_log_task_status (log_task_id, log_msg);
+                bd_utils_report_finished (prog_id, log_msg);
+                g_free (task_path);
+                g_free (log_msg);
+                return;
+            }
         }
     } else if (g_variant_check_format_string (ret, "(o)", TRUE)) {
         g_variant_get (ret, "(o)", &task_path);

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -67,3 +67,9 @@
     - distro: "debian"
       version: "testing"
       reason: "mount.ntfs-3g randomly hangs on Debian testing"
+
+- test: lvm_dbus_tests.LvmTestLVsnapshots.test_snapshotcreate_lvorigin_snapshotmerge
+  skip_on:
+    - distro: "centos"
+      version: "9"
+      reason: "snapshot merge doesn't work on CentOS 9 Stream with LVM DBus API"


### PR DESCRIPTION
For functions that return two object paths, one of them must be
a valid path -- either the function returns a newly created object
or a valid job, if it return "/", "/" we should report error.

-----

Still not sure why is this happening but `PvCreate` currently returns `("/", "/")` on CentOS 9 which means we are trying to query progress on `/`:

```
[28] Done.
[28] Waiting for job '/' to finish
[28] Job '/' finished
gi.repository.GLib.GError: g-dbus-error-quark: Waiting for 'PvCreate' method of the '/com/redhat/lvmdbus1/Manager' object to finish failed: Failed to get Complete property of the / object: GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Method "Get" with signature "ss" on interface "org.freedesktop.DBus.Properties" doesn't exist (19)
```