### PR TITLE
Add new argument for bd_fs_wipe/clean to control force wipe

### DIFF
--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -33,5 +33,12 @@
     <literal>bd_nvdimm_namepace_get_supported_sector_sizes</literal> has been removed, use <literal>bd_nvdimm_namespace_get_supported_sector_sizes</literal> instead.
   </para>
 
+  <simplesect><title>FS plugin</title>
+  <para>
+    <literal>bd_fs_clean</literal> and <literal>bd_fs_wipe</literal> have new parameter <literal>force</literal>
+    that allows controlling whether the signatures will be removed from a mounted device or not. Use
+    <literal>TRUE</literal> to preserve the original behaviour.
+  </para>
+
   </simplesect>
 </chapter>

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -884,17 +884,19 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
  * bd_fs_wipe:
  * @device: the device to wipe signatures from
  * @all: whether to wipe all (%TRUE) signatures or just the first (%FALSE) one
+ * @force: whether to wipe signatures on a mounted @device
  * @error: (out): place to store error (if any)
  *
  * Returns: whether signatures were successfully wiped on @device or not
  *
  * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_WIPE
  */
-gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
+gboolean bd_fs_wipe (const gchar *device, gboolean all, gboolean force, GError **error);
 
 /**
  * bd_fs_clean:
  * @device: the device to clean
+ * @force: whether to wipe signatures on a mounted @device
  * @error: (out): place to store error (if any)
  *
  * Clean all signatures from @device.
@@ -906,7 +908,7 @@ gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
  *
  * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_WIPE
  */
-gboolean bd_fs_clean (const gchar *device, GError **error);
+gboolean bd_fs_clean (const gchar *device, gboolean force, GError **error);
 
 /**
  * bd_fs_get_fstype:

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -3,8 +3,8 @@
 #ifndef BD_FS_GENERIC
 #define BD_FS_GENERIC
 
-gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
-gboolean bd_fs_clean (const gchar *device, GError **error);
+gboolean bd_fs_wipe (const gchar *device, gboolean all, gboolean force, GError **error) ;
+gboolean bd_fs_clean (const gchar *device, gboolean force, GError **error);
 gchar* bd_fs_get_fstype (const gchar *device,  GError **error);
 
 gboolean bd_fs_freeze (const gchar *mountpoint, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -349,6 +349,18 @@ def loop_setup(file, offset=0, size=0, read_only=False, part_scan=True):
 __all__.append("loop_setup")
 
 
+_fs_wipe = BlockDev.fs_wipe
+@override(BlockDev.fs_wipe)
+def fs_wipe(spec, all=False, force=False):
+    return _fs_wipe(spec, all, force)
+__all__.append("fs_wipe")
+
+_fs_clean = BlockDev.fs_clean
+@override(BlockDev.fs_clean)
+def fs_clean(spec, force=False):
+    return _fs_clean(spec, force)
+__all__.append("fs_clean")
+
 _fs_unmount = BlockDev.fs_unmount
 @override(BlockDev.fs_unmount)
 def fs_unmount(spec, lazy=False, force=False, extra=None, **kwargs):


### PR DESCRIPTION
Our current implementation allows to wipe mounted devices by
default, we should let users decide whether they want it or not.

Fixes: #483 

Related #484 and https://github.com/storaged-project/udisks/pull/901