### PR TITLE
Fix typos

### DIFF
--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -437,7 +437,7 @@ static BDNVDIMMNamespaceInfo* get_nvdimm_namespace_info (struct ndctl_namespace 
             break;
         default:
             g_set_error (error, BD_NVDIMM_ERROR, BD_NVDIMM_ERROR_NAMESPACE_FAIL,
-                         "Failed to get information about namespaces: Unknow mode.");
+                         "Failed to get information about namespaces: Unknown mode.");
             bd_nvdimm_namespace_info_free (info);
             return NULL;
     }


### PR DESCRIPTION
Spotted by lintian

------

Backport (or in this case probably "forwardport") of #747 to master, the other typo was already fixed in 662f92c8e63760eb15879fbeef33aa47e0d36b8c