### PR TITLE
nvme: Add bd_nvme_find_ctrls_for_ns()

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -859,4 +859,5 @@ bd_nvme_discovery_log_entry_free
 BDNVMEAddressFamily
 BDNVMETCPSecurity
 bd_nvme_discover
+bd_nvme_find_ctrls_for_ns
 </SECTION>

--- a/src/lib/plugin_apis/nvme.api
+++ b/src/lib/plugin_apis/nvme.api
@@ -1435,4 +1435,22 @@ gboolean bd_nvme_disconnect_by_path (const gchar *path, GError **error);
  */
 BDNVMEDiscoveryLogEntry ** bd_nvme_discover (const gchar *discovery_ctrl, gboolean persistent, const gchar *transport, const gchar *transport_addr, const gchar *transport_svcid, const gchar *host_traddr, const gchar *host_iface, const gchar *host_nqn, const gchar *host_id, const BDExtraArg **extra, GError **error);
 
+/**
+ * bd_nvme_find_ctrls_for_ns:
+ * @ns_sysfs_path: NVMe namespace device file.
+ * @subsysnqn: (nullable): Limit matching to the specified subsystem NQN.
+ * @host_nqn: (nullable): Limit matching to the specified host NQN.
+ * @host_id: (nullable): Limit matching to the specified host ID.
+ * @error: (out) (nullable): Place to store error (if any).
+ *
+ * A convenient utility function to look up all controllers associated
+ *  with a NVMe subsystem the specified namespace is part of.
+ *
+ * Returns: (transfer full) (array zero-terminated=1): list of controller sysfs paths
+ *          or %NULL in case of an error (with @error set).
+ *
+ * Tech category: %BD_NVME_TECH_FABRICS-%BD_NVME_TECH_MODE_INITIATOR
+ */
+gchar ** bd_nvme_find_ctrls_for_ns (const gchar *ns_sysfs_path, const gchar *subsysnqn, const gchar *host_nqn, const gchar *host_id, GError **error);
+
 #endif  /* BD_NVME_API */

--- a/src/plugins/nvme/nvme.h
+++ b/src/plugins/nvme/nvme.h
@@ -667,5 +667,11 @@ BDNVMEDiscoveryLogEntry ** bd_nvme_discover          (const gchar       *discove
                                                       const BDExtraArg **extra,
                                                       GError           **error);
 
+gchar **               bd_nvme_find_ctrls_for_ns     (const gchar       *ns_sysfs_path,
+                                                      const gchar       *subsysnqn,
+                                                      const gchar       *host_nqn,
+                                                      const gchar       *host_id,
+                                                      GError           **error);
+
 
 #endif  /* BD_NVME */

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -394,6 +394,45 @@ class NVMeFabricsTestCase(NVMeTest):
             self.assertTrue(re.match(r'/dev/nvme[0-9]+n[0-9]+', ns))
             self.assertTrue(os.path.exists(ns))
 
+            # verify the sysfs paths
+            ret, ns_sysfs_path, err = run_command("udevadm info --query=path %s" % ns)
+            if ret != 0:
+                raise RuntimeError("Error getting udev info for %s: '%s'" % (ns,  err))
+            self.assertIsNotNone(ns_sysfs_path)
+            self.assertGreater(len(ns_sysfs_path), 0)
+            ns_sysfs_path = "/sys" + ns_sysfs_path
+            ret, ctrl_sysfs_path, err = run_command("udevadm info --query=path %s" % ctrls[0])
+            if ret != 0:
+                raise RuntimeError("Error getting udev info for %s: '%s'" % (ctrls[0],  err))
+            self.assertIsNotNone(ctrl_sysfs_path)
+            self.assertGreater(len(ctrl_sysfs_path), 0)
+            ctrl_sysfs_path = "/sys" + ctrl_sysfs_path
+
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, None, None, None)
+            self.assertIsNotNone(ctrl_sysfs_paths)
+            self.assertEqual(len(ctrl_sysfs_paths), 1)
+            self.assertEqual(ctrl_sysfs_path, ctrl_sysfs_paths[0])
+
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path + "xxx", None, None, None)
+            self.assertEqual(len(ctrl_sysfs_paths), 0)
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, self.SUBNQN, None, None)
+            self.assertEqual(len(ctrl_sysfs_paths), 1)
+            self.assertEqual(ctrl_sysfs_path, ctrl_sysfs_paths[0])
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, self.SUBNQN, self.hostnqn, None)
+            self.assertEqual(len(ctrl_sysfs_paths), 1)
+            self.assertEqual(ctrl_sysfs_path, ctrl_sysfs_paths[0])
+
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, "unknownsubsysnqn", None, None)
+            self.assertEqual(len(ctrl_sysfs_paths), 0)
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, None, "unknownhostnqn", None)
+            self.assertEqual(len(ctrl_sysfs_paths), 0)
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, self.SUBNQN, "unknownhostnqn", None)
+            self.assertEqual(len(ctrl_sysfs_paths), 0)
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, None, None, "unknownhostid")
+            self.assertEqual(len(ctrl_sysfs_paths), 0)
+            ctrl_sysfs_paths = BlockDev.nvme_find_ctrls_for_ns(ns_sysfs_path, self.SUBNQN, self.hostnqn, "unknownhostid")
+            self.assertEqual(len(ctrl_sysfs_paths), 0)
+
         # disconnect
         BlockDev.nvme_disconnect(self.SUBNQN)
         for c in ctrls:


### PR DESCRIPTION
sysfs topology helper function, there might be others like this needed in the future. The actual matching might change a little bit in the future, the API should stay unchanged. This all works on sysfs paths since there might not be a device node created yet (e.g. detached namespace).