### PR TITLE
libnvme-1.0-rc4 adaptations

### DIFF
--- a/src/lib/plugin_apis/nvme.api
+++ b/src/lib/plugin_apis/nvme.api
@@ -1317,6 +1317,7 @@ gboolean bd_nvme_sanitize (const gchar *device, BDNVMESanitizeAction action, gbo
  * - `"hdr_digest"`: Generates/verifies header digest (TCP). Boolean value.
  * - `"data_digest"`: Generates/verifies data digest (TCP). Boolean value.
  * - `"tls"`: Enable TLS encryption (TCP). Boolean value.
+ * - `"hostsymname"`: TP8010: NVMe host symbolic name.
  *
  * Boolean values can be expressed by "0"/"1", "on"/"off" or "True"/"False" case-insensitive
  * strings. Failed numerical or boolean string conversions will result in the option being ignored.
@@ -1415,6 +1416,7 @@ gboolean bd_nvme_disconnect_by_path (const gchar *path, GError **error);
  * - `"hdr_digest"`: Generates/verifies header digest (TCP). Boolean value.
  * - `"data_digest"`: Generates/verifies data digest (TCP). Boolean value.
  * - `"tls"`: Enable TLS encryption (TCP). Boolean value.
+ * - `"hostsymname"`: TP8010: NVMe host symbolic name.
  *
  * Boolean values can be expressed by "0"/"1", "on"/"off" or "True"/"False" case-insensitive
  * strings. Failed numerical or boolean string conversions will result in the option being ignored.

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -180,7 +180,7 @@ class NVMeTestCase(NVMeTest):
         with self.assertRaisesRegexp(GLib.GError, r".*Failed to open device .*': No such file or directory"):
             BlockDev.nvme_get_self_test_log("/dev/nonexistent")
 
-        message = r"NVMe Get Log Page - Device Self-test Log command error: Invalid Field in Command: A reserved coded value or an unsupported value in a defined field"
+        message = r"NVMe Get Log Page - Device Self-test Log command error: Invalid Field in Command: A reserved coded value or an unsupported value in a defined field|NVMe Get Log Page - Device Self-test Log command error: unrecognized"
         with self.assertRaisesRegexp(GLib.GError, message):
             # Cannot retrieve self-test log on a nvme target loop devices
             BlockDev.nvme_get_self_test_log(self.nvme_dev)
@@ -199,7 +199,7 @@ class NVMeTestCase(NVMeTest):
         with self.assertRaisesRegexp(GLib.GError, message):
             BlockDev.nvme_device_self_test(self.nvme_ns_dev, BlockDev.NVMESelfTestAction.NOT_RUNNING)
 
-        message = r"NVMe Device Self-test command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field"
+        message = r"NVMe Device Self-test command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field|NVMe Device Self-test command error: Invalid Queue Identifier: The creation of the I/O Completion Queue failed due to an invalid queue identifier specified as part of the command"
         with self.assertRaisesRegexp(GLib.GError, message):
             BlockDev.nvme_device_self_test(self.nvme_dev, BlockDev.NVMESelfTestAction.SHORT)
         with self.assertRaisesRegexp(GLib.GError, message):
@@ -235,7 +235,7 @@ class NVMeTestCase(NVMeTest):
             BlockDev.nvme_format(self.nvme_dev, 123, BlockDev.NVMEFormatSecureErase.NONE)
 
         # format doesn't really work on the kernel loop target
-        message = r"Format NVM command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field"
+        message = r"Format NVM command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field|Format NVM command error: Invalid Queue Identifier: The creation of the I/O Completion Queue failed due to an invalid queue identifier specified as part of the command"
         with self.assertRaisesRegexp(GLib.GError, message):
             BlockDev.nvme_format(self.nvme_ns_dev, 0, BlockDev.NVMEFormatSecureErase.NONE)
         with self.assertRaisesRegexp(GLib.GError, message):
@@ -249,7 +249,7 @@ class NVMeTestCase(NVMeTest):
         with self.assertRaisesRegexp(GLib.GError, r".*Failed to open device .*': No such file or directory"):
             BlockDev.nvme_get_sanitize_log("/dev/nonexistent")
 
-        message = r"NVMe Get Log Page - Sanitize Status Log command error: Invalid Field in Command: A reserved coded value or an unsupported value in a defined field"
+        message = r"NVMe Get Log Page - Sanitize Status Log command error: Invalid Field in Command: A reserved coded value or an unsupported value in a defined field|NVMe Get Log Page - Sanitize Status Log command error: unrecognized"
         with self.assertRaisesRegexp(GLib.GError, message):
             # Cannot retrieve sanitize log on a nvme target loop devices
             BlockDev.nvme_get_sanitize_log(self.nvme_dev)
@@ -265,7 +265,7 @@ class NVMeTestCase(NVMeTest):
         with self.assertRaisesRegexp(GLib.GError, message):
             BlockDev.nvme_sanitize("/dev/nonexistent", BlockDev.NVMESanitizeAction.BLOCK_ERASE, False, 0, 0, False)
 
-        message = r"Sanitize command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field"
+        message = r"Sanitize command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field|Sanitize command error: Invalid Queue Identifier: The creation of the I/O Completion Queue failed due to an invalid queue identifier specified as part of the command"
         for i in [BlockDev.NVMESanitizeAction.BLOCK_ERASE, BlockDev.NVMESanitizeAction.CRYPTO_ERASE, BlockDev.NVMESanitizeAction.OVERWRITE, BlockDev.NVMESanitizeAction.EXIT_FAILURE]:
             with self.assertRaisesRegexp(GLib.GError, message):
                 BlockDev.nvme_sanitize(self.nvme_dev, i, False, 0, 0, False)


### PR DESCRIPTION
Those different error messages in the tests look suspicious, unfortunately I have no real nvme device around to test if it was an actual `libnvme` regression or just tweaked ioctl arguments.