### PR TITLE
exec: Fix deprecated glib function call

### DIFF
--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -229,7 +229,12 @@ gboolean bd_utils_exec_and_report_status_error (const gchar **argv, const BDExtr
     /* g_spawn_sync set the status in the same way waitpid() does, we need
        to get the process exit code manually (this is similar to calling
        WEXITSTATUS but also sets the error for terminated processes */
-    if (!g_spawn_check_exit_status (exit_status, &l_error)) {
+
+    #if !GLIB_CHECK_VERSION(2, 69, 0)
+    #define g_spawn_check_wait_status(x) (g_spawn_check_exit_status (x))
+    #endif
+
+    if (!g_spawn_check_wait_status (exit_status, &l_error)) {
         if (g_error_matches (l_error, G_SPAWN_ERROR, G_SPAWN_ERROR_FAILED)) {
             /* process was terminated abnormally (e.g. using a signal) */
             g_free (stdout_data);


### PR DESCRIPTION
Glib will rename "g_spawn_check_exit_status()" to "g_spawn_check_wait_status()"
in version 2.69.