### PR TITLE
tests: Remove test for NTFS read-only mounting

### DIFF
--- a/tests/fs_tests/mount_test.py
+++ b/tests/fs_tests/mount_test.py
@@ -265,32 +265,3 @@ class MountTestCase(FSTestCase):
         succ = BlockDev.fs_unmount(self.loop_dev, False, False, None)
         self.assertTrue(succ)
         self.assertFalse(os.path.ismount(tmp))
-
-    def test_mount_ntfs_ro(self):
-        """ Test mounting and unmounting read-only device with NTFS filesystem"""
-
-        if not self.ntfs_avail:
-            self.skipTest("skipping NTFS: not available")
-
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, None)
-        self.assertTrue(succ)
-
-        tmp = tempfile.mkdtemp(prefix="libblockdev.", suffix="mount_test")
-        self.addCleanup(os.rmdir, tmp)
-
-        # set the device read-only
-        self.setro(self.loop_dev)
-        self.addCleanup(self.setrw, self.loop_dev)
-
-        # forced rw mount should fail
-        with self.assertRaises(GLib.GError):
-            BlockDev.fs_mount(self.loop_dev, tmp, "ntfs", "rw")
-
-        # read-only mount should work
-        succ = BlockDev.fs_mount(self.loop_dev, tmp, "ntfs", "ro")
-        self.assertTrue(succ)
-        self.assertTrue(os.path.ismount(tmp))
-
-        succ = BlockDev.fs_unmount(self.loop_dev, False, False, None)
-        self.assertTrue(succ)
-        self.assertFalse(os.path.ismount(tmp))

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -24,12 +24,6 @@
 
 ---
 
-- test: fs_tests.mount_test.MountTestCase.test_mount_ntfs_ro
-  skip_on:
-    - distro: "debian"
-      version: ["10", "11", "testing"]
-      reason: "NTFS mounting of read-only devices doesn't work as expected on Debian"
-
 - test: kbd_test.KbdZRAM*
   skip_on:
     - distro: "debian"


### PR DESCRIPTION
With latest version of ntfs-3g now available in Fedora, mounting
a read only device no longer returns an error, the device is just
mounted as read only with a warning being printed to stdout.
This test was originally added to check that error reporting from
libmount works correnctly with helper programs so it doesn't makes
sense to keep it when mount.ntfs no longer returns an error.