### PR TITLE
Add support for creating and activating integrity devices

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -191,7 +191,7 @@ AS_IF([test "x$with_crypto" != "xno"],
       AS_IF([$PKG_CONFIG --atleast-version=2.0.3 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_2])], [])
       AS_IF([$PKG_CONFIG --atleast-version=2.3.0 libcryptsetup],
-            [AC_DEFINE([LIBCRYPTSETUP_BITLK])], [])
+            [AC_DEFINE([LIBCRYPTSETUP_23])], [])
       AS_IF([$PKG_CONFIG --atleast-version=2.4.0 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_24])], [])
       AS_IF([test "x$with_escrow" != "xno"],

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -1,5 +1,6 @@
 #include <glib.h>
 #include <blockdev/utils.h>
+#include <libcryptsetup.h>
 
 #define BD_CRYPTO_LUKS_METADATA_SIZE G_GUINT64_CONSTANT (2097152ULL) // 2 MiB
 
@@ -250,6 +251,115 @@ GType bd_crypto_luks_extra_get_type () {
 
     return type;
 }
+
+#define BD_CRYPTO_TYPE_INTEGRITY_EXTRA (bd_crypto_integrity_extra_get_type ())
+GType bd_crypto_integrity_extra_get_type();
+
+/**
+ * BDCryptoIntegrityExtra:
+ * @sector_size: integrity sector size
+ * @journal_size: size of journal in bytes
+ * @journal_watermark: journal flush watermark in percents; in bitmap mode sectors-per-bit
+ * @journal_commit_time: journal commit time (or bitmap flush time) in ms
+ * @interleave_sectors: number of interleave sectors (power of two)
+ * @tag_size: tag size per-sector in bytes
+ * @buffer_sectors: number of sectors in one buffer
+ */
+typedef struct BDCryptoIntegrityExtra {
+    guint32 sector_size;
+    guint64 journal_size;
+    guint journal_watermark;
+    guint journal_commit_time;
+    guint32 interleave_sectors;
+    guint32 tag_size;
+    guint32 buffer_sectors;
+} BDCryptoIntegrityExtra;
+
+/**
+ * bd_crypto_integrity_extra_copy: (skip)
+ * @extra: (allow-none): %BDCryptoIntegrityExtra to copy
+ *
+ * Creates a new copy of @extra.
+ */
+BDCryptoIntegrityExtra* bd_crypto_integrity_extra_copy (BDCryptoIntegrityExtra *extra) {
+    if (extra == NULL)
+        return NULL;
+
+    BDCryptoIntegrityExtra *new_extra = g_new0 (BDCryptoIntegrityExtra, 1);
+
+    new_extra->sector_size = extra->sector_size;
+    new_extra->journal_size = extra->journal_size;
+    new_extra->journal_watermark = extra->journal_watermark;
+    new_extra->journal_commit_time = extra->journal_commit_time;
+    new_extra->interleave_sectors = extra->interleave_sectors;
+    new_extra->tag_size = extra->tag_size;
+    new_extra->buffer_sectors = extra->buffer_sectors;
+
+    return new_extra;
+}
+
+/**
+ * bd_crypto_integrity_extra_free: (skip)
+ * @extra: (allow-none): %BDCryptoIntegrityExtra to free
+ *
+ * Frees @extra.
+ */
+void bd_crypto_integrity_extra_free (BDCryptoIntegrityExtra *extra) {
+    if (extra == NULL)
+        return;
+
+    g_free (extra);
+}
+
+/**
+ * bd_crypto_integrity_extra_new: (constructor)
+ * @sector_size: integrity sector size, 0 for default (512)
+ * @journal_size: size of journal in bytes
+ * @journal_watermark: journal flush watermark in percents; in bitmap mode sectors-per-bit
+ * @journal_commit_time: journal commit time (or bitmap flush time) in ms
+ * @interleave_sectors: number of interleave sectors (power of two)
+ * @tag_size: tag size per-sector in bytes
+ * @buffer_sectors: number of sectors in one buffer
+ *
+ * Returns: (transfer full): a new Integrity extra argument
+ */
+BDCryptoIntegrityExtra* bd_crypto_integrity_extra_new (guint64 sector_size, guint64 journal_size, guint journal_watermark, guint journal_commit_time, guint64 interleave_sectors, guint64 tag_size, guint64 buffer_sectors) {
+    BDCryptoIntegrityExtra *ret = g_new0 (BDCryptoIntegrityExtra, 1);
+    ret->sector_size = sector_size;
+    ret->journal_size = journal_size;
+    ret->journal_watermark = journal_watermark;
+    ret->journal_commit_time = journal_commit_time;
+    ret->interleave_sectors = interleave_sectors;
+    ret->tag_size = tag_size;
+    ret->buffer_sectors = buffer_sectors;
+
+    return ret;
+}
+
+GType bd_crypto_integrity_extra_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDCryptoIntegrityExtra",
+                                            (GBoxedCopyFunc) bd_crypto_integrity_extra_copy,
+                                            (GBoxedFreeFunc) bd_crypto_integrity_extra_free);
+    }
+
+    return type;
+}
+
+typedef enum {
+    BD_CRYPTO_INTEGRITY_OPEN_NO_JOURNAL         = CRYPT_ACTIVATE_NO_JOURNAL,
+    BD_CRYPTO_INTEGRITY_OPEN_RECOVERY           = CRYPT_ACTIVATE_RECOVERY,
+#ifdef CRYPT_ACTIVATE_NO_JOURNAL_BITMAP
+    BD_CRYPTO_INTEGRITY_OPEN_NO_JOURNAL_BITMAP  = CRYPT_ACTIVATE_NO_JOURNAL_BITMAP,
+#endif
+    BD_CRYPTO_INTEGRITY_OPEN_RECALCULATE        = CRYPT_ACTIVATE_RECALCULATE,
+#ifdef CRYPT_ACTIVATE_RECALCULATE_RESET
+    BD_CRYPTO_INTEGRITY_OPEN_RECALCULATE_RESET  = CRYPT_ACTIVATE_RECALCULATE_RESET,
+#endif
+    BD_CRYPTO_INTEGRITY_OPEN_ALLOW_DISCARDS     = CRYPT_ACTIVATE_ALLOW_DISCARDS,
+} BDCryptoIntegrityOpenFlags;
 
 #define BD_CRYPTO_TYPE_LUKS_INFO (bd_crypto_luks_info_get_type ())
 GType bd_crypto_luks_info_get_type();
@@ -954,6 +1064,53 @@ BDCryptoIntegrityInfo* bd_crypto_integrity_info (const gchar *device, GError **e
  * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_QUERY
  */
 BDCryptoLUKSTokenInfo** bd_crypto_luks_token_info (const gchar *device, GError **error);
+
+/**
+ * bd_crypto_integrity_format:
+ * @device: a device to format as integrity
+ * @algorithm: integrity algorithm specification (e.g. "crc32c" or "sha256") or %NULL to use the default
+ * @wipe: whether to wipe the device after format; a device that is not initially wiped will contain invalid checksums
+ * @key_data: (allow-none) (array length=key_size): integrity key or %NULL if not needed
+ * @key_size: size the integrity key and @key_data
+ * @extra: (allow-none): extra arguments for integrity format creation
+ * @error: (out): place to store error (if any)
+ *
+ * Formats the given @device as integrity according to the other parameters given.
+ *
+ * Returns: whether the given @device was successfully formatted as integrity or not
+ * (the @error) contains the error in such cases)
+ *
+ * Tech category: %BD_CRYPTO_TECH_INTEGRITY-%BD_CRYPTO_TECH_MODE_CREATE
+ */
+gboolean bd_crypto_integrity_format (const gchar *device, const gchar *algorithm, gboolean wipe, const guint8* key_data, gsize key_size, BDCryptoIntegrityExtra *extra, GError **error);
+
+/**
+ * bd_crypto_integrity_open:
+ * @device: integrity device to open
+ * @name: name for the opened @device
+ * @algorithm: (allow-none): integrity algorithm specification (e.g. "crc32c" or "sha256") or %NULL to use the default
+ * @key_data: (allow-none) (array length=key_size): integrity key or %NULL if not needed
+ * @key_size: size the integrity key and @key_data
+ * @flags: flags for the integrity device activation
+ * @extra: (allow-none): extra arguments for integrity open
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully opened or not
+ *
+ * Tech category: %BD_CRYPTO_TECH_INTEGRITY-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
+ */
+gboolean bd_crypto_integrity_open (const gchar *device, const gchar *name, const gchar *algorithm, const guint8* key_data, gsize key_size, BDCryptoIntegrityOpenFlags flags, BDCryptoIntegrityExtra *extra, GError **error);
+
+/**
+ * bd_crypto_integrity_close:
+ * @integrity_device: integrity device to close
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the given @integrity_device was successfully closed or not
+ *
+ * Tech category: %BD_CRYPTO_TECH_INTEGRITY-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
+ */
+gboolean bd_crypto_integrity_close (const gchar *integrity_device, GError **error);
 
 /**
  * bd_crypto_keyring_add_key:

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -115,6 +115,43 @@ BDCryptoLUKSExtra* bd_crypto_luks_extra_copy (BDCryptoLUKSExtra *extra);
 BDCryptoLUKSExtra* bd_crypto_luks_extra_new (guint64 data_alignment, const gchar *data_device, const gchar *integrity, guint64 sector_size, const gchar *label, const gchar *subsystem, BDCryptoLUKSPBKDF *pbkdf);
 
 /**
+ * BDCryptoIntegrityExtra:
+ * @sector_size: integrity sector size
+ * @journal_size: size of journal in bytes
+ * @journal_watermark: journal flush watermark in percents; in bitmap mode sectors-per-bit
+ * @journal_commit_time: journal commit time (or bitmap flush time) in ms
+ * @interleave_sectors: number of interleave sectors (power of two)
+ * @tag_size: tag size per-sector in bytes
+ * @buffer_sectors: number of sectors in one buffer
+ */
+typedef struct BDCryptoIntegrityExtra {
+    guint32 sector_size;
+    guint64 journal_size;
+    guint journal_watermark;
+    guint journal_commit_time;
+    guint32 interleave_sectors;
+    guint32 tag_size;
+    guint32 buffer_sectors;
+} BDCryptoIntegrityExtra;
+
+void bd_crypto_integrity_extra_free (BDCryptoIntegrityExtra *extra);
+BDCryptoIntegrityExtra* bd_crypto_integrity_extra_copy (BDCryptoIntegrityExtra *extra);
+BDCryptoIntegrityExtra* bd_crypto_integrity_extra_new (guint64 sector_size, guint64 journal_size, guint journal_watermark, guint journal_commit_time, guint64 interleave_sectors, guint64 tag_size, guint64 buffer_sectors);
+
+typedef enum {
+    BD_CRYPTO_INTEGRITY_OPEN_NO_JOURNAL         = CRYPT_ACTIVATE_NO_JOURNAL,
+    BD_CRYPTO_INTEGRITY_OPEN_RECOVERY           = CRYPT_ACTIVATE_RECOVERY,
+#ifdef CRYPT_ACTIVATE_NO_JOURNAL_BITMAP
+    BD_CRYPTO_INTEGRITY_OPEN_NO_JOURNAL_BITMAP  = CRYPT_ACTIVATE_NO_JOURNAL_BITMAP,
+#endif
+    BD_CRYPTO_INTEGRITY_OPEN_RECALCULATE        = CRYPT_ACTIVATE_RECALCULATE,
+#ifdef CRYPT_ACTIVATE_RECALCULATE_RESET
+    BD_CRYPTO_INTEGRITY_OPEN_RECALCULATE_RESET  = CRYPT_ACTIVATE_RECALCULATE_RESET,
+#endif
+    BD_CRYPTO_INTEGRITY_OPEN_ALLOW_DISCARDS     = CRYPT_ACTIVATE_ALLOW_DISCARDS,
+} BDCryptoIntegrityOpenFlags;
+
+/**
  * BDCryptoLUKSInfo:
  * @version: LUKS version
  * @cipher: used cipher (e.g. "aes")
@@ -223,6 +260,10 @@ gboolean bd_crypto_luks_header_restore (const gchar *device, const gchar *backup
 BDCryptoLUKSInfo* bd_crypto_luks_info (const gchar *device, GError **error);
 BDCryptoIntegrityInfo* bd_crypto_integrity_info (const gchar *device, GError **error);
 BDCryptoLUKSTokenInfo** bd_crypto_luks_token_info (const gchar *device, GError **error);
+
+gboolean bd_crypto_integrity_format (const gchar *device, const gchar *algorithm, gboolean wipe, const guint8* key_data, gsize key_size, BDCryptoIntegrityExtra *extra, GError **error);
+gboolean bd_crypto_integrity_open (const gchar *device, const gchar *name, const gchar *algorithm, const guint8* key_data, gsize key_size, BDCryptoIntegrityOpenFlags flags, BDCryptoIntegrityExtra *extra, GError **error);
+gboolean bd_crypto_integrity_close (const gchar *integrity_device, GError **error);
 
 gboolean bd_crypto_keyring_add_key (const gchar *key_desc, const guint8 *pass_data, gsize data_len, GError **error);
 

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -329,6 +329,30 @@ def crypto_keyring_add_key(key_desc, key):
 __all__.append("crypto_keyring_add_key")
 
 
+class CryptoIntegrityExtra(BlockDev.CryptoIntegrityExtra):
+    def __new__(cls, sector_size=0, journal_size=0, journal_watermark=0, journal_commit_time=0, interleave_sectors=0, tag_size=0, buffer_sectors=0):
+        ret = BlockDev.CryptoIntegrityExtra.new(sector_size, journal_size, journal_watermark, journal_commit_time, interleave_sectors, tag_size, buffer_sectors)
+        ret.__class__ = cls
+        return ret
+    def __init__(self, *args, **kwargs):   # pylint: disable=unused-argument
+        super(CryptoIntegrityExtra, self).__init__()  #pylint: disable=bad-super-call
+CryptoIntegrityExtra = override(CryptoIntegrityExtra)
+__all__.append("CryptoIntegrityExtra")
+
+
+_crypto_integrity_format = BlockDev.crypto_integrity_format
+@override(BlockDev.crypto_integrity_format)
+def crypto_integrity_format(device, algorithm=None, wipe=True, key_data=None, extra=None):
+    return _crypto_integrity_format(device, algorithm, wipe, key_data, extra)
+__all__.append("crypto_integrity_format")
+
+_crypto_integrity_open = BlockDev.crypto_integrity_open
+@override(BlockDev.crypto_integrity_open)
+def crypto_integrity_open(device, name, algorithm, key_data=None, flags=0, extra=None):
+    return _crypto_integrity_open(device, name, algorithm, key_data, flags, extra)
+__all__.append("crypto_integrity_open")
+
+
 _dm_create_linear = BlockDev.dm_create_linear
 @override(BlockDev.dm_create_linear)
 def dm_create_linear(map_name, device, length, uuid=None):

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -35,6 +35,7 @@ class CryptoTestCase(unittest.TestCase):
     requested_plugins = BlockDev.plugin_specs_from_names(("crypto", "loop"))
 
     _dm_name = "libblockdevTestLUKS"
+    _sparse_size = 1024**3
 
     @classmethod
     def setUpClass(cls):
@@ -48,8 +49,8 @@ class CryptoTestCase(unittest.TestCase):
 
     def setUp(self):
         self.addCleanup(self._clean_up)
-        self.dev_file = create_sparse_tempfile("crypto_test", 1024**3)
-        self.dev_file2 = create_sparse_tempfile("crypto_test2", 1024**3)
+        self.dev_file = create_sparse_tempfile("crypto_test", self._sparse_size)
+        self.dev_file2 = create_sparse_tempfile("crypto_test2", self._sparse_size)
         try:
             self.loop_dev = create_lio_device(self.dev_file)
         except RuntimeError as e:
@@ -1294,6 +1295,7 @@ class CryptoTestBitlk(CryptoTestCase):
 class CryptoTestIntegrity(CryptoTestCase):
 
     _dm_name = "libblockdevTestIntegrity"
+    _sparse_size = 100 * 1024**2
 
     @unittest.skipUnless(HAVE_LUKS2, "Integrity not supported")
     def test_integrity(self):

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import tempfile
 import overrides_hack
+import secrets
 import shutil
 import subprocess
 import locale
@@ -33,6 +34,8 @@ class CryptoTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("crypto", "loop"))
 
+    _dm_name = "libblockdevTestLUKS"
+
     @classmethod
     def setUpClass(cls):
         unittest.TestCase.setUpClass()
@@ -63,7 +66,7 @@ class CryptoTestCase(unittest.TestCase):
 
     def _clean_up(self):
         try:
-            BlockDev.crypto_luks_close("libblockdevTestLUKS")
+            BlockDev.crypto_luks_close(self._dm_name)
         except:
             pass
 
@@ -1062,7 +1065,7 @@ class CryptoTestLuksSectorSize(CryptoTestCase):
         self.assertTrue(succ)
 
 
-class CryptoTestIntegrity(CryptoTestCase):
+class CryptoTestLUKS2Integrity(CryptoTestCase):
     @tag_test(TestTags.SLOW)
     @unittest.skipUnless(HAVE_LUKS2, "LUKS 2 not supported")
     def test_luks2_integrity(self):
@@ -1286,3 +1289,92 @@ class CryptoTestBitlk(CryptoTestCase):
         succ = BlockDev.crypto_bitlk_close("libblockdevTestBitlk")
         self.assertTrue(succ)
         self.assertFalse(os.path.exists("/dev/mapper/libblockdevTestBitlk"))
+
+
+class CryptoTestIntegrity(CryptoTestCase):
+
+    _dm_name = "libblockdevTestIntegrity"
+
+    @unittest.skipUnless(HAVE_LUKS2, "Integrity not supported")
+    def test_integrity(self):
+        # basic format+open+close test
+        succ = BlockDev.crypto_integrity_format(self.loop_dev, "sha256", False)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "sha256")
+        self.assertTrue(succ)
+        self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+        info = BlockDev.crypto_integrity_info(self._dm_name)
+        self.assertEqual(info.algorithm, "sha256")
+
+        succ = BlockDev.crypto_integrity_close(self._dm_name)
+        self.assertTrue(succ)
+        self.assertFalse(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+        # same now with a keyed algorithm
+        key = list(secrets.token_bytes(64))
+
+        succ = BlockDev.crypto_integrity_format(self.loop_dev, "hmac(sha256)", False, key)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "hmac(sha256)", key)
+        self.assertTrue(succ)
+        self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+        info = BlockDev.crypto_integrity_info(self._dm_name)
+        self.assertEqual(info.algorithm, "hmac(sha256)")
+
+        succ = BlockDev.crypto_integrity_close(self._dm_name)
+        self.assertTrue(succ)
+        self.assertFalse(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+        # same with some custom parameters
+        extra = BlockDev.CryptoIntegrityExtra(sector_size=4096, interleave_sectors=65536)
+        succ = BlockDev.crypto_integrity_format(self.loop_dev, "crc32c", wipe=False, extra=extra)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "crc32c")
+        self.assertTrue(succ)
+        self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+        info = BlockDev.crypto_integrity_info(self._dm_name)
+        self.assertEqual(info.algorithm, "crc32c")
+        self.assertEqual(info.sector_size, 4096)
+        self.assertEqual(info.interleave_sectors, 65536)
+
+        succ = BlockDev.crypto_integrity_close(self._dm_name)
+        self.assertTrue(succ)
+        self.assertFalse(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+    @tag_test(TestTags.SLOW)
+    @unittest.skipUnless(HAVE_LUKS2, "Integrity not supported")
+    def test_integrity_wipe(self):
+        # also check that wipe progress reporting works
+        progress_log = []
+
+        def _my_progress_func(_task, _status, completion, msg):
+            progress_log.append((completion, msg))
+
+        succ = BlockDev.utils_init_prog_reporting(_my_progress_func)
+        self.assertTrue(succ)
+        self.addCleanup(BlockDev.utils_init_prog_reporting, None)
+
+        succ = BlockDev.crypto_integrity_format(self.loop_dev, "sha256", True)
+        self.assertTrue(succ)
+
+        # at least one message "Integrity device wipe in progress" should be logged
+        self.assertTrue(any(prog[1] == "Integrity device wipe in progress" for prog in progress_log))
+
+        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "sha256")
+        self.assertTrue(succ)
+        self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
+
+        # check the devices was wiped and the checksums recalculated
+        # (mkfs reads some blocks first so without checksums it would fail)
+        ret, _out, err = run_command("mkfs.ext2 /dev/mapper/%s " % self._dm_name)
+        self.assertEqual(ret, 0, msg="Failed to create ext2 filesystem on integrity: %s" % err)
+
+        succ = BlockDev.crypto_integrity_close(self._dm_name)
+        self.assertTrue(succ)
+        self.assertFalse(os.path.exists("/dev/mapper/%s" % self._dm_name))


### PR DESCRIPTION
This adds support for create, open and close actions for standalone
integrity devices using cryptsetup.

----- 

I'm creating this as a draft, because I'm still not 100 % sure the API for `integrity_format` and `integrity_open` makes sense and I might change it a bit when working on the blivet part of the integrity support.