### PR TITLE
tests: Skip LVM DBus writecache tests too

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -72,7 +72,7 @@
       version: "9"
       reason: "latest libnvme is not yet available on CentOS 9"
 
-- test: lvm_test.LvmPVVGLVWritecacheAttachDetachTestCase
+- test: (lvm_test|lvm_dbus_tests).LvmPVVGLVWritecacheAttachDetachTestCase
   skip_on:
     - arch: "i686"
       reason: "Cache attach/detach fails with ENOMEM on 32bit systems"


### PR DESCRIPTION
Followup for c97126407e62b2b25291773917bbfd0306ea28ef, the issue
affects the DBus plugin too.