### PR TITLE
Provide replacement function for strerror_l()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,8 @@ AC_CHECK_HEADERS([dlfcn.h string.h unistd.h sys/fcntl.h sys/ioctl.h linux/random
                  [LIBBLOCKDEV_SOFT_FAILURE([Header file $ac_header not found.])],
                  [])
 
+AC_CHECK_FUNCS([strerror_l])
+
 AC_ARG_WITH([bcache],
     AS_HELP_STRING([--with-bcache], [support bcache @<:@default=yes@:>@]),
     [],

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -71,6 +71,13 @@
 
 #define UNUSED __attribute__((unused))
 
+#if !defined(HAVE_STRERROR_L)
+static char *strerror_l(int errnum, locale_t locale UNUSED)
+{
+	return strerror(errnum);
+}
+#endif
+
 /**
  * SECTION: crypto
  * @short_description: plugin for operations with encrypted devices

--- a/src/utils/module.c
+++ b/src/utils/module.c
@@ -259,6 +259,14 @@ gboolean bd_utils_unload_kernel_module (const gchar *module_name, GError **error
     return TRUE;
 }
 
+#define UNUSED __attribute__((unused))
+
+#if !defined(HAVE_STRERROR_L)
+static char *strerror_l(int errnum, locale_t locale UNUSED)
+{
+	return strerror(errnum);
+}
+#endif
 
 static BDUtilsLinuxVersion detected_linux_ver;
 static gboolean have_linux_ver = FALSE;


### PR DESCRIPTION
`strerror_l()` is not implemented in some C libraries, such as uClibc, so let's provide a simple replacement function that falls back on `strerror()`.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
[Retrieved from: https://git.buildroot.net/buildroot/tree/package/libblockdev/0001-Provide-replacement-function-for-strerror_l.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>