### PR TITLE
vdo_stats: Default to 100 % savings for invalid savings values

### DIFF
--- a/src/plugins/vdo_stats.c
+++ b/src/plugins/vdo_stats.c
@@ -96,7 +96,7 @@ static void add_block_stats (GHashTable *stats) {
     g_hash_table_replace (stats, g_strdup ("oneKBlocksUsed"), g_strdup_printf ("%"G_GINT64_FORMAT, (data_blocks_used + overhead_blocks_used) * block_size / 1024));
     g_hash_table_replace (stats, g_strdup ("oneKBlocksAvailable"), g_strdup_printf ("%"G_GINT64_FORMAT, (physical_blocks - data_blocks_used - overhead_blocks_used) * block_size / 1024));
     g_hash_table_replace (stats, g_strdup ("usedPercent"), g_strdup_printf ("%.0f", 100.0 * (gfloat) (data_blocks_used + overhead_blocks_used) / (gfloat) physical_blocks + 0.5));
-    savings = (logical_blocks_used > 0) ? (gint64) (100.0 * (gfloat) (logical_blocks_used - data_blocks_used) / (gfloat) logical_blocks_used) : -1;
+    savings = (logical_blocks_used > 0) ? (gint64) (100.0 * (gfloat) (logical_blocks_used - data_blocks_used) / (gfloat) logical_blocks_used) : 100;
     g_hash_table_replace (stats, g_strdup ("savings"), g_strdup_printf ("%"G_GINT64_FORMAT, savings));
     if (savings >= 0)
         g_hash_table_replace (stats, g_strdup ("savingPercent"), g_strdup_printf ("%"G_GINT64_FORMAT, savings));


### PR DESCRIPTION
We are currently using "-1" when VDO logical_blocks_used is 0
which doesn't match the LVM logic which returns 100 so to make
both values in vdo_info and vdo_stats equal we should return 100
in this case too.

Port of #674 to 2.x to make our CI happy.