### PR TITLE
spec: Require the same version of utils for lvm-devel and lvm-dbus-devel

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -353,7 +353,7 @@ providing the LVM-related functionality.
 %package lvm-devel
 Summary:     Development files for the libblockdev-lvm plugin/library
 Requires: %{name}-lvm%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description lvm-devel
@@ -375,7 +375,7 @@ providing the LVM-related functionality utilizing the LVM DBus API.
 %package lvm-dbus-devel
 Summary:     Development files for the libblockdev-lvm-dbus plugin/library
 Requires: %{name}-lvm-dbus%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa} >= 1.4
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description lvm-dbus-devel


### PR DESCRIPTION
subpackages. This is a kind of hack to make sure both packages are
always on the same version.

----

The problem is the `/usr/include/blockdev/lvm.h` header file which is "shared" between `libblockdev-lvm-devel` and `libblockdev-lvm-dbus-devel`. But because there is no relation/dependency between those two package, it is possible to upgrade only one of them. Or it actually isn't possible because the upgrade will fail with a file conflict

```
Error: Transaction test error:
  file /usr/include/blockdev/lvm.h from install of libblockdev-lvm-dbus-devel-2.25-9.el9.x86_64 conflicts with file from package libblockdev-lvm-devel-2.25-7.el9.x86_64
```

(obviously only if there is a difference in `lmv.h` between the two versions). If we require `libblockdev-utils-devel%{?_isa} = %{version}-%{release}` for both of them, this will be solved -- upgrade of `libblockdev-lvm-devel` will force upgrade of `libblockdev-utils-devel` which will force upgrade `libblockdev-lvm-dbus-devel`. If you have a better idea how to deal with this, feel free to share it. The only other way how to solve this I can think of, is to use `Conflicts` which might break more things.