### PR TITLE
lvm: Use "lvmconfig full" to get valid config instead of "current"

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -4316,9 +4316,9 @@ static gboolean _lvm_devices_enabled () {
     gint scanned = 0;
     g_autofree gchar *config_arg = NULL;
 
-    /* try current config first -- if we get something from this it means the feature is
+    /* try full config first -- if we get something from this it means the feature is
        explicitly enabled or disabled by system lvm.conf or using the --config option */
-    args[2] = "current";
+    args[2] = "full";
 
     /* make sure to include the global config from us when getting the current config value */
     g_mutex_lock (&global_config_lock);

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -3451,9 +3451,9 @@ static gboolean _lvm_devices_enabled () {
     gboolean enabled = FALSE;
     gint scanned = 0;
 
-    /* try current config first -- if we get something from this it means the feature is
+    /* try full config first -- if we get something from this it means the feature is
        explicitly enabled or disabled by system lvm.conf or using the --config option */
-    args[2] = "current";
+    args[2] = "full";
     ret = call_lvm_and_capture_output (args, NULL, &output, &loc_error);
     if (ret) {
         scanned = sscanf (output, "use_devicesfile=%u", &enabled);


### PR DESCRIPTION
"lvmconfig current" doesn't work together with --config even if we
don't override the "use_devicefile" key. "lvmconfig full" seems to
be working in all cases.

----

This is unfortunately hard to test because there isn't a better way to check whether the `use_devicefile` feature is enabled or not (it's a compile time option and is different even with same versions of LVM on different versions of RHEL/CentOS).