### PR TITLE
nvme: Fix LBA Format data size matching in bd_nvme_format()

### DIFF
--- a/src/plugins/nvme/nvme-op.c
+++ b/src/plugins/nvme/nvme-op.c
@@ -135,7 +135,7 @@ static __u8 find_lbaf_for_size (int fd, __u32 nsid, guint16 lba_data_size, GErro
        return flbas;
     }
 
-    for (i = 0; i < ns_info.nlbaf; i++)
+    for (i = 0; i <= ns_info.nlbaf + ns_info.nulbaf; i++)
         if (1UL << ns_info.lbaf[i].ds == lba_data_size && ns_info.lbaf[i].ms == 0)
             return i;
 

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -170,9 +170,7 @@ class NVMeTestCase(NVMeTest):
             BlockDev.nvme_get_error_log_entries("/dev/nonexistent")
 
         log = BlockDev.nvme_get_error_log_entries(self.nvme_dev)
-        # expect an empty log...
         self.assertIsNotNone(log)
-        self.assertEqual(len(log), 1)
         # TODO: find a way to spoof drive errors
 
 


### PR DESCRIPTION
Follow-up on 7ef22c5, a forgotten part.