### PR TITLE
tests: Fix creating loop device for CryptoTestLuksSectorSize

### DIFF
--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -1006,7 +1006,7 @@ class CryptoTestLuksSectorSize(CryptoTestCase):
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev = "/dev/%s" % loop
 
-        succ, loop = BlockDev.loop_setup(self.dev_file)
+        succ, loop = BlockDev.loop_setup(self.dev_file2)
         if not succ:
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev2 = "/dev/%s" % loop


### PR DESCRIPTION
I'm amazed that creating two loop devices backed with a single file and then changing sector size of one of them to 4k actually works, but it probably explains why the test randomly fails when trying change the sector size.