### PR TITLE
fs: Return BD_FS_ERROR_NOFS on unknown filesystem

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -22,6 +22,7 @@ typedef enum {
     BD_FS_ERROR_AUTH,
     BD_FS_ERROR_TECH_UNAVAIL,
     BD_FS_ERROR_UUID_INVALID,
+    BD_FS_ERROR_UNKNOWN_FS,
 } BDFsError;
 
 /**

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -18,6 +18,7 @@ typedef enum {
     BD_FS_ERROR_TECH_UNAVAIL,
     BD_FS_ERROR_LABEL_INVALID,
     BD_FS_ERROR_UUID_INVALID,
+    BD_FS_ERROR_UNKNOWN_FS,
 } BDFsError;
 
 /* XXX: where the file systems start at the enum of technologies */

--- a/src/plugins/fs/mount.c
+++ b/src/plugins/fs/mount.c
@@ -227,7 +227,7 @@ static gboolean get_mount_error_old (struct libmnt_context *cxt, int rc, MountAr
                     g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
                                  "Filesystem type not specified");
                 else
-                    g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                    g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UNKNOWN_FS,
                                  "Filesystem type %s not configured in kernel.", args->fstype);
                 break;
             case EROFS:
@@ -343,6 +343,9 @@ static gboolean get_mount_error_new (struct libmnt_context *cxt, int rc, MountAr
         if (permission)
             g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_AUTH,
                          "Operation not permitted.");
+        else if (syscall_errno == ENODEV)
+            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UNKNOWN_FS,
+                         "Filesystem type %s not configured in kernel.", args->fstype);
         else {
             if (*buf == '\0')
                 g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,

--- a/tests/fs_tests/mount_test.py
+++ b/tests/fs_tests/mount_test.py
@@ -46,6 +46,10 @@ class MountTestCase(FSTestCase):
 
         self.addCleanup(utils.umount, self.loop_dev)
 
+        # try mounting unknown filesystem type
+        with self.assertRaisesRegex(GLib.GError, r"Filesystem type .* not configured in kernel."):
+            BlockDev.fs_mount(self.loop_dev, tmp, "nonexisting", None)
+
         succ = BlockDev.fs_mount(self.loop_dev, tmp, "vfat", None)
         self.assertTrue(succ)
         self.assertTrue(os.path.ismount(tmp))


### PR DESCRIPTION
According to the mount(2) syscall manpage the return code
for an unknown filesystem is ENODEV, not shared with any other
error condition.