### PR TITLE
fs: Return BD_FS_ERROR_UNKNOWN_FS on mounting unknown filesystem

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -21,6 +21,7 @@ typedef enum {
     BD_FS_ERROR_NOT_MOUNTED,
     BD_FS_ERROR_AUTH,
     BD_FS_ERROR_TECH_UNAVAIL,
+    BD_FS_ERROR_UNKNOWN_FS = 11,
 } BDFsError;
 
 #define BD_FS_TYPE_EXT2_INFO (bd_fs_ext2_info_get_type ())

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -16,6 +16,7 @@ typedef enum {
     BD_FS_ERROR_NOT_MOUNTED,
     BD_FS_ERROR_AUTH, // keep this entry last (XXX?)
     BD_FS_ERROR_TECH_UNAVAIL,
+    BD_FS_ERROR_UNKNOWN_FS = 11,
 } BDFsError;
 
 /* XXX: where the file systems start at the enum of technologies */

--- a/src/plugins/fs/mount.c
+++ b/src/plugins/fs/mount.c
@@ -227,7 +227,7 @@ static gboolean get_mount_error_old (struct libmnt_context *cxt, int rc, MountAr
                     g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
                                  "Filesystem type not specified");
                 else
-                    g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                    g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UNKNOWN_FS,
                                  "Filesystem type %s not configured in kernel.", args->fstype);
                 break;
             case EROFS:
@@ -343,6 +343,9 @@ static gboolean get_mount_error_new (struct libmnt_context *cxt, int rc, MountAr
         if (permission)
             g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_AUTH,
                          "Operation not permitted.");
+        else if (syscall_errno == ENODEV)
+            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_UNKNOWN_FS,
+                         "Filesystem type %s not configured in kernel.", args->fstype);
         else {
             if (*buf == '\0')
                 g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1050,6 +1050,10 @@ class MountTest(FSTestCase):
 
         self.addCleanup(umount, self.loop_dev)
 
+        # try mounting unknown filesystem type
+        with self.assertRaisesRegex(GLib.GError, r"Filesystem type .* not configured in kernel."):
+            BlockDev.fs_mount(self.loop_dev, tmp, "nonexisting", None)
+
         succ = BlockDev.fs_mount(self.loop_dev, tmp, "vfat", None)
         self.assertTrue(succ)
         self.assertTrue(os.path.ismount(tmp))


### PR DESCRIPTION
According to the mount(2) syscall manpage the return code
for an unknown filesystem is ENODEV, not shared with any other
error condition.

This necessarily involves return code change from BD_FS_ERROR_FAIL.

(cherry picked from commit 7577eae8a87831ab238b5ff804bb28f64180a812)