### PR TITLE
lvm: Allow using empty name for VDO pool when creating VDO volumes

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -1558,7 +1558,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  * bd_lvm_vdo_pool_create:
  * @vg_name: name of the VG to create a new LV in
  * @lv_name: name of the to-be-created VDO LV
- * @pool_name: name of the to-be-created VDO pool LV
+ * @pool_name: (allow-none): name of the to-be-created VDO pool LV or %NULL for default name
  * @data_size: requested size of the data VDO LV (physical size of the @pool_name VDO pool LV)
  * @virtual_size: requested virtual_size of the @lv_name VDO LV
  * @index_memory: amount of index memory (in bytes) or 0 for default

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -3839,7 +3839,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  * bd_lvm_vdo_pool_create:
  * @vg_name: name of the VG to create a new LV in
  * @lv_name: name of the to-be-created VDO LV
- * @pool_name: name of the to-be-created VDO pool LV
+ * @pool_name: (allow-none): name of the to-be-created VDO pool LV or %NULL for default name
  * @data_size: requested size of the data VDO LV (physical size of the @pool_name VDO pool LV)
  * @virtual_size: requested virtual_size of the @lv_name VDO LV
  * @index_memory: amount of index memory (in bytes) or 0 for default
@@ -3860,6 +3860,7 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
     GVariant *extra_params = NULL;
     gchar *old_config = NULL;
     const gchar *write_policy_str = NULL;
+    g_autofree gchar *name = NULL;
 
     write_policy_str = bd_lvm_get_vdo_write_policy_str (write_policy, error);
     if (*error)
@@ -3867,7 +3868,13 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
 
     /* build the params tuple */
     g_variant_builder_init (&builder, G_VARIANT_TYPE_TUPLE);
-    g_variant_builder_add_value (&builder, g_variant_new ("s", pool_name));
+
+    if (!pool_name) {
+        name = g_strdup_printf ("%s_vpool", lv_name);
+        g_variant_builder_add_value (&builder, g_variant_new ("s", name));
+    } else
+        g_variant_builder_add_value (&builder, g_variant_new ("s", pool_name));
+
     g_variant_builder_add_value (&builder, g_variant_new ("s", lv_name));
     g_variant_builder_add_value (&builder, g_variant_new ("t", data_size));
     g_variant_builder_add_value (&builder, g_variant_new ("t", virtual_size));

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -2908,7 +2908,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
  * bd_lvm_vdo_pool_create:
  * @vg_name: name of the VG to create a new LV in
  * @lv_name: name of the to-be-created VDO LV
- * @pool_name: name of the to-be-created VDO pool LV
+ * @pool_name: (allow-none): name of the to-be-created VDO pool LV or %NULL for default name
  * @data_size: requested size of the data VDO LV (physical size of the @pool_name VDO pool LV)
  * @virtual_size: requested virtual_size of the @lv_name VDO LV
  * @index_memory: amount of index memory (in bytes) or 0 for default
@@ -2938,7 +2938,11 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
 
     args[6] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", data_size / 1024);
     args[8] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", virtual_size / 1024);
-    args[14] = g_strdup_printf ("%s/%s", vg_name, pool_name);
+
+    if (pool_name) {
+        args[14] = g_strdup_printf ("%s/%s", vg_name, pool_name);
+    } else
+        args[14] = vg_name;
 
     /* index_memory and write_policy can be specified only using the config */
     g_mutex_lock (&global_config_lock);
@@ -2959,7 +2963,9 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
 
     g_free ((gchar *) args[6]);
     g_free ((gchar *) args[8]);
-    g_free ((gchar *) args[14]);
+
+    if (pool_name)
+        g_free ((gchar *) args[14]);
 
     return success;
 }

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1904,6 +1904,20 @@ class LVMVDOTest(LVMTestCase):
         self.assertEqual(BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy), "sync")
 
     @tag_test(TestTags.SLOW)
+    def test_vdo_pool_create_noname(self):
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", None, 7 * 1024**3, 35 * 1024**3)
+        self.assertTrue(succ)
+
+        lv_info = BlockDev.lvm_lvinfo("testVDOVG", "vdoLV")
+        self.assertIsNotNone(lv_info)
+        self.assertEqual(lv_info.segtype, "vdo")
+
+        pool_name = BlockDev.lvm_vdolvpoolname("testVDOVG", "vdoLV")
+        self.assertEqual(lv_info.pool_lv, pool_name)
+        pool_info = BlockDev.lvm_lvinfo("testVDOVG", pool_name)
+        self.assertEqual(pool_info.segtype, "vdo-pool")
+
+    @tag_test(TestTags.SLOW)
     def test_resize(self):
         succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 5 * 1024**3, 10 * 1024**3)
         self.assertTrue(succ)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1823,6 +1823,20 @@ class LVMVDOTest(LVMTestCase):
         self.assertEqual(BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy), "sync")
 
     @tag_test(TestTags.SLOW)
+    def test_vdo_pool_create_noname(self):
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", None, 7 * 1024**3, 35 * 1024**3)
+        self.assertTrue(succ)
+
+        lv_info = BlockDev.lvm_lvinfo("testVDOVG", "vdoLV")
+        self.assertIsNotNone(lv_info)
+        self.assertEqual(lv_info.segtype, "vdo")
+
+        pool_name = BlockDev.lvm_vdolvpoolname("testVDOVG", "vdoLV")
+        self.assertEqual(lv_info.pool_lv, pool_name)
+        pool_info = BlockDev.lvm_lvinfo("testVDOVG", pool_name)
+        self.assertEqual(pool_info.segtype, "vdo-pool")
+
+    @tag_test(TestTags.SLOW)
     def test_resize(self):
         succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 5 * 1024**3, 10 * 1024**3)
         self.assertTrue(succ)


### PR DESCRIPTION
LVM doesn't need it to create the VDO pool/VDO LV pair so we
shouldn't require it.

Related: https://github.com/storaged-project/udisks/issues/939