### PR TITLE
tests: Skip NVDIMM enable/disable and reconfigure tests on rawhide

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -67,3 +67,9 @@
     - distro: "centos"
       version: "9"
       reason: "snapshot merge doesn't work on CentOS 9 Stream with LVM DBus API"
+
+- test: nvdimm_test.NVDIMMNoDevTest.(test_enable_disable|test_namespace_reconfigure)
+  skip_on:
+    - distro: "fedora"
+      version: "36"
+      reason: "Namespace disabling and reconfiguration hangs in kernel on rawhide"


### PR DESCRIPTION
Something is broken on rawhide kernel and kills our CI so we'll just temporary skip those two tests.