### PR TITLE
Support for LVM devices file

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -1807,4 +1807,30 @@ GHashTable* bd_lvm_vdo_get_stats_full (const gchar *vg_name, const gchar *pool_n
  */
 BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_name, GError **error);
 
+/**
+ * bd_lvm_devices_add:
+ * @device: device (PV) to add to the devices file
+ * @devices_file: (allow-none): LVM devices file or %NULL for default
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the lvmdevices command
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully added to @devices_file or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_devices_add (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_lvm_devices_delete:
+ * @device: device (PV) to delete from the devices file
+ * @devices_file: (allow-none): LVM devices file or %NULL for default
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the lvmdevices command
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully removed from @devices_file or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_devices_delete (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error);
+
 #endif  /* BD_LVM_API */

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -625,6 +625,7 @@ typedef enum {
     BD_LVM_TECH_GLOB_CONF,
     BD_LVM_TECH_VDO,
     BD_LVM_TECH_WRITECACHE,
+    BD_LVM_TECH_DEVICES,
 } BDLVMTech;
 
 typedef enum {
@@ -1311,6 +1312,28 @@ gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error);
  * Tech category: %BD_LVM_TECH_GLOB_CONF no mode (it is ignored)
  */
 gchar* bd_lvm_get_global_config (GError **error);
+
+/**
+ * bd_lvm_set_devices_filter:
+ * @devices: (allow-none) (array zero-terminated=1): list of devices for lvm commands to work on
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the devices filter was successfully set or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_set_devices_filter (const gchar **devices, GError **error);
+
+/**
+ * bd_lvm_get_devices_filter:
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (array zero-terminated=1): a copy of a string representation of
+ *                                                     the currently set LVM devices filter
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gchar** bd_lvm_get_devices_filter (GError **error);
 
 /**
  * bd_lvm_cache_get_default_md_size:

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -4302,3 +4302,55 @@ BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_nam
 
     return stats;
 }
+
+/**
+ * bd_lvm_devices_add:
+ * @device: device (PV) to add to the devices file
+ * @devices_file: (allow-none): LVM devices file or %NULL for default
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the lvmdevices command
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully added to @devices_file or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_devices_add (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"lvmdevices", "--adddev", device, NULL, NULL};
+    g_autofree gchar *devfile = NULL;
+
+    if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
+        return FALSE;
+
+    if (devices_file) {
+        devfile = g_strdup_printf ("--devicesfile=%s", devices_file);
+        args[3] = devfile;
+    }
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}
+
+/**
+ * bd_lvm_devices_delete:
+ * @device: device (PV) to delete from the devices file
+ * @devices_file: (allow-none): LVM devices file or %NULL for default
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the lvmdevices command
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully removed from @devices_file or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_devices_delete (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"lvmdevices", "--deldev", device, NULL, NULL};
+    g_autofree gchar *devfile = NULL;
+
+    if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
+        return FALSE;
+
+    if (devices_file) {
+        devfile = g_strdup_printf ("--devicesfile=%s", devices_file);
+        args[3] = devfile;
+    }
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -48,6 +48,8 @@
 static GMutex global_config_lock;
 static gchar *global_config_str = NULL;
 
+static gchar *global_devices_str = NULL;
+
 #define LVM_BUS_NAME "com.redhat.lvmdbus1"
 #define LVM_OBJ_PREFIX "/com/redhat/lvmdbus1"
 #define MANAGER_OBJ "/com/redhat/lvmdbus1/Manager"
@@ -257,10 +259,19 @@ static gboolean setup_dbus_connection (GError **error) {
     return TRUE;
 }
 
+static volatile guint avail_deps = 0;
 static volatile guint avail_dbus_deps = 0;
 static volatile guint avail_features = 0;
 static volatile guint avail_module_deps = 0;
 static GMutex deps_check_lock;
+
+#define DEPS_LVMDEVICES 0
+#define DEPS_LVMDEVICES_MASK (1 << DEPS_LVMDEVICES)
+#define DEPS_LAST 1
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"lvmdevices", NULL, NULL, NULL},
+};
 
 #define DBUS_DEPS_LVMDBUSD 0
 #define DBUS_DEPS_LVMDBUSD_MASK (1 << DBUS_DEPS_LVMDBUSD)
@@ -405,6 +416,8 @@ gboolean bd_lvm_is_tech_avail (BDLVMTech tech, guint64 mode, GError **error) {
     case BD_LVM_TECH_WRITECACHE:
         return check_dbus_deps (&avail_dbus_deps, DBUS_DEPS_LVMDBUSD_MASK|DBUS_DEPS_LVMDBUSD_WRITECACHE_MASK, dbus_deps, DBUS_DEPS_LAST, &deps_check_lock, error) &&
                check_features (&avail_features, FEATURES_WRITECACHE_MASK, features, FEATURES_LAST, &deps_check_lock, error);
+    case BD_LVM_TECH_DEVICES:
+        return check_deps (&avail_deps, DEPS_LVMDEVICES_MASK, deps, DEPS_LAST, &deps_check_lock, error);
     default:
         /* everything is supported by this implementation of the plugin */
         return check_dbus_deps (&avail_dbus_deps, DBUS_DEPS_LVMDBUSD_MASK, dbus_deps, DBUS_DEPS_LAST, &deps_check_lock, error);
