### PR TITLE
Do not check that XFS shrink fails with xfsprogs >= 5.12

### DIFF
--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -1,8 +1,10 @@
 import os
+import re
 import subprocess
 import unittest
 
 from contextlib import contextmanager
+from distutils.version import LooseVersion
 
 import utils
 import overrides_hack
@@ -148,3 +150,10 @@ class FSTestCase(unittest.TestCase):
         ret, _out, _err = utils.run_command("blockdev --setrw %s" % device)
         if ret != 0:
             self.fail("Failed to set %s read-write" % device)
+
+    def _get_xfs_version(self):
+        _ret, out, _err = utils.run_command("mkfs.xfs -V")
+        m = re.search(r"mkfs\.xfs version ([\d\.]+)", out)
+        if not m or len(m.groups()) != 1:
+            raise RuntimeError("Failed to determine xfsprogs version from: %s" % out)
+        return LooseVersion(m.groups()[0])

--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -13,8 +13,11 @@ from gi.repository import BlockDev
 @contextmanager
 def mounted(device, where, ro=False):
     utils.mount(device, where, ro)
-    yield
-    utils.umount(where)
+
+    try:
+        yield
+    finally:
+        utils.umount(where)
 
 
 def check_output(args, ignore_retcode=True):

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -847,9 +847,11 @@ class GenericResize(GenericTestCase):
         self.assertEqual(fi.block_size * fi.block_count, 50 * 1024**2)
 
         # (still) impossible to shrink an XFS file system
-        with mounted(lv, self.mount_dir):
-            with self.assertRaises(GLib.GError):
-                succ = BlockDev.fs_resize(lv, 40 * 1024**2)
+        xfs_version = self._get_xfs_version()
+        if xfs_version < LooseVersion("5.1.12"):
+            with mounted(lv, self.mount_dir):
+                with self.assertRaises(GLib.GError):
+                    succ = BlockDev.fs_resize(lv, 40 * 1024**2)
 
         utils.run("lvresize -L70M libbd_fs_tests/xfs_test >/dev/null 2>&1")
         # should grow


### PR DESCRIPTION
So XFS now has experimental support for shrinking in `xfs_growfs`. This was not really publicly announced and I'm not sure how stable and safe it is but we definitely need more work before we support it (especially adding some free space variable to `BDFSXfsInfo`) so let's just skip the test for now with newest xfsprogs.