### PR TITLE
Fix setting "empty" global config for LVM commands

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -3000,7 +3000,10 @@ gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error UNUSE
     g_free (global_config_str);
 
     /* now store the new one */
-    global_config_str = g_strdup (new_config);
+    if (!new_config || g_strcmp0 (new_config, "") == 0)
+         global_config_str = NULL;
+    else
+        global_config_str = g_strdup (new_config);
 
     g_mutex_unlock (&global_config_lock);
     return TRUE;

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -2171,7 +2171,10 @@ gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error UNUSE
     g_free (global_config_str);
 
     /* now store the new one */
-    global_config_str = g_strdup (new_config);
+    if (!new_config || g_strcmp0 (new_config, "") == 0)
+         global_config_str = NULL;
+    else
+        global_config_str = g_strdup (new_config);
 
     g_mutex_unlock (&global_config_lock);
     return TRUE;

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -2017,3 +2017,15 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
         with self.assertRaisesRegex(GLib.GError, "LVM devices file not enabled."):
             BlockDev.lvm_devices_add("", self.devicefile)
+
+
+class LvmConfigTestPvremove(LvmPVonlyTestCase):
+
+    @tag_test(TestTags.REGRESSION)
+    def test_set_empty_config(self):
+        succ = BlockDev.lvm_pvcreate(self.loop_dev)
+        self.assertTrue(succ)
+
+        BlockDev.lvm_set_global_config("")
+        succ = BlockDev.lvm_pvremove(self.loop_dev)
+        self.assertTrue(succ)

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1974,7 +1974,7 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
         if not self.devices_avail:
             self.skipTest("skipping LVM devices file test: not supported")
 
-        self.addCleanup(BlockDev.lvm_set_global_config, "")
+        self.addCleanup(BlockDev.lvm_set_global_config, None)
 
         # force-enable the feature, it might be disabled by default
         succ = BlockDev.lvm_set_global_config("devices { use_devicesfile=1 }")
@@ -2001,13 +2001,13 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
         dfile = read_file("/etc/lvm/devices/" + self.devicefile)
         self.assertNotIn(self.loop_dev, dfile)
 
-        BlockDev.lvm_set_global_config("")
+        BlockDev.lvm_set_global_config(None)
 
     def test_devices_enabled(self):
         if not self.devices_avail:
             self.skipTest("skipping LVM devices file test: not supported")
 
-        self.addCleanup(BlockDev.lvm_set_global_config, "")
+        self.addCleanup(BlockDev.lvm_set_global_config, None)
 
         # checking if the feature is enabled or disabled is hard so lets just disable
         # the devices file using the global config and check lvm_devices_add fails

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1998,3 +1998,15 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
         with self.assertRaisesRegex(GLib.GError, "LVM devices file not enabled."):
             BlockDev.lvm_devices_add("", self.devicefile)
+
+
+class LvmConfigTestPvremove(LvmPVonlyTestCase):
+
+    @tag_test(TestTags.REGRESSION)
+    def test_set_empty_config(self):
+        succ = BlockDev.lvm_pvcreate(self.loop_dev)
+        self.assertTrue(succ)
+
+        BlockDev.lvm_set_global_config("")
+        succ = BlockDev.lvm_pvremove(self.loop_dev)
+        self.assertTrue(succ)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1955,7 +1955,7 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
         if not self.devices_avail:
             self.skipTest("skipping LVM devices file test: not supported")
 
-        self.addCleanup(BlockDev.lvm_set_global_config, "")
+        self.addCleanup(BlockDev.lvm_set_global_config, None)
 
         # force-enable the feature, it might be disabled by default
         succ = BlockDev.lvm_set_global_config("devices { use_devicesfile=1 }")
@@ -1982,13 +1982,13 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
         dfile = read_file("/etc/lvm/devices/" + self.devicefile)
         self.assertNotIn(self.loop_dev, dfile)
 
-        BlockDev.lvm_set_global_config("")
+        BlockDev.lvm_set_global_config(None)
 
     def test_devices_enabled(self):
         if not self.devices_avail:
             self.skipTest("skipping LVM devices file test: not supported")
 
-        self.addCleanup(BlockDev.lvm_set_global_config, "")
+        self.addCleanup(BlockDev.lvm_set_global_config, None)
 
         # checking if the feature is enabled or disabled is hard so lets just disable
         # the devices file using the global config and check lvm_devices_add fails


### PR DESCRIPTION
This fixes issue where using `BlockDev.lvm_set_global_config("")` will cause all commands to be run with `--config` without parameter, so for example for `pvremove` we will call `pvremove --config /dev/sda`. It doesn't make sense to call lvm with empty config, `--config ""` doesn't replace/remove defaults from `/etc/lvm/lvm.conf` so if user set's it to an empty string we should just ignore it and set the internal variable to `NULL`.