### PR TITLE
Distutils deprecation

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -55,6 +55,7 @@
       - ntfsprogs
       - python3-bytesize
       - python3-dbus
+      - python3-packaging
       - python3-pylint
       - python3-yaml
       - reiserfs-utils
@@ -115,6 +116,7 @@
       - ntfsprogs
       - python3-bytesize
       - python3-dbus
+      - python3-packaging
       - python3-pylint
       - python3-yaml
       - targetcli
@@ -175,6 +177,7 @@
       - ntfs-3g
       - pylint3
       - python3-bytesize
+      - python3-packaging
       - python3-pydbus
       - python3-yaml
       - reiserfsprogs

--- a/src/python/gi/overrides/Makefile.am
+++ b/src/python/gi/overrides/Makefile.am
@@ -1,5 +1,5 @@
 if WITH_PYTHON3
-py3libdir = $(shell python3 -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
+py3libdir = $(shell python3 -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'platbase': '${exec_prefix}'}))")
 py3overridesdir = $(py3libdir)/gi/overrides
 dist_py3overrides_DATA = BlockDev.py
 endif

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -6,7 +6,7 @@ import re
 import shutil
 import time
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import overrides_hack
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, mount, umount, run_command, TestTags, tag_test
@@ -70,7 +70,7 @@ class BtrfsTestCase(unittest.TestCase):
         m = re.search(r"[Bb]trfs.* v([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine btrfs version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
 class BtrfsTestCreateQuerySimple(BtrfsTestCase):
     @tag_test(TestTags.CORE)
@@ -185,7 +185,7 @@ class BtrfsTestCreateDeleteSubvolume(BtrfsTestCase):
         """Verify that it is possible to create/delete subvolume"""
 
         btrfs_version = self._get_btrfs_version()
-        if btrfs_version >= LooseVersion('4.13.2'):
+        if btrfs_version >= Version('4.13.2'):
             self.skipTest('subvolumes list is broken with btrfs-progs v4.13.2')
 
         succ = BlockDev.btrfs_create_volume([self.loop_dev], "myShinyBtrfs", None, None, None)

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -3,10 +3,10 @@ from __future__ import division
 import unittest
 import os
 import re
+import shutil
 import time
 
 from distutils.version import LooseVersion
-from distutils.spawn import find_executable
 
 import overrides_hack
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, mount, umount, run_command, TestTags, tag_test
@@ -28,7 +28,7 @@ class BtrfsTestCase(unittest.TestCase):
         if not BlockDev.utils_have_kernel_module("btrfs"):
             raise unittest.SkipTest('Btrfs kernel module not available, skipping.')
 
-        if not find_executable("btrfs"):
+        if not shutil.which("btrfs"):
             raise unittest.SkipTest("btrfs executable not foundin $PATH, skipping.")
 
         if not BlockDev.is_initialized():

--- a/tests/fs_tests/f2fs_test.py
+++ b/tests/fs_tests/f2fs_test.py
@@ -1,7 +1,7 @@
 import tempfile
 import re
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from .fs_test import FSTestCase, mounted
 
@@ -30,7 +30,7 @@ class F2FSTestCase(FSTestCase):
         m = re.search(r"resize.f2fs ([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine f2fs version from: %s" % out)
-        return LooseVersion(m.groups()[0]) >= LooseVersion("1.12.0")
+        return Version(m.groups()[0]) >= Version("1.12.0")
 
     def _check_fsck_f2fs_version(self):
         # if it can run -V to get version it can do the check

--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -4,7 +4,7 @@ import subprocess
 import unittest
 
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import utils
 import overrides_hack
@@ -156,7 +156,7 @@ class FSTestCase(unittest.TestCase):
         m = re.search(r"mkfs\.xfs version ([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine xfsprogs version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def _destroy_lvm(self, vgname):
         utils.run("vgremove --yes %s >/dev/null 2>&1" % vgname)

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -3,7 +3,7 @@ import time
 import tempfile
 import re
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 from .fs_test import FSTestCase, mounted, check_output
@@ -32,7 +32,7 @@ class GenericTestCase(FSTestCase):
         m = re.search(r"mkfs\.fat ([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine dosfstools version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
 
 class TestGenericWipe(GenericTestCase):
@@ -59,7 +59,7 @@ class TestGenericWipe(GenericTestCase):
 
         # vfat has multiple signatures on the device so it allows us to test the
         # 'all' argument of fs_wipe()
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1 --mbr=n" % self.loop_dev)
         else:
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1" % self.loop_dev)
@@ -84,7 +84,7 @@ class TestGenericWipe(GenericTestCase):
         self.assertEqual(fs_type, b"")
 
         # now do the wipe all in a one step
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1 --mbr=n" % self.loop_dev)
         else:
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1" % self.loop_dev)
@@ -142,7 +142,7 @@ class TestClean(GenericTestCase):
 
         # vfat has multiple signatures on the device so it allows us to test
         # that clean removes all signatures
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1 --mbr=n" % self.loop_dev)
         else:
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1" % self.loop_dev)
@@ -417,7 +417,7 @@ class GenericMkfs(GenericTestCase):
     def test_vfat_generic_mkfs(self):
         """ Test generic mkfs with vfat """
         label = "LABEL"
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             extra = [BlockDev.ExtraArg.new("--mbr=n", "")]
         else:
             extra = None
@@ -833,7 +833,7 @@ class GenericResize(GenericTestCase):
     def test_vfat_generic_resize(self):
         """Test generic resize function with a vfat file system"""
         def mkfs_vfat(device, options=None):
-            if self._vfat_version >= LooseVersion("4.2"):
+            if self._vfat_version >= Version("4.2"):
                 if options:
                     return BlockDev.fs_vfat_mkfs(device, options + [BlockDev.ExtraArg.new("--mbr=n", "")])
                 else:
@@ -871,7 +871,7 @@ class GenericResize(GenericTestCase):
 
         # (still) impossible to shrink an XFS file system
         xfs_version = self._get_xfs_version()
-        if xfs_version < LooseVersion("5.12"):
+        if xfs_version < Version("5.12"):
             with mounted(lv, self.mount_dir):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_resize(lv, 40 * 1024**2)
@@ -914,7 +914,7 @@ class GenericResize(GenericTestCase):
         m = re.search(r"resize.f2fs ([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine f2fs version from: %s" % out)
-        return LooseVersion(m.groups()[0]) >= LooseVersion("1.12.0")
+        return Version(m.groups()[0]) >= Version("1.12.0")
 
     def test_f2fs_generic_resize(self):
         """Verify that it is possible to resize an f2fs file system"""
@@ -1008,7 +1008,7 @@ class GenericGetFreeSpace(GenericTestCase):
     def test_vfat_get_free_space(self):
         """Test generic resize function with a vfat file system"""
         def mkfs_vfat(device, options=None):
-            if self._vfat_version >= LooseVersion("4.2"):
+            if self._vfat_version >= Version("4.2"):
                 if options:
                     return BlockDev.fs_vfat_mkfs(device, options + [BlockDev.ExtraArg.new("--mbr=n", "")])
                 else:

--- a/tests/fs_tests/vfat_test.py
+++ b/tests/fs_tests/vfat_test.py
@@ -1,7 +1,7 @@
 import re
 import tempfile
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from .fs_test import FSTestCase, mounted
 
@@ -18,7 +18,7 @@ class VfatTestCase(FSTestCase):
 
         self.mount_dir = tempfile.mkdtemp(prefix="libblockdev.", suffix="vfat_test")
 
-        if self._get_dosfstools_version() <= LooseVersion("4.1"):
+        if self._get_dosfstools_version() <= Version("4.1"):
             self._mkfs_options = None
         else:
             self._mkfs_options = [BlockDev.ExtraArg.new("--mbr=n", "")]
@@ -29,7 +29,7 @@ class VfatTestCase(FSTestCase):
         m = re.search(r"mkfs\.fat ([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine dosfstools version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
 
 class VfatTestAvailability(VfatTestCase):

--- a/tests/fs_tests/xfs_test.py
+++ b/tests/fs_tests/xfs_test.py
@@ -1,6 +1,6 @@
 import tempfile
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from .fs_test import FSTestCase, mounted, check_output
 
@@ -255,7 +255,7 @@ class XfsResize(XfsTestCase):
 
         # (still) impossible to shrink an XFS file system
         xfs_version = self._get_xfs_version()
-        if xfs_version < LooseVersion("5.12"):
+        if xfs_version < Version("5.12"):
             with mounted(lv, self.mount_dir):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_xfs_resize(self.mount_dir, 40 * 1024**2 / fi.block_size, None)

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -164,8 +164,8 @@ class KbdZRAMStatsTestCase(KbdZRAMTestCase):
         """Verify that it is possible to get stats for a zram device"""
 
         # location of some sysfs files we use is different since linux 4.11
-        kernel_version = os.uname()[2]
-        if Version(kernel_version) >= Version("4.11"):
+        ver = BlockDev.utils_get_linux_version()
+        if Version("%d.%d.%d" % (ver.major, ver.minor, ver.micro)) >= Version("4.11"):
             self._zram_get_stats_new()
         else:
             self._zram_get_stats_old()

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import time
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, wipe_all, fake_path, read_file, TestTags, tag_test
 from bytesize import bytesize
 import overrides_hack
@@ -165,7 +165,7 @@ class KbdZRAMStatsTestCase(KbdZRAMTestCase):
 
         # location of some sysfs files we use is different since linux 4.11
         kernel_version = os.uname()[2]
-        if LooseVersion(kernel_version) >= LooseVersion("4.11"):
+        if Version(kernel_version) >= Version("4.11"):
             self._zram_get_stats_new()
         else:
             self._zram_get_stats_old()

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -1,10 +1,10 @@
 import unittest
 import os
 import re
+import shutil
 import time
 from contextlib import contextmanager
 from distutils.version import LooseVersion
-from distutils.spawn import find_executable
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, wipe_all, fake_path, read_file, TestTags, tag_test
 from bytesize import bytesize
 import overrides_hack
@@ -261,7 +261,7 @@ class KbdBcacheNodevTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not find_executable("make-bcache"):
+        if not shutil.which("make-bcache"):
             raise unittest.SkipTest("make-bcache executable not found in $PATH, skipping.")
 
         if not BlockDev.is_initialized():
@@ -291,7 +291,7 @@ class KbdBcacheTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not find_executable("make-bcache"):
+        if not shutil.which("make-bcache"):
             raise unittest.SkipTest("make-bcache executable not found in $PATH, skipping.")
 
         if not BlockDev.is_initialized():

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -6,7 +6,7 @@ import overrides_hack
 import re
 import shutil
 import subprocess
-from distutils.version import LooseVersion
+from packaging.version import Version
 from itertools import chain
 
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, run_command, TestTags, tag_test
@@ -38,7 +38,7 @@ class LVMTestCase(unittest.TestCase):
         m = re.search(r"LVM version:\s+([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine LVM version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     @classmethod
     def _get_lvm_segtypes(cls):
@@ -1450,7 +1450,7 @@ class LvmPVVGcachedLVpoolTestCase(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.06"):
+        if lvm_version < Version("2.03.06"):
             cpool_name = "testCache"
         else:
             # since 2.03.06 LVM adds _cpool suffix to the cache pool after attaching it
@@ -1465,7 +1465,7 @@ class LvmPVVGLVWritecacheAttachDetachTestCase(LvmPVVGLVcachePoolTestCase):
         """Verify that is it possible to attach and detach a writecache LV"""
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.10"):
+        if lvm_version < Version("2.03.10"):
             self.skipTest("LVM writecache support in DBus API not available")
 
         lvm_segtypes = self._get_lvm_segtypes()
@@ -1518,7 +1518,7 @@ class LvmPVVGWritecachedLVTestCase(LvmPVVGLVTestCase):
         """Verify that it is possible to create a cached LV in a single step"""
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.10"):
+        if lvm_version < Version("2.03.10"):
             self.skipTest("LVM writecache support in DBus API not available")
 
         lvm_segtypes = self._get_lvm_segtypes()
@@ -1763,7 +1763,7 @@ class LVMVDOTest(LVMTestCase):
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         lvm_version = cls._get_lvm_version()
-        if lvm_version < LooseVersion("2.3.07"):
+        if lvm_version < Version("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")
 
         super().setUpClass()

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -6,7 +6,7 @@ import overrides_hack
 import re
 import shutil
 import subprocess
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command
 from gi.repository import BlockDev, GLib
@@ -32,7 +32,7 @@ class LVMTestCase(unittest.TestCase):
         m = re.search(r"LVM version:\s+([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine LVM version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     @classmethod
     def _get_lvm_segtypes(cls):
@@ -1361,7 +1361,7 @@ class LvmPVVGcachedLVpoolTestCase(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.06"):
+        if lvm_version < Version("2.03.06"):
             cpool_name = "testCache"
         else:
             # since 2.03.06 LVM adds _cpool suffix to the cache pool after attaching it
@@ -1442,7 +1442,7 @@ class LvmPVVGLVWritecacheAttachDetachTestCase(LvmPVVGLVcachePoolTestCase):
         """Verify that is it possible to attach and detach a writecache LV"""
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.02"):
+        if lvm_version < Version("2.03.02"):
             self.skipTest("LVM writecache support not available")
 
         lvm_segtypes = self._get_lvm_segtypes()
@@ -1494,7 +1494,7 @@ class LvmPVVGWritecachedLVTestCase(LvmPVVGLVTestCase):
         """Verify that it is possible to create a writecached LV in a single step"""
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.02"):
+        if lvm_version < Version("2.03.02"):
             self.skipTest("LVM writecache support not available")
 
         lvm_segtypes = self._get_lvm_segtypes()
@@ -1678,7 +1678,7 @@ class LVMVDOTest(LVMTestCase):
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         lvm_version = cls._get_lvm_version()
-        if lvm_version < LooseVersion("2.3.07"):
+        if lvm_version < Version("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")
 
         super().setUpClass()

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import unittest
 import overrides_hack
 
@@ -8,7 +9,6 @@ from distutils.version import LooseVersion
 
 from utils import run_command, read_file, fake_path, TestTags, tag_test
 from gi.repository import BlockDev, GLib
-from distutils.spawn import find_executable
 
 
 class NVDIMMTestCase(unittest.TestCase):
@@ -17,7 +17,7 @@ class NVDIMMTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not find_executable("ndctl"):
+        if not shutil.which("ndctl"):
             raise unittest.SkipTest("ndctl executable not foundin $PATH, skipping.")
 
         if not BlockDev.is_initialized():

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -5,7 +5,7 @@ import shutil
 import unittest
 import overrides_hack
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from utils import run_command, read_file, fake_path, TestTags, tag_test
 from gi.repository import BlockDev, GLib
@@ -43,7 +43,7 @@ class NVDIMMNamespaceTestCase(NVDIMMTestCase):
         m = re.search(r"([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine ndctl version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def setUp(self):
         self.sys_info = self._get_nvdimm_info()
@@ -168,7 +168,7 @@ class NVDIMMNamespaceTestCase(NVDIMMTestCase):
         # ndctl renamed the modes from 'memory' and 'dax' to 'fsdax' and 'devdax'
         # in version 60, so we need to choose different mode based on version
         ndctl_version = self._get_ndctl_version()
-        if ndctl_version >= LooseVersion("60.0"):
+        if ndctl_version >= Version("60.0"):
             mode = BlockDev.NVDIMMNamespaceMode.FSDAX
         else:
             mode = BlockDev.NVDIMMNamespaceMode.MEMORY

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -6,7 +6,7 @@ import overrides_hack
 
 from gi.repository import BlockDev, GLib
 from bytesize.bytesize import Size, ROUND_UP, B
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 class PartTestCase(unittest.TestCase):
@@ -19,7 +19,7 @@ class PartTestCase(unittest.TestCase):
         m = re.search(r"fdisk from util-linux\s+([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine fdisk version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     @classmethod
     def setUpClass(cls):
@@ -1023,7 +1023,7 @@ class PartCreateResizePartCase(PartTestCase):
         except Exception as e:
             resize_tolerance = 0
         else:
-            if fdisk_version < LooseVersion("2.33"):
+            if fdisk_version < Version("2.33"):
                 # older versions of libfdisk don't count free space between partitions as a usable
                 # free space which also means max size for resize is about 1 MiB smaller because
                 # the free space between the partition being resized and the "free space" partition

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -7,13 +7,13 @@ import datetime
 import os
 import pdb
 import re
+import shutil
 import subprocess
 import sys
 import traceback
 import unittest
 import yaml
 
-from distutils.spawn import find_executable
 
 from utils import TestTags, get_version
 
@@ -354,7 +354,7 @@ if __name__ == '__main__':
     result = runner.run(suite)
 
     # dump cropped journal to log file
-    if find_executable('journalctl'):
+    if shutil.which('journalctl'):
         with open('journaldump.log', 'w') as outfile:
             subprocess.call(['journalctl', '-S', start_time], stdout=outfile)
 


### PR DESCRIPTION
The distutils Python module is deprecated and will be removed in Python 3.12. We are using it mostly in tests for `LooseVersion` and `find_executable`.