### PR TITLE
tests: Create bigger devices for XFS tests

### DIFF
--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -156,7 +156,7 @@ class FSTestCase(FSNoDevTestCase):
         utils.run("vgremove --yes %s >/dev/null 2>&1" % vgname)
         utils.run("pvremove --yes %s >/dev/null 2>&1" % self.loop_dev)
 
-    def _setup_lvm(self, vgname, lvname):
+    def _setup_lvm(self, vgname, lvname, lvsize="50M"):
         ret, _out, err = utils.run_command("pvcreate -ff -y %s" % self.loop_dev)
         if ret != 0:
             raise RuntimeError("Failed to create PV for fs tests: %s" % err)
@@ -166,7 +166,7 @@ class FSTestCase(FSNoDevTestCase):
             raise RuntimeError("Failed to create VG for fs tests: %s" % err)
         self.addCleanup(self._destroy_lvm, vgname)
 
-        ret, _out, err = utils.run_command("lvcreate -n %s -L50M %s" % (lvname, vgname))
+        ret, _out, err = utils.run_command("lvcreate -n %s -L%s %s" % (lvname, lvsize, vgname))
         if ret != 0:
             raise RuntimeError("Failed to create LV for fs tests: %s" % err)
 

--- a/tests/fs_tests/mount_test.py
+++ b/tests/fs_tests/mount_test.py
@@ -108,7 +108,7 @@ class MountTestCase(FSTestCase):
 
         backing_file = utils.create_sparse_tempfile("ro_mount", 50 * 1024**2)
         self.addCleanup(os.unlink, backing_file)
-        self.assertTrue(BlockDev.fs_xfs_mkfs(backing_file, None))
+        self.assertTrue(BlockDev.fs_ext2_mkfs(backing_file, None))
 
         succ, dev = BlockDev.loop_setup(backing_file, 0, 0, True, False)
         self.assertTrue(succ)

--- a/tests/fs_tests/xfs_test.py
+++ b/tests/fs_tests/xfs_test.py
@@ -16,6 +16,8 @@ class XfsNoDevTestCase(FSNoDevTestCase):
 
 
 class XfsTestCase(FSTestCase):
+    loop_size = 500 * 1024**2
+
     def setUp(self):
         super(XfsTestCase, self).setUp()
 
@@ -260,7 +262,7 @@ class XfsResize(XfsTestCase):
     def test_xfs_resize(self):
         """Verify that it is possible to resize an xfs file system"""
 
-        lv = self._setup_lvm(vgname="libbd_fs_tests", lvname="xfs_test")
+        lv = self._setup_lvm(vgname="libbd_fs_tests", lvname="xfs_test", lvsize="350M")
 
         succ = BlockDev.fs_xfs_mkfs(lv, None)
         self.assertTrue(succ)
@@ -268,7 +270,7 @@ class XfsResize(XfsTestCase):
         with mounted(lv, self.mount_dir):
             fi = BlockDev.fs_xfs_get_info(lv)
         self.assertTrue(fi)
-        self.assertEqual(fi.block_size * fi.block_count, 50 * 1024**2)
+        self.assertEqual(fi.block_size * fi.block_count, 350 * 1024**2)
 
         # no change, nothing should happen
         with mounted(lv, self.mount_dir):
@@ -278,7 +280,7 @@ class XfsResize(XfsTestCase):
         with mounted(lv, self.mount_dir):
             fi = BlockDev.fs_xfs_get_info(lv)
         self.assertTrue(fi)
-        self.assertEqual(fi.block_size * fi.block_count, 50 * 1024**2)
+        self.assertEqual(fi.block_size * fi.block_count, 350 * 1024**2)
 
         # (still) impossible to shrink an XFS file system
         xfs_version = self._get_xfs_version()
@@ -287,34 +289,34 @@ class XfsResize(XfsTestCase):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_xfs_resize(self.mount_dir, 40 * 1024**2 / fi.block_size, None)
 
-        self._lvresize("libbd_fs_tests", "xfs_test", "70M")
-        # should grow
+        self._lvresize("libbd_fs_tests", "xfs_test", "400M")
+        # should grow to 400 MiB (full size of the LV)
         with mounted(lv, self.mount_dir):
             succ = BlockDev.fs_xfs_resize(self.mount_dir, 0, None)
         self.assertTrue(succ)
         with mounted(lv, self.mount_dir):
             fi = BlockDev.fs_xfs_get_info(lv)
         self.assertTrue(fi)
-        self.assertEqual(fi.block_size * fi.block_count, 70 * 1024**2)
+        self.assertEqual(fi.block_size * fi.block_count, 400 * 1024**2)
 
-        self._lvresize("libbd_fs_tests", "xfs_test", "90M")
-        # should grow just to 80 MiB
+        self._lvresize("libbd_fs_tests", "xfs_test", "450M")
+        # grow just to 430 MiB
         with mounted(lv, self.mount_dir):
-            succ = BlockDev.fs_xfs_resize(self.mount_dir, 80 * 1024**2 / fi.block_size, None)
+            succ = BlockDev.fs_xfs_resize(self.mount_dir, 430 * 1024**2 / fi.block_size, None)
         self.assertTrue(succ)
         with mounted(lv, self.mount_dir):
             fi = BlockDev.fs_xfs_get_info(lv)
         self.assertTrue(fi)
-        self.assertEqual(fi.block_size * fi.block_count, 80 * 1024**2)
+        self.assertEqual(fi.block_size * fi.block_count, 430 * 1024**2)
 
-        # should grow to 90 MiB
+        # should grow to 450 MiB (full size of the LV)
         with mounted(lv, self.mount_dir):
             succ = BlockDev.fs_xfs_resize(self.mount_dir, 0, None)
         self.assertTrue(succ)
         with mounted(lv, self.mount_dir):
             fi = BlockDev.fs_xfs_get_info(lv)
         self.assertTrue(fi)
-        self.assertEqual(fi.block_size * fi.block_count, 90 * 1024**2)
+        self.assertEqual(fi.block_size * fi.block_count, 450 * 1024**2)
 
 
 class XfsSetUUID(XfsTestCase):


### PR DESCRIPTION
Starting with xfsprogs 5.19 minimal size for XFS is 300 MiB.