### PR TITLE
lvm: Report special error when system.devices file is not enabled

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -34,6 +34,7 @@ typedef enum {
     BD_LVM_ERROR_FAIL,
     BD_LVM_ERROR_NOT_SUPPORTED,
     BD_LVM_ERROR_VDO_POLICY_INVAL,
+    BD_LVM_ERROR_DEVICES_DISABLED,
 } BDLVMError;
 
 typedef enum {

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -4303,6 +4303,64 @@ BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_nam
     return stats;
 }
 
+/* check whether the LVM devices file is enabled by LVM
+ * we use the existence of the "lvmdevices" command to check whether the feature is available
+ * or not, but this can still be disabled either in LVM or in lvm.conf
+ */
+static gboolean _lvm_devices_enabled () {
+    const gchar *args[6] = {"lvmconfig", "--typeconfig", NULL, "devices/use_devicesfile", NULL, NULL};
+    gboolean ret = FALSE;
+    GError *loc_error = NULL;
+    gchar *output = NULL;
+    gboolean enabled = FALSE;
+    gint scanned = 0;
+    g_autofree gchar *config_arg = NULL;
+
+    /* try current config first -- if we get something from this it means the feature is
+       explicitly enabled or disabled by system lvm.conf or using the --config option */
+    args[2] = "current";
+
+    /* make sure to include the global config from us when getting the current config value */
+    g_mutex_lock (&global_config_lock);
+    if (global_config_str) {
+        config_arg = g_strdup_printf ("--config=%s", global_config_str);
+        args[4] = config_arg;
+    }
+
+    ret = bd_utils_exec_and_capture_output (args, NULL, &output, &loc_error);
+    g_mutex_unlock (&global_config_lock);
+    if (ret) {
+        scanned = sscanf (output, "use_devicesfile=%u", &enabled);
+        g_free (output);
+        if (scanned != 1)
+            return FALSE;
+
+        return enabled;
+    } else {
+        g_clear_error (&loc_error);
+        g_free (output);
+    }
+
+    output = NULL;
+
+    /* now try default */
+    args[2] = "default";
+    ret = bd_utils_exec_and_capture_output (args, NULL, &output, &loc_error);
+    if (ret) {
+        scanned = sscanf (output, "# use_devicesfile=%u", &enabled);
+        g_free (output);
+        if (scanned != 1)
+            return FALSE;
+
+        return enabled;
+    } else {
+        g_clear_error (&loc_error);
+        g_free (output);
+    }
+
+    return FALSE;
+}
+
 /**
  * bd_lvm_devices_add:
  * @device: device (PV) to add to the devices file
@@ -4320,6 +4378,12 @@ gboolean bd_lvm_devices_add (const gchar *device, const gchar *devices_file, con
 
     if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
         return FALSE;
+
+    if (!_lvm_devices_enabled ()) {
+        g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_DEVICES_DISABLED,
+                     "LVM devices file not enabled.");
+        return FALSE;
+    }
 
     if (devices_file) {
         devfile = g_strdup_printf ("--devicesfile=%s", devices_file);
@@ -4346,6 +4410,12 @@ gboolean bd_lvm_devices_delete (const gchar *device, const gchar *devices_file, 
 
     if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
         return FALSE;
+
+    if (!_lvm_devices_enabled ()) {
+        g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_DEVICES_DISABLED,
+                     "LVM devices file not enabled.");
+        return FALSE;
+    }
 
     if (devices_file) {
         devfile = g_strdup_printf ("--devicesfile=%s", devices_file);

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -3439,6 +3439,54 @@ BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_nam
     return stats;
 }
 
+/* check whether the LVM devices file is enabled by LVM
+ * we use the existence of the "lvmdevices" command to check whether the feature is available
+ * or not, but this can still be disabled either in LVM or in lvm.conf
+ */
+static gboolean _lvm_devices_enabled () {
+    const gchar *args[5] = {"config", "--typeconfig", NULL, "devices/use_devicesfile", NULL};
+    gboolean ret = FALSE;
+    GError *loc_error = NULL;
+    gchar *output = NULL;
+    gboolean enabled = FALSE;
+    gint scanned = 0;
+
+    /* try current config first -- if we get something from this it means the feature is
+       explicitly enabled or disabled by system lvm.conf or using the --config option */
+    args[2] = "current";
+    ret = call_lvm_and_capture_output (args, NULL, &output, &loc_error);
+    if (ret) {
+        scanned = sscanf (output, "use_devicesfile=%u", &enabled);
+        g_free (output);
+        if (scanned != 1)
+            return FALSE;
+
+        return enabled;
+    } else {
+        g_clear_error (&loc_error);
+        g_free (output);
+    }
+
+    output = NULL;
+
+    /* now try default */
+    args[2] = "default";
+    ret = call_lvm_and_capture_output (args, NULL, &output, &loc_error);
+    if (ret) {
+        scanned = sscanf (output, "# use_devicesfile=%u", &enabled);
+        g_free (output);
+        if (scanned != 1)
+            return FALSE;
+
+        return enabled;
+    } else {
+        g_clear_error (&loc_error);
+        g_free (output);
+    }
+
+    return FALSE;
+}
+
 /**
  * bd_lvm_devices_add:
  * @device: device (PV) to add to the devices file
@@ -3456,6 +3504,12 @@ gboolean bd_lvm_devices_add (const gchar *device, const gchar *devices_file, con
 
     if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
         return FALSE;
+
+    if (!_lvm_devices_enabled ()) {
+        g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_DEVICES_DISABLED,
+                     "LVM devices file not enabled.");
+        return FALSE;
+    }
 
     if (devices_file) {
         devfile = g_strdup_printf ("--devicesfile=%s", devices_file);
@@ -3482,6 +3536,12 @@ gboolean bd_lvm_devices_delete (const gchar *device, const gchar *devices_file, 
 
     if (!bd_lvm_is_tech_avail (BD_LVM_TECH_DEVICES, 0, error))
         return FALSE;
+
+    if (!_lvm_devices_enabled ()) {
+        g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_DEVICES_DISABLED,
+                     "LVM devices file not enabled.");
+        return FALSE;
+    }
 
     if (devices_file) {
         devfile = g_strdup_printf ("--devicesfile=%s", devices_file);

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -38,6 +38,7 @@ typedef enum {
     BD_LVM_ERROR_FAIL,
     BD_LVM_ERROR_NOT_SUPPORTED,
     BD_LVM_ERROR_VDO_POLICY_INVAL,
+    BD_LVM_ERROR_DEVICES_DISABLED,
 } BDLVMError;
 
 typedef enum {

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1974,6 +1974,12 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
         if not self.devices_avail:
             self.skipTest("skipping LVM devices file test: not supported")
 
+        self.addCleanup(BlockDev.lvm_set_global_config, "")
+
+        # force-enable the feature, it might be disabled by default
+        succ = BlockDev.lvm_set_global_config("devices { use_devicesfile=1 }")
+        self.assertTrue(succ)
+
         succ = BlockDev.lvm_pvcreate(self.loop_dev)
         self.assertTrue(succ)
 
@@ -1994,6 +2000,8 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
         dfile = read_file("/etc/lvm/devices/" + self.devicefile)
         self.assertNotIn(self.loop_dev, dfile)
+
+        BlockDev.lvm_set_global_config("")
 
     def test_devices_enabled(self):
         if not self.devices_avail:

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1994,3 +1994,18 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
         dfile = read_file("/etc/lvm/devices/" + self.devicefile)
         self.assertNotIn(self.loop_dev, dfile)
+
+    def test_devices_enabled(self):
+        if not self.devices_avail:
+            self.skipTest("skipping LVM devices file test: not supported")
+
+        self.addCleanup(BlockDev.lvm_set_global_config, "")
+
+        # checking if the feature is enabled or disabled is hard so lets just disable
+        # the devices file using the global config and check lvm_devices_add fails
+        # with the correct exception message
+        succ = BlockDev.lvm_set_global_config("devices { use_devicesfile=0 }")
+        self.assertTrue(succ)
+
+        with self.assertRaisesRegex(GLib.GError, "LVM devices file not enabled."):
+            BlockDev.lvm_devices_add("", self.devicefile)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1955,6 +1955,12 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
         if not self.devices_avail:
             self.skipTest("skipping LVM devices file test: not supported")
 
+        self.addCleanup(BlockDev.lvm_set_global_config, "")
+
+        # force-enable the feature, it might be disabled by default
+        succ = BlockDev.lvm_set_global_config("devices { use_devicesfile=1 }")
+        self.assertTrue(succ)
+
         succ = BlockDev.lvm_pvcreate(self.loop_dev)
         self.assertTrue(succ)
 
@@ -1975,6 +1981,8 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
         dfile = read_file("/etc/lvm/devices/" + self.devicefile)
         self.assertNotIn(self.loop_dev, dfile)
+
+        BlockDev.lvm_set_global_config("")
 
     def test_devices_enabled(self):
         if not self.devices_avail:

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1975,3 +1975,18 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
         dfile = read_file("/etc/lvm/devices/" + self.devicefile)
         self.assertNotIn(self.loop_dev, dfile)
+
+    def test_devices_enabled(self):
+        if not self.devices_avail:
+            self.skipTest("skipping LVM devices file test: not supported")
+
+        self.addCleanup(BlockDev.lvm_set_global_config, "")
+
+        # checking if the feature is enabled or disabled is hard so lets just disable
+        # the devices file using the global config and check lvm_devices_add fails
+        # with the correct exception message
+        succ = BlockDev.lvm_set_global_config("devices { use_devicesfile=0 }")
+        self.assertTrue(succ)
+
+        with self.assertRaisesRegex(GLib.GError, "LVM devices file not enabled."):
+            BlockDev.lvm_devices_add("", self.devicefile)


### PR DESCRIPTION
This can be disabled either in LVM by a compile time option or
by a lvm.conf option so we should report a specific error for this
case so users can distinguish between the feature not being enabled
and not being supported at all.