### PR TITLE
tests: Create bigger devices for XFS tests

### DIFF
--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -1127,7 +1127,7 @@ class MountTest(FSTestCase):
 
         backing_file = create_sparse_tempfile("ro_mount", 50 * 1024**2)
         self.addCleanup(os.unlink, backing_file)
-        self.assertTrue(BlockDev.fs_xfs_mkfs(backing_file, None))
+        self.assertTrue(BlockDev.fs_ext2_mkfs(backing_file, None))
 
         succ, dev = BlockDev.loop_setup(backing_file, 0, 0, True, False)
         self.assertTrue(succ)


### PR DESCRIPTION
Starting with xfsprogs 5.19 minimal size for XFS is 300 MiB.