### PR TITLE
lvm: Fix bd_lvm_get_supported_pe_sizes in Python on 32bit

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -637,7 +637,7 @@ gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error);
  * bd_lvm_get_supported_pe_sizes:
  * @error: (out): place to store error (if any)
  *
- * Returns: (transfer full) (array zero-terminated=1): list of supported PE sizes
+ * Returns: (transfer full) (array fixed-size=25): list of supported PE sizes
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1173,7 +1173,7 @@ gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error UNUSED) {
  * bd_lvm_get_supported_pe_sizes:
  * @error: (out): place to store error (if any)
  *
- * Returns: (transfer full) (array zero-terminated=1): list of supported PE sizes
+ * Returns: (transfer full) (array fixed-size=25): list of supported PE sizes
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -708,7 +708,7 @@ gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error UNUSED) {
  * bd_lvm_get_supported_pe_sizes:
  * @error: (out): place to store error (if any)
  *
- * Returns: (transfer full) (array zero-terminated=1): list of supported PE sizes
+ * Returns: (transfer full) (array fixed-size=25): list of supported PE sizes
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -68,8 +68,14 @@ class LvmNoDevTestCase(LVMTestCase):
     def test_get_supported_pe_sizes(self):
         """Verify that supported PE sizes are really supported"""
 
-        for size in BlockDev.lvm_get_supported_pe_sizes():
+        supported = BlockDev.lvm_get_supported_pe_sizes()
+
+        for size in supported:
             self.assertTrue(BlockDev.lvm_is_supported_pe_size(size))
+
+        self.assertIn(4 * 1024, supported)
+        self.assertIn(4 * 1024 **2, supported)
+        self.assertIn(16 * 1024**3, supported)
 
     @tag_test(TestTags.NOSTORAGE)
     def test_get_max_lv_size(self):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -61,8 +61,14 @@ class LvmNoDevTestCase(LVMTestCase):
     def test_get_supported_pe_sizes(self):
         """Verify that supported PE sizes are really supported"""
 
-        for size in BlockDev.lvm_get_supported_pe_sizes():
+        supported = BlockDev.lvm_get_supported_pe_sizes()
+
+        for size in supported:
             self.assertTrue(BlockDev.lvm_is_supported_pe_size(size))
+
+        self.assertIn(4 * 1024, supported)
+        self.assertIn(4 * 1024 **2, supported)
+        self.assertIn(16 * 1024**3, supported)
 
     @tag_test(TestTags.NOSTORAGE)
     def test_get_max_lv_size(self):


### PR DESCRIPTION
Pygobject fails to get size of the returned zero terminated array
on 32bit systems. With older versions we get only the first value
from the list and with newer versions we get an abort. The number
of supported PE sizes is constant so we can use the fixed-size
annotation to workaround this issue without changing API.