### PR TITLE
nvme: Differentiate fabrics connection error codes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,7 +268,10 @@ AS_IF([test "x$with_nvdimm" != "xno"],
       [])
 
 AS_IF([test "x$with_nvme" != "xno"],
-      [LIBBLOCKDEV_PKG_CHECK_MODULES([NVME], [libnvme])],
+      [LIBBLOCKDEV_PKG_CHECK_MODULES([NVME], [libnvme >= 1.0])
+      AS_IF([$PKG_CONFIG --atleast-version=1.1 libnvme],
+            [AC_DEFINE([HAVE_LIBNVME_1_1])], [])
+      ],
       [])
 
 AC_SUBST([skip_patterns], [$skip_patterns])

--- a/src/lib/plugin_apis/nvme.api
+++ b/src/lib/plugin_apis/nvme.api
@@ -25,6 +25,12 @@ GQuark bd_nvme_error_quark (void) {
  * @BD_NVME_ERROR_SC_PATH: Path related error.
  * @BD_NVME_ERROR_SC_VENDOR_SPECIFIC: NVMe Vendor specific error.
  * @BD_NVME_ERROR_NO_MATCH: No matching resource found (e.g. a Fabrics Controller).
+ * @BD_NVME_ERROR_CONNECT: General connection error.
+ * @BD_NVME_ERROR_CONNECT_ALREADY: Already connected.
+ * @BD_NVME_ERROR_CONNECT_INVALID: Invalid argument specified.
+ * @BD_NVME_ERROR_CONNECT_ADDRINUSE: HostNQN already in use.
+ * @BD_NVME_ERROR_CONNECT_NODEV: Invalid interface.
+ * @BD_NVME_ERROR_CONNECT_OPNOTSUPP: Operation not supported.
  */
 /* BpG-skip-end */
 typedef enum {
@@ -39,6 +45,12 @@ typedef enum {
     BD_NVME_ERROR_SC_PATH,
     BD_NVME_ERROR_SC_VENDOR_SPECIFIC,
     BD_NVME_ERROR_NO_MATCH,
+    BD_NVME_ERROR_CONNECT,
+    BD_NVME_ERROR_CONNECT_ALREADY,
+    BD_NVME_ERROR_CONNECT_INVALID,
+    BD_NVME_ERROR_CONNECT_ADDRINUSE,
+    BD_NVME_ERROR_CONNECT_NODEV,
+    BD_NVME_ERROR_CONNECT_OPNOTSUPP,
 } BDNVMEError;
 
 typedef enum {

--- a/src/plugins/nvme/nvme-fabrics.c
+++ b/src/plugins/nvme/nvme-fabrics.c
@@ -256,9 +256,8 @@ gboolean bd_nvme_connect (const gchar *subsysnqn, const gchar *transport, const 
 
     ctrl = nvme_create_ctrl (root, subsysnqn, transport, transport_addr, host_traddr, host_iface, transport_svcid);
     if (ctrl == NULL) {
-        g_set_error (error, BD_NVME_ERROR, BD_NVME_ERROR_FAILED,
-                     "Error creating the controller: %s",
-                     strerror_l (errno, _C_LOCALE));
+        _nvme_fabrics_errno_to_gerror (-1, errno, error);
+        g_prefix_error (error, "Error creating the controller: ");
         nvme_free_tree (root);
         return FALSE;
     }
@@ -267,9 +266,8 @@ gboolean bd_nvme_connect (const gchar *subsysnqn, const gchar *transport, const 
 
     ret = nvmf_add_ctrl (host, ctrl, &cfg);
     if (ret != 0) {
-        g_set_error (error, BD_NVME_ERROR, BD_NVME_ERROR_FAILED,
-                     "Error connecting the controller: %s",
-                     (errno >= ENVME_CONNECT_RESOLVE) ? nvme_errno_to_string (errno) : strerror_l (errno, _C_LOCALE));
+        _nvme_fabrics_errno_to_gerror (ret, errno, error);
+        g_prefix_error (error, "Error connecting the controller: ");
         nvme_free_ctrl (ctrl);
         nvme_free_tree (root);
         return FALSE;
@@ -574,18 +572,16 @@ BDNVMEDiscoveryLogEntry ** bd_nvme_discover (const gchar *discovery_ctrl, gboole
     if (!ctrl) {
         ctrl = nvme_create_ctrl (root, NVME_DISC_SUBSYS_NAME, transport, transport_addr, host_traddr, host_iface, transport_svcid);
         if (ctrl == NULL) {
-            g_set_error (error, BD_NVME_ERROR, BD_NVME_ERROR_FAILED,
-                         "Error creating the controller: %s",
-                         strerror_l (errno, _C_LOCALE));
+            _nvme_fabrics_errno_to_gerror (-1, errno, error);
+            g_prefix_error (error, "Error creating the controller: ");
             nvme_free_tree (root);
             return NULL;
         }
         nvme_ctrl_set_discovery_ctrl (ctrl, TRUE);
         ret = nvmf_add_ctrl (host, ctrl, &cfg);
         if (ret != 0) {
-            g_set_error (error, BD_NVME_ERROR, BD_NVME_ERROR_FAILED,
-                         "Error connecting the controller: %s",
-                         (errno >= ENVME_CONNECT_RESOLVE) ? nvme_errno_to_string (errno) : strerror_l (errno, _C_LOCALE));
+            _nvme_fabrics_errno_to_gerror (ret, errno, error);
+            g_prefix_error (error, "Error connecting the controller: ");
             nvme_free_ctrl (ctrl);
             nvme_free_tree (root);
             return NULL;

--- a/src/plugins/nvme/nvme-private.h
+++ b/src/plugins/nvme/nvme-private.h
@@ -17,6 +17,7 @@
 
 /* nvme-error.c */
 void _nvme_status_to_error (gint status, gboolean fabrics, GError **error);
+void _nvme_fabrics_errno_to_gerror (int result, int _errno, GError **error);
 
 /* nvme-info.c */
 gint _open_dev (const gchar *device, GError **error);

--- a/src/plugins/nvme/nvme.h
+++ b/src/plugins/nvme/nvme.h
@@ -21,6 +21,12 @@ GQuark bd_nvme_error_quark (void);
  * @BD_NVME_ERROR_SC_PATH: Path related error.
  * @BD_NVME_ERROR_SC_VENDOR_SPECIFIC: NVMe Vendor specific error.
  * @BD_NVME_ERROR_NO_MATCH: No matching resource found (e.g. a Fabrics Controller).
+ * @BD_NVME_ERROR_CONNECT: General connection error.
+ * @BD_NVME_ERROR_CONNECT_ALREADY: Already connected.
+ * @BD_NVME_ERROR_CONNECT_INVALID: Invalid argument specified.
+ * @BD_NVME_ERROR_CONNECT_ADDRINUSE: HostNQN already in use.
+ * @BD_NVME_ERROR_CONNECT_NODEV: Invalid interface.
+ * @BD_NVME_ERROR_CONNECT_OPNOTSUPP: Operation not supported.
  */
 typedef enum {
     BD_NVME_ERROR_TECH_UNAVAIL,
@@ -34,6 +40,12 @@ typedef enum {
     BD_NVME_ERROR_SC_PATH,
     BD_NVME_ERROR_SC_VENDOR_SPECIFIC,
     BD_NVME_ERROR_NO_MATCH,
+    BD_NVME_ERROR_CONNECT,
+    BD_NVME_ERROR_CONNECT_ALREADY,
+    BD_NVME_ERROR_CONNECT_INVALID,
+    BD_NVME_ERROR_CONNECT_ADDRINUSE,
+    BD_NVME_ERROR_CONNECT_NODEV,
+    BD_NVME_ERROR_CONNECT_OPNOTSUPP,
 } BDNVMEError;
 
 typedef enum {


### PR DESCRIPTION
The kernel nvme host driver maps errors to standard errno values,
libnvme maps them back to own internal codes and libblockdev does
the mapping once again for GError. The kernel host driver often
spits more information into the kernel log, but that's very
difficult for userspace to catch for the particular call.

Some codes are available only with libnvme >= 1.1