### PR TITLE
install-test-dependencies: Do not install reiserfs-utils on Fedora

### DIFF
--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -60,7 +60,6 @@
       - python3-packaging
       - python3-pylint
       - python3-yaml
-      - reiserfs-utils
       - targetcli
       - udftools
       - volume_key


### PR DESCRIPTION
The package is no longer available on Fedora 35 and newer.