@@ -542,6 +555,7 @@ static gboolean unbox_params_and_add (GVariant *params, GVariantBuilder *builder
 
 static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, guint64 *task_id, guint64 *progress_id, gboolean lock_config, GError **error) {
     GVariant *config = NULL;
+    GVariant *devices = NULL;
     GVariant *param = NULL;
     GVariantIter iter;
     GVariantBuilder builder;
@@ -563,8 +577,8 @@ static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gch
     if (lock_config)
         g_mutex_lock (&global_config_lock);
 
-    if (global_config_str || extra_params || extra_args) {
-        if (global_config_str || extra_args) {
+    if (global_config_str || global_devices_str || extra_params || extra_args) {
+        if (global_config_str || global_devices_str || extra_args) {
             /* add the global config to the extra_params */
             g_variant_builder_init (&extra_builder, G_VARIANT_TYPE_DICTIONARY);
 
@@ -583,6 +597,11 @@ static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gch
             if (global_config_str) {
                 config = g_variant_new ("s", global_config_str);
                 g_variant_builder_add (&extra_builder, "{sv}", "--config", config);
+                added_extra = TRUE;
+            }
+            if (global_devices_str) {
+                devices = g_variant_new ("s", global_devices_str);
+                g_variant_builder_add (&extra_builder, "{sv}", "--devices", devices);
                 added_extra = TRUE;
             }
 
@@ -3001,6 +3020,58 @@ gchar* bd_lvm_get_global_config (GError **error UNUSED) {
 
     g_mutex_lock (&global_config_lock);
     ret = g_strdup (global_config_str ? global_config_str : "");
+    g_mutex_unlock (&global_config_lock);
+
+    return ret;
+}
+
+/**
+ * bd_lvm_set_devices_filter:
+ * @devices: (allow-none) (array zero-terminated=1): list of devices for lvm commands to work on
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the devices filter was successfully set or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_set_devices_filter (const gchar **devices, GError **error) {
+    if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
+        return FALSE;
+
+    g_mutex_lock (&global_config_lock);
+
+    /* first free the old value */
+    g_free (global_devices_str);
+
+    /* now store the new one */
+    if (!devices || !(*devices))
+        global_devices_str = NULL;
+    else
+        global_devices_str = g_strjoinv (",", (gchar **) devices);
+
+    g_mutex_unlock (&global_config_lock);
+    return TRUE;
+}
+
+/**
+ * bd_lvm_get_devices_filter:
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (array zero-terminated=1): a copy of a string representation of
+ *                                                     the currently set LVM devices filter
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gchar** bd_lvm_get_devices_filter (GError **error UNUSED) {
+    gchar **ret = NULL;
+
+    g_mutex_lock (&global_config_lock);
+
+    if (global_devices_str)
+        ret = g_strsplit (global_devices_str, ",", -1);
+    else
+        ret = NULL;
+
     g_mutex_unlock (&global_config_lock);
 
     return ret;

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -3438,3 +3438,55 @@ BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_nam
 
     return stats;
 }
+
+/**
+ * bd_lvm_devices_add:
+ * @device: device (PV) to add to the devices file
+ * @devices_file: (allow-none): LVM devices file or %NULL for default
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the lvmdevices command
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully added to @devices_file or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_devices_add (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"lvmdevices", "--adddev", device, NULL, NULL};
+    g_autofree gchar *devfile = NULL;
+
+    if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
+        return FALSE;
+
+    if (devices_file) {
+        devfile = g_strdup_printf ("--devicesfile=%s", devices_file);
+        args[3] = devfile;
+    }
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}
+
+/**
+ * bd_lvm_devices_delete:
+ * @device: device (PV) to delete from the devices file
+ * @devices_file: (allow-none): LVM devices file or %NULL for default
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the lvmdevices command
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully removed from @devices_file or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_devices_delete (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"lvmdevices", "--deldev", device, NULL, NULL};
+    g_autofree gchar *devfile = NULL;
+
+    if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
+        return FALSE;
+
+    if (devices_file) {
+        devfile = g_strdup_printf ("--devicesfile=%s", devices_file);
+        args[3] = devfile;
+    }
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -49,6 +49,8 @@
 static GMutex global_config_lock;
 static gchar *global_config_str = NULL;
 
+static gchar *global_devices_str = NULL;
+
 /**
  * SECTION: lvm
  * @short_description: plugin for operations with LVM
@@ -233,10 +235,13 @@ static GMutex deps_check_lock;
 
 #define DEPS_LVM 0
 #define DEPS_LVM_MASK (1 << DEPS_LVM)
-#define DEPS_LAST 1
+#define DEPS_LVMDEVICES 1
+#define DEPS_LVMDEVICES_MASK (1 << DEPS_LVMDEVICES)
+#define DEPS_LAST 2
 
 static const UtilDep deps[DEPS_LAST] = {
     {"lvm", LVM_MIN_VERSION, "version", "LVM version:\\s+([\\d\\.]+)"},
+    {"lvmdevices", NULL, NULL, NULL},
 };
 
 #define FEATURES_VDO 0
@@ -351,6 +356,8 @@ gboolean bd_lvm_is_tech_avail (BDLVMTech tech, guint64 mode, GError **error) {
     case BD_LVM_TECH_WRITECACHE:
             return check_features (&avail_features, FEATURES_WRITECACHE_MASK, features, FEATURES_LAST, &deps_check_lock, error) &&
                    check_deps (&avail_deps, DEPS_LVM_MASK, deps, DEPS_LAST, &deps_check_lock, error);
+    case BD_LVM_TECH_DEVICES:
+            return check_deps (&avail_deps, DEPS_LVMDEVICES_MASK, deps, DEPS_LAST, &deps_check_lock, error);
     default:
         /* everything is supported by this implementation of the plugin */
         return check_deps (&avail_deps, DEPS_LVM_MASK, deps, DEPS_LAST, &deps_check_lock, error);
@@ -361,6 +368,8 @@ static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg 
     gboolean success = FALSE;
     guint i = 0;
     guint args_length = g_strv_length ((gchar **) args);
+    g_autofree gchar *config_arg = NULL;
+    g_autofree gchar *devices_arg = NULL;
 
     if (!check_deps (&avail_deps, DEPS_LVM_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
@@ -369,20 +378,26 @@ static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg 
     if (lock_config)
         g_mutex_lock (&global_config_lock);
 
-    /* allocate enough space for the args plus "lvm", "--config" and NULL */
-    const gchar **argv = g_new0 (const gchar*, args_length + 3);
+    /* allocate enough space for the args plus "lvm", "--config", "--devices" and NULL */
+    const gchar **argv = g_new0 (const gchar*, args_length + 4);
 
     /* construct argv from args with "lvm" prepended */
     argv[0] = "lvm";
     for (i=0; i < args_length; i++)
         argv[i+1] = args[i];
-    argv[args_length + 1] = global_config_str ? g_strdup_printf("--config=%s", global_config_str) : NULL;
-    argv[args_length + 2] = NULL;
+    if (global_config_str) {
+        config_arg = g_strdup_printf("--config=%s", global_config_str);
+        argv[++args_length] = config_arg;
+    }
+    if (global_devices_str) {
+        devices_arg = g_strdup_printf("--devices=%s", global_devices_str);
+        argv[++args_length] = devices_arg;
+    }
+    argv[++args_length] = NULL;
 
     success = bd_utils_exec_and_report_error (argv, extra, error);
     if (lock_config)
         g_mutex_unlock (&global_config_lock);
-    g_free ((gchar *) argv[args_length + 1]);
     g_free (argv);
 
     return success;
@@ -392,6 +407,8 @@ static gboolean call_lvm_and_capture_output (const gchar **args, const BDExtraAr
     gboolean success = FALSE;
     guint i = 0;
     guint args_length = g_strv_length ((gchar **) args);
+    g_autofree gchar *config_arg = NULL;
+    g_autofree gchar *devices_arg = NULL;
 
     if (!check_deps (&avail_deps, DEPS_LVM_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
@@ -399,19 +416,25 @@ static gboolean call_lvm_and_capture_output (const gchar **args, const BDExtraAr
     /* don't allow global config string changes during the run */
     g_mutex_lock (&global_config_lock);
 
-    /* allocate enough space for the args plus "lvm", "--config" and NULL */
-    const gchar **argv = g_new0 (const gchar*, args_length + 3);
+    /* allocate enough space for the args plus "lvm", "--config", "--devices" and NULL */
+    const gchar **argv = g_new0 (const gchar*, args_length + 4);
 
     /* construct argv from args with "lvm" prepended */
     argv[0] = "lvm";
     for (i=0; i < args_length; i++)
         argv[i+1] = args[i];
-    argv[args_length + 1] = global_config_str ? g_strdup_printf("--config=%s", global_config_str) : NULL;
-    argv[args_length + 2] = NULL;
+    if (global_config_str) {
+        config_arg = g_strdup_printf("--config=%s", global_config_str);
+        argv[++args_length] = config_arg;
+    }
+    if (global_devices_str) {
+        devices_arg = g_strdup_printf("--devices=%s", global_devices_str);
+        argv[++args_length] = devices_arg;
+    }
+    argv[++args_length] = NULL;
 
     success = bd_utils_exec_and_capture_output (argv, extra, output, error);
     g_mutex_unlock (&global_config_lock);
-    g_free ((gchar *) argv[args_length + 1]);
     g_free (argv);
 
     return success;
@@ -2168,6 +2191,58 @@ gchar* bd_lvm_get_global_config (GError **error UNUSED) {
 
     g_mutex_lock (&global_config_lock);
     ret = g_strdup (global_config_str ? global_config_str : "");
+    g_mutex_unlock (&global_config_lock);
+
+    return ret;
+}
+
+/**
+ * bd_lvm_set_devices_filter:
+ * @devices: (allow-none) (array zero-terminated=1): list of devices for lvm commands to work on
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the devices filter was successfully set or not
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gboolean bd_lvm_set_devices_filter (const gchar **devices, GError **error) {
+    if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
+        return FALSE;
+
+    g_mutex_lock (&global_config_lock);
+
+    /* first free the old value */
+    g_free (global_devices_str);
+
+    /* now store the new one */
+    if (!devices || !(*devices))
+        global_devices_str = NULL;
+    else
+        global_devices_str = g_strjoinv (",", (gchar **) devices);
+
+    g_mutex_unlock (&global_config_lock);
+    return TRUE;
+}
+
+/**
+ * bd_lvm_get_devices_filter:
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (array zero-terminated=1): a copy of a string representation of
+ *                                                     the currently set LVM devices filter
+ *
+ * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
+ */
+gchar** bd_lvm_get_devices_filter (GError **error UNUSED) {
+    gchar **ret = NULL;
+
+    g_mutex_lock (&global_config_lock);
+
+    if (global_devices_str)
+        ret = g_strsplit (global_devices_str, ",", -1);
+    else
+        ret = NULL;
+
     g_mutex_unlock (&global_config_lock);
 
     return ret;

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -206,6 +206,7 @@ typedef enum {
     BD_LVM_TECH_GLOB_CONF,
     BD_LVM_TECH_VDO,
     BD_LVM_TECH_WRITECACHE,
+    BD_LVM_TECH_DEVICES,
 } BDLVMTech;
 
 typedef enum {
@@ -284,6 +285,9 @@ gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name
 
 gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error);
 gchar* bd_lvm_get_global_config (GError **error);
+
+gboolean bd_lvm_set_devices_filter (const gchar **devices, GError **error);
+gchar** bd_lvm_get_devices_filter (GError **error);
 
 guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error);
 const gchar* bd_lvm_cache_get_mode_str (BDLVMCacheMode mode, GError **error);

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -330,4 +330,7 @@ BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_st
 BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_name, GError **error);
 GHashTable* bd_lvm_vdo_get_stats_full (const gchar *vg_name, const gchar *pool_name, GError **error);
 
+gboolean bd_lvm_devices_add (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_devices_delete (const gchar *device, const gchar *devices_file, const BDExtraArg **extra, GError **error);
+
 #endif /* BD_LVM */

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -889,6 +889,21 @@ def lvm_vdo_pool_convert(vg_name, lv_name, pool_name, virtual_size, index_memory
     return _lvm_vdo_pool_convert(vg_name, lv_name, pool_name, virtual_size, index_memory, compression, deduplication, write_policy, extra)
 __all__.append("lvm_vdo_pool_convert")
 
+_lvm_devices_add = BlockDev.lvm_devices_add
+@override(BlockDev.lvm_devices_add)
+def lvm_devices_add(device, devices_file=None, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _lvm_devices_add(device, devices_file, extra)
+__all__.append("lvm_devices_add")
+
+_lvm_devices_delete = BlockDev.lvm_devices_delete
+@override(BlockDev.lvm_devices_delete)
+def lvm_devices_delete(device, devices_file=None, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _lvm_devices_delete(device, devices_file, extra)
+__all__.append("lvm_devices_delete")
+
+
 _md_get_superblock_size = BlockDev.md_get_superblock_size
 @override(BlockDev.md_get_superblock_size)
 def md_get_superblock_size(size, version=None):

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -13,10 +13,8 @@ class LibraryOpsTestCase(unittest.TestCase):
     # all plugins except for 'btrfs', 'fs' and 'mpath' -- these don't have all
     # the dependencies on CentOS/Debian and we don't need them for this test
     requested_plugins = BlockDev.plugin_specs_from_names(("crypto", "dm",
-                                                          "kbd", "loop", "lvm",
+                                                          "kbd", "loop",
                                                           "mdraid", "part", "swap"))
-
-    orig_config_dir = ""
 
     @classmethod
     def setUpClass(cls):
@@ -24,6 +22,171 @@ class LibraryOpsTestCase(unittest.TestCase):
             BlockDev.init(cls.requested_plugins, None)
         else:
             BlockDev.reinit(cls.requested_plugins, True, None)
+
+    @classmethod
+    def tearDownClass(cls):
+        BlockDev.switch_init_checks(True)
+
+    def my_log_func(self, level, msg):
+        # not much to verify here
+        self.assertTrue(isinstance(level, int))
+        self.assertTrue(isinstance(msg, str))
+
+        self.log += msg + "\n"
+
+    @tag_test(TestTags.CORE)
+    def test_logging_setup(self):
+        """Verify that setting up logging works as expected"""
+
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, False, self.my_log_func))
+
+        # we are cheking for info log messages and default level is warning
+        BlockDev.utils_set_log_level(BlockDev.UTILS_LOG_INFO)
+
+        succ = BlockDev.utils_exec_and_report_error(["true"])
+        self.assertTrue(succ)
+
+        # reinit with no logging function should change nothing about logging
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, False, None))
+
+        succ, out = BlockDev.utils_exec_and_capture_output(["echo", "hi"])
+        self.assertTrue(succ)
+        self.assertEqual(out, "hi\n")
+
+        match = re.search(r'Running \[(\d+)\] true', self.log)
+        self.assertIsNot(match, None)
+        task_id1 = match.group(1)
+        match = re.search(r'Running \[(\d+)\] echo hi', self.log)
+        self.assertIsNot(match, None)
+        task_id2 = match.group(1)
+
+        self.assertIn("...done [%s] (exit code: 0)" % task_id1, self.log)
+        self.assertIn("stdout[%s]:" % task_id1, self.log)
+        self.assertIn("stderr[%s]:" % task_id1, self.log)
+
+        self.assertIn("stdout[%s]: hi" % task_id2, self.log)
+        self.assertIn("stderr[%s]:" % task_id2, self.log)
+        self.assertIn("...done [%s] (exit code: 0)" % task_id2, self.log)
+
+    @tag_test(TestTags.CORE)
+    def test_require_plugins(self):
+        """Verify that loading only required plugins works as expected"""
+
+        ps = BlockDev.PluginSpec()
+        ps.name = BlockDev.Plugin.SWAP
+        ps.so_name = ""
+        self.assertTrue(BlockDev.reinit([ps], True, None))
+        self.assertEqual(BlockDev.get_available_plugin_names(), ["swap"])
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
+
+    @tag_test(TestTags.CORE)
+    def test_not_implemented(self):
+        """Verify that unloaded/unimplemented functions report errors"""
+
+        # should be loaded and working
+        self.assertTrue(BlockDev.md_canonicalize_uuid("3386ff85:f5012621:4a435f06:1eb47236"))
+
+        ps = BlockDev.PluginSpec()
+        ps.name = BlockDev.Plugin.SWAP
+        ps.so_name = ""
+        self.assertTrue(BlockDev.reinit([ps], True, None))
+        self.assertEqual(BlockDev.get_available_plugin_names(), ["swap"])
+
+        # no longer loaded
+        with self.assertRaises(GLib.GError):
+            BlockDev.md_canonicalize_uuid("3386ff85:f5012621:4a435f06:1eb47236")
+
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
+
+        # loaded again
+        self.assertTrue(BlockDev.md_canonicalize_uuid("3386ff85:f5012621:4a435f06:1eb47236"))
+
+    def test_ensure_init(self):
+        """Verify that ensure_init just returns when already initialized"""
+
+        # the library is already initialized, ensure_init() shonuld do nothing
+        avail_plugs = BlockDev.get_available_plugin_names()
+        self.assertTrue(BlockDev.ensure_init(self.requested_plugins, None))
+        self.assertEqual(avail_plugs, BlockDev.get_available_plugin_names())
+
+        # reinit with a subset of plugins
+        plugins = BlockDev.plugin_specs_from_names(["swap", "part"])
+        self.assertTrue(BlockDev.reinit(plugins, True, None))
+        self.assertEqual(set(BlockDev.get_available_plugin_names()), set(["swap", "part"]))
+
+        # ensure_init with the same subset -> nothing should change
+        self.assertTrue(BlockDev.ensure_init(plugins, None))
+        self.assertEqual(set(BlockDev.get_available_plugin_names()), set(["swap", "part"]))
+
+        # ensure_init with more plugins -> extra plugins should be loaded
+        plugins = BlockDev.plugin_specs_from_names(["swap", "part", "crypto"])
+        self.assertTrue(BlockDev.ensure_init(plugins, None))
+        self.assertEqual(set(BlockDev.get_available_plugin_names()), set(["swap", "part", "crypto"]))
+
+        # reinit to unload all plugins
+        self.assertTrue(BlockDev.reinit([], True, None))
+        self.assertEqual(BlockDev.get_available_plugin_names(), [])
+
+        # ensure_init to load all plugins back
+        self.assertTrue(BlockDev.ensure_init(self.requested_plugins, None))
+        self.assertGreaterEqual(len(BlockDev.get_available_plugin_names()), 7)
+
+    def test_try_reinit(self):
+        """Verify that try_reinit() works as expected"""
+
+        # try reinitializing with only some utilities being available and thus
+        # only some plugins able to load
+        with fake_path("tests/fake_utils/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "swaplabel"]):
+            succ, loaded = BlockDev.try_reinit(self.requested_plugins, True, None)
+            self.assertFalse(succ)
+            for plug_name in ("swap", "crypto"):
+                self.assertIn(plug_name, loaded)
+
+        # reset back to all plugins
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
+
+        # now the same with a subset of plugins requested
+        plugins = BlockDev.plugin_specs_from_names(["swap", "crypto"])
+        with fake_path("tests/fake_utils/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "swaplabel"]):
+            succ, loaded = BlockDev.try_reinit(plugins, True, None)
+            self.assertTrue(succ)
+            self.assertEqual(set(loaded), set(["swap", "crypto"]))
+
+    def test_non_en_init(self):
+        """Verify that the library initializes with lang different from en_US"""
+
+        orig_lang = os.environ.get("LANG")
+        os.environ["LANG"] = "cs.CZ_UTF-8"
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
+        if orig_lang:
+            os.environ["LANG"] = orig_lang
+        else:
+            del os.environ["LANG"]
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
+
+
+class PluginsTestCase(unittest.TestCase):
+    # only LVM plugin for this test
+    requested_plugins = BlockDev.plugin_specs_from_names(("lvm",))
+
+    orig_config_dir = ""
+
+    @classmethod
+    def setUpClass(cls):
+        BlockDev.switch_init_checks(False)
+        if not BlockDev.is_initialized():
+            BlockDev.init(cls.requested_plugins, None)
+        else:
+            BlockDev.reinit(cls.requested_plugins, True, None)
+
+        try:
+            cls.devices_avail = BlockDev.lvm_is_tech_avail(BlockDev.LVMTech.DEVICES, 0)
+        except:
+            cls.devices_avail = False
+
+    @classmethod
+    def tearDownClass(cls):
+        BlockDev.switch_init_checks(True)
 
     def setUp(self):
         self.orig_config_dir = os.environ.get("LIBBLOCKDEV_CONFIG_DIR", "")
@@ -185,6 +348,12 @@ class LibraryOpsTestCase(unittest.TestCase):
     def test_plugin_fallback(self):
         """Verify that fallback when loading plugins works as expected"""
 
+        if not self.devices_avail:
+            self.skipTest("skipping plugin fallback test: missing some LVM dependencies")
+
+        BlockDev.switch_init_checks(True)
+        self.addCleanup(BlockDev.switch_init_checks, False)
+
         # library should be successfully initialized
         self.assertTrue(BlockDev.is_initialized())
 
@@ -206,7 +375,7 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # now reinit the library with the config preferring the new build
         orig_conf_dir = os.environ.get("LIBBLOCKDEV_CONFIG_DIR")
-        os.environ["LIBBLOCKDEV_CONFIG_DIR"] = "tests/plugin_prio_conf.d"
+        os.environ["LIBBLOCKDEV_CONFIG_DIR"] = "tests/test_configs/plugin_prio_conf.d"
         self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
 
         # the original plugin should be loaded because the new one should fail
@@ -243,142 +412,9 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         self.assertEqual(BlockDev.lvm_get_max_lv_size(), orig_max_size)
 
-    def my_log_func(self, level, msg):
-        # not much to verify here
-        self.assertTrue(isinstance(level, int))
-        self.assertTrue(isinstance(msg, str))
 
-        self.log += msg + "\n"
-
-    @tag_test(TestTags.CORE)
-    def test_logging_setup(self):
-        """Verify that setting up logging works as expected"""
-
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, False, self.my_log_func))
-
-        # we are cheking for info log messages and default level is warning
-        BlockDev.utils_set_log_level(BlockDev.UTILS_LOG_INFO)
-
-        succ = BlockDev.utils_exec_and_report_error(["true"])
-        self.assertTrue(succ)
-
-        # reinit with no logging function should change nothing about logging
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, False, None))
-
-        succ, out = BlockDev.utils_exec_and_capture_output(["echo", "hi"])
-        self.assertTrue(succ)
-        self.assertEqual(out, "hi\n")
-
-        match = re.search(r'Running \[(\d+)\] true', self.log)
-        self.assertIsNot(match, None)
-        task_id1 = match.group(1)
-        match = re.search(r'Running \[(\d+)\] echo hi', self.log)
-        self.assertIsNot(match, None)
-        task_id2 = match.group(1)
-
-        self.assertIn("...done [%s] (exit code: 0)" % task_id1, self.log)
-        self.assertIn("stdout[%s]:" % task_id1, self.log)
-        self.assertIn("stderr[%s]:" % task_id1, self.log)
-
-        self.assertIn("stdout[%s]: hi" % task_id2, self.log)
-        self.assertIn("stderr[%s]:" % task_id2, self.log)
-        self.assertIn("...done [%s] (exit code: 0)" % task_id2, self.log)
-
-    @tag_test(TestTags.CORE)
-    def test_require_plugins(self):
-        """Verify that loading only required plugins works as expected"""
-
-        ps = BlockDev.PluginSpec()
-        ps.name = BlockDev.Plugin.SWAP
-        ps.so_name = ""
-        self.assertTrue(BlockDev.reinit([ps], True, None))
-        self.assertEqual(BlockDev.get_available_plugin_names(), ["swap"])
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
-
-    @tag_test(TestTags.CORE)
-    def test_not_implemented(self):
-        """Verify that unloaded/unimplemented functions report errors"""
-
-        # should be loaded and working
-        self.assertTrue(BlockDev.lvm_get_max_lv_size() > 0)
-
-        ps = BlockDev.PluginSpec()
-        ps.name = BlockDev.Plugin.SWAP
-        ps.so_name = ""
-        self.assertTrue(BlockDev.reinit([ps], True, None))
-        self.assertEqual(BlockDev.get_available_plugin_names(), ["swap"])
-
-        # no longer loaded
-        with self.assertRaises(GLib.GError):
-            BlockDev.lvm_get_max_lv_size()
-
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
-
-        # loaded again
-        self.assertTrue(BlockDev.lvm_get_max_lv_size() > 0)
-
-    def test_ensure_init(self):
-        """Verify that ensure_init just returns when already initialized"""
-
-        # the library is already initialized, ensure_init() shonuld do nothing
-        avail_plugs = BlockDev.get_available_plugin_names()
-        self.assertTrue(BlockDev.ensure_init(self.requested_plugins, None))
-        self.assertEqual(avail_plugs, BlockDev.get_available_plugin_names())
-
-        # reinit with a subset of plugins
-        plugins = BlockDev.plugin_specs_from_names(["swap", "lvm"])
-        self.assertTrue(BlockDev.reinit(plugins, True, None))
-        self.assertEqual(set(BlockDev.get_available_plugin_names()), set(["swap", "lvm"]))
-
-        # ensure_init with the same subset -> nothing should change
-        self.assertTrue(BlockDev.ensure_init(plugins, None))
-        self.assertEqual(set(BlockDev.get_available_plugin_names()), set(["swap", "lvm"]))
-
-        # ensure_init with more plugins -> extra plugins should be loaded
-        plugins = BlockDev.plugin_specs_from_names(["swap", "lvm", "crypto"])
-        self.assertTrue(BlockDev.ensure_init(plugins, None))
-        self.assertEqual(set(BlockDev.get_available_plugin_names()), set(["swap", "lvm", "crypto"]))
-
-        # reinit to unload all plugins
-        self.assertTrue(BlockDev.reinit([], True, None))
-        self.assertEqual(BlockDev.get_available_plugin_names(), [])
-
-        # ensure_init to load all plugins back
-        self.assertTrue(BlockDev.ensure_init(self.requested_plugins, None))
-        self.assertGreaterEqual(len(BlockDev.get_available_plugin_names()), 8)
-
-    def test_try_reinit(self):
-        """Verify that try_reinit() works as expected"""
-
-        # try reinitializing with only some utilities being available and thus
-        # only some plugins able to load
-        with fake_path("tests/fake_utils/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "lvm", "swaplabel"]):
-            succ, loaded = BlockDev.try_reinit(self.requested_plugins, True, None)
-            self.assertFalse(succ)
-            for plug_name in ("swap", "lvm", "crypto"):
-                self.assertIn(plug_name, loaded)
-
-        # reset back to all plugins
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
-
-        # now the same with a subset of plugins requested
-        plugins = BlockDev.plugin_specs_from_names(["lvm", "swap", "crypto"])
-        with fake_path("tests/fake_utils/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "lvm", "swaplabel"]):
-            succ, loaded = BlockDev.try_reinit(plugins, True, None)
-            self.assertTrue(succ)
-            self.assertEqual(set(loaded), set(["swap", "lvm", "crypto"]))
-
-    def test_non_en_init(self):
-        """Verify that the library initializes with lang different from en_US"""
-
-        orig_lang = os.environ.get("LANG")
-        os.environ["LANG"] = "cs.CZ_UTF-8"
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
-        if orig_lang:
-            os.environ["LANG"] = orig_lang
-        else:
-            del os.environ["LANG"]
-        self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
+class DepChecksTestCase(unittest.TestCase):
+    requested_plugins = BlockDev.plugin_specs_from_names(( "swap",))
 
     def test_dep_checks_disabled(self):
         """Verify that disabling runtime dep checks works"""

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 from distutils.version import LooseVersion
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command, read_file
 from gi.repository import BlockDev, GLib
 
 
@@ -1940,3 +1940,38 @@ class LVMVDOTest(LVMTestCase):
 
         full_stats = BlockDev.lvm_vdo_get_stats_full("testVDOVG", "vdoPool")
         self.assertIn("writeAmplificationRatio", full_stats.keys())
+
+
+class LvmTestDevicesFile(LvmPVonlyTestCase):
+    devicefile = "bd_lvm_test.devices"
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree("/etc/lvm/devices/" + cls.devicefile, ignore_errors=True)
+
+        super(LvmTestDevicesFile, cls).tearDownClass()
+
+    def test_devices_add_delete(self):
+        if not self.devices_avail:
+            self.skipTest("skipping LVM devices file test: not supported")
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev)
+        self.assertTrue(succ)
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.lvm_devices_add("/non/existing/device", self.devicefile)
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.lvm_devices_delete(self.loop_dev, self.devicefile)
+
+        succ = BlockDev.lvm_devices_add(self.loop_dev, self.devicefile)
+        self.assertTrue(succ)
+
+        dfile = read_file("/etc/lvm/devices/" + self.devicefile)
+        self.assertIn(self.loop_dev, dfile)
+
+        succ = BlockDev.lvm_devices_delete(self.loop_dev, self.devicefile)
+        self.assertTrue(succ)
+
+        dfile = read_file("/etc/lvm/devices/" + self.devicefile)
+        self.assertNotIn(self.loop_dev, dfile)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -21,10 +21,17 @@ class LVMTestCase(unittest.TestCase):
         ps.so_name = "libbd_lvm.so.2"
         cls.requested_plugins = [ps]
 
+        BlockDev.switch_init_checks(False)
         if not BlockDev.is_initialized():
             BlockDev.init(cls.requested_plugins, None)
         else:
             BlockDev.reinit(cls.requested_plugins, True, None)
+        BlockDev.switch_init_checks(True)
+
+        try:
+            cls.devices_avail = BlockDev.lvm_is_tech_avail(BlockDev.LVMTech.DEVICES, 0)
+        except:
+            cls.devices_avail = False
 
     @classmethod
     def _get_lvm_version(cls):
@@ -43,6 +50,8 @@ class LVMTestCase(unittest.TestCase):
 class LvmNoDevTestCase(LVMTestCase):
     def __init__(self, *args, **kwargs):
         super(LvmNoDevTestCase, self).__init__(*args, **kwargs)
+
+    def setUp(self):
         self._log = ""
 
     @classmethod
@@ -229,6 +238,44 @@ class LvmNoDevTestCase(LVMTestCase):
 
         # reset back to default
         succ = BlockDev.lvm_set_global_config(None)
+        self.assertTrue(succ)
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_get_set_global_devices_filter(self):
+        """Verify that getting and setting LVM devices filter works as expected"""
+        if not self.devices_avail:
+            self.skipTest("skipping LVM devices filter test: not supported")
+
+        # setup logging
+        self.assertTrue(BlockDev.reinit(self.requested_plugins, False, self._store_log))
+
+        # no global config set initially
+        self.assertListEqual(BlockDev.lvm_get_devices_filter(), [])
+
+        # set and try to get back
+        succ = BlockDev.lvm_set_devices_filter(["/dev/sda"])
+        self.assertTrue(succ)
+        self.assertListEqual(BlockDev.lvm_get_devices_filter(), ["/dev/sda"])
+
+        # reset and try to get back
+        succ = BlockDev.lvm_set_devices_filter(None)
+        self.assertTrue(succ)
+        self.assertListEqual(BlockDev.lvm_get_devices_filter(), [])
+
+        # set twice and try to get back twice
+        succ = BlockDev.lvm_set_devices_filter(["/dev/sda"])
+        self.assertTrue(succ)
+        succ = BlockDev.lvm_set_devices_filter(["/dev/sdb"])
+        self.assertTrue(succ)
+        self.assertEqual(BlockDev.lvm_get_devices_filter(), ["/dev/sdb"])
+
+        # set something sane and check it's really used
+        succ = BlockDev.lvm_set_devices_filter(["/dev/sdb", "/dev/sdc"])
+        BlockDev.lvm_lvs(None)
+        self.assertIn("--devices=/dev/sdb,/dev/sdc", self._log)
+
+        # reset back to default
+        succ = BlockDev.lvm_set_devices_filter(None)
         self.assertTrue(succ)
 
     @tag_test(TestTags.NOSTORAGE)
@@ -1593,6 +1640,9 @@ class LvmTestLVTags(LvmPVVGLVTestCase):
 
 class LVMUnloadTest(LVMTestCase):
     def setUp(self):
+        if not self.devices_avail:
+            self.skipTest("skipping LVM unload test: missing some LVM dependencies")
+
         # make sure the library is initialized with all plugins loaded for other
         # tests
         self.addCleanup(BlockDev.reinit, self.requested_plugins, True, None)


### PR DESCRIPTION
LVM 2.03.12 introduces a new config file `/etc/lvm/devices/system.devices`, all devices that LVM should have access to must be specified there (except for `pvcreate` that can work on any device and will add it to the file). The problem for blivet is that it currently heavily uses the `--config devices { filter=[""] }'` device filtering that is no longer supported, the behaviour of the filter is partially replaced by the `--devices` option where we can specify devices for LVM to use (this bypasses the config file).

This is a work in progress change for blivet with changes limited to the CLI plugin (we'll probably need to add the `lvmdevices` command to LVM DBus API, not sure about that yet) and I will probably change it a lot based on the progress of the blivet code for this new "feature".