### PR TITLE
crypto: Include libcryptsetup.h in crypto.h to fix compile errors

### DIFF
--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -1,5 +1,6 @@
 #include <glib.h>
 #include <blockdev/utils.h>
+#include <libcryptsetup.h>
 
 #ifndef BD_CRYPTO
 #define BD_CRYPTO


### PR DESCRIPTION
We use some libcryptsetup constants in crypto.h.

----

/me wonders if using the cryptsetup flags directly for `BDCryptoIntegrityOpenFlags` is the best idea. It might be better to "translate" those to the cryptsetup flags in `bd_crypto_integrity_open` and avoid including libcryptsetup.h here and in `crypto.api`. Thoughts?