### PR TITLE
Add generic functions to check filesystem label and UUID

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1035,6 +1035,23 @@ gboolean bd_fs_check_label (const gchar *fstype, const gchar *label, GError **er
 gboolean bd_fs_set_label (const gchar *device, const gchar *label, const gchar *fstype, GError **error);
 
 /**
+ * bd_fs_check_uuid:
+ * @fstype: the filesystem type to check @uuid for
+ * @uuid: uuid to check
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * This calls other fs check uuid functions from this plugin based on the provided
+ * filesystem (e.g. bd_fs_xfs_check_uuid for XFS). This function will return
+ * an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether @uuid is a valid UUID for the @fstype file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_check_uuid (const gchar *fstype, const gchar *uuid, GError **error);
+
+/**
  * bd_fs_set_uuid:
  * @device: the device with file system to set the UUID for
  * @uuid: (nullable): UUID to set or %NULL to generate a new one

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1001,6 +1001,23 @@ gboolean bd_fs_repair (const gchar *device, const gchar *fstype, GError **error)
 gboolean bd_fs_check (const gchar *device, const gchar *fstype, GError **error);
 
 /**
+ * bd_fs_check_label:
+ * @fstype: the filesystem type to check @label for
+ * @label: label to check
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * This calls other fs check label functions from this plugin based on the provided
+ * filesystem (e.g. bd_fs_xfs_check_label for XFS). This function will return
+ * an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether @label is a valid label for the @fstype file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_check_label (const gchar *fstype, const gchar *label, GError **error);
+
+/**
  * bd_fs_set_label:
  * @device: the device with file system to set the label for
  * @label: label to set

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -45,6 +45,7 @@ typedef enum {
     BD_FS_REPAIR,
     BD_FS_CHECK,
     BD_FS_LABEL,
+    BD_FS_LABEL_CHECK,
     BD_FS_GET_SIZE,
     BD_FS_UUID,
     BD_FS_GET_FREE_SPACE,
@@ -907,6 +908,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_ext4_check (device, NULL, error);
             case BD_FS_LABEL:
                 return bd_fs_ext4_set_label (device, label, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_ext4_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_ext4_set_uuid (device, uuid, error);
             default:
@@ -922,6 +925,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_xfs_check (device, error);
             case BD_FS_LABEL:
                 return bd_fs_xfs_set_label (device, label, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_xfs_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_xfs_set_uuid (device, uuid, error);
             default:
@@ -935,6 +940,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_vfat_repair (device, NULL, error);
             case BD_FS_CHECK:
                 return bd_fs_vfat_check (device, NULL, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_vfat_check_label (label, error);
             case BD_FS_LABEL:
                 return bd_fs_vfat_set_label (device, label, error);
             case BD_FS_UUID:
@@ -950,6 +957,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_ntfs_repair (device, error);
             case BD_FS_CHECK:
                 return bd_fs_ntfs_check (device, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_ntfs_check_label (label, error);
             case BD_FS_LABEL:
                 return bd_fs_ntfs_set_label (device, label, error);
             case BD_FS_UUID:
@@ -967,6 +976,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_f2fs_check (device, NULL, error);
             case BD_FS_LABEL:
                 break;
+            case BD_FS_LABEL_CHECK:
+                break;
             case BD_FS_UUID:
                 break;
             default:
@@ -982,6 +993,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 break;
             case BD_FS_LABEL:
                 return bd_fs_nilfs2_set_label (device, label, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_nilfs2_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_nilfs2_set_uuid (device, uuid, error);
             default:
@@ -997,6 +1010,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_exfat_check (device, NULL, error);
             case BD_FS_LABEL:
                 return bd_fs_exfat_set_label (device, label, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_exfat_check_label (label, error);
             case BD_FS_UUID:
                 break;
             default:
@@ -1012,6 +1027,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_btrfs_check (device, NULL, error);
             case BD_FS_LABEL:
                 return btrfs_set_label (device, label, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_btrfs_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_btrfs_set_uuid (device, uuid, error);
             default:
@@ -1027,6 +1044,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 break;
             case BD_FS_LABEL:
                 return bd_fs_udf_set_label (device, label, error);
+            case BD_FS_LABEL_CHECK:
+                return bd_fs_udf_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_udf_set_uuid (device, uuid, error);
             default:
@@ -1045,6 +1064,9 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             break;
         case BD_FS_LABEL:
             op_name = "Setting the label of";
+            break;
+        case BD_FS_LABEL_CHECK:
+            op_name = "Checking label format for";
             break;
         case BD_FS_UUID:
             op_name = "Setting UUID of";
@@ -1112,6 +1134,31 @@ gboolean bd_fs_repair (const gchar *device, const gchar *fstype, GError **error)
 gboolean bd_fs_check (const gchar *device, const gchar *fstype, GError **error) {
     return device_operation (device, fstype, BD_FS_CHECK, 0, NULL, NULL, error);
 }
+
+/**
+ * bd_fs_check_label:
+ * @fstype: the filesystem type to check @label for
+ * @label: label to check
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * This calls other fs check label functions from this plugin based on the provided
+ * filesystem (e.g. bd_fs_xfs_check_label for XFS). This function will return
+ * an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether @label is a valid label for the @fstype file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_check_label (const gchar *fstype, const gchar *label, GError **error) {
+    if (!fstype) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_NOFS,
+                     "Filesystem type must be specified to check label format");
+        return FALSE;
+    }
+    return device_operation (NULL, fstype, BD_FS_LABEL_CHECK, 0, label, NULL, error);
+}
+
 
 /**
  * bd_fs_set_label:

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -48,6 +48,7 @@ typedef enum {
     BD_FS_LABEL_CHECK,
     BD_FS_GET_SIZE,
     BD_FS_UUID,
+    BD_FS_UUID_CHECK,
     BD_FS_GET_FREE_SPACE,
 } BDFsOpType;
 
@@ -912,6 +913,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_ext4_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_ext4_set_uuid (device, uuid, error);
+            case BD_FS_UUID_CHECK:
+                return bd_fs_ext4_check_uuid (uuid, error);
             default:
                 g_assert_not_reached ();
         }
@@ -929,6 +932,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_xfs_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_xfs_set_uuid (device, uuid, error);
+            case BD_FS_UUID_CHECK:
+                return bd_fs_xfs_check_uuid (uuid, error);
             default:
                 g_assert_not_reached ();
         }
@@ -945,6 +950,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             case BD_FS_LABEL:
                 return bd_fs_vfat_set_label (device, label, error);
             case BD_FS_UUID:
+                break;
+            case BD_FS_UUID_CHECK:
                 break;
             default:
                 g_assert_not_reached ();
@@ -963,6 +970,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_ntfs_set_label (device, label, error);
             case BD_FS_UUID:
                 return bd_fs_ntfs_set_uuid (device, uuid, error);
+            case BD_FS_UUID_CHECK:
+                return bd_fs_ntfs_check_uuid (uuid, error);
             default:
                 g_assert_not_reached ();
         }
@@ -979,6 +988,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             case BD_FS_LABEL_CHECK:
                 break;
             case BD_FS_UUID:
+                break;
+            case BD_FS_UUID_CHECK:
                 break;
             default:
                 g_assert_not_reached ();
@@ -997,6 +1008,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_nilfs2_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_nilfs2_set_uuid (device, uuid, error);
+            case BD_FS_UUID_CHECK:
+                return bd_fs_nilfs2_check_uuid (uuid, error);
             default:
                 g_assert_not_reached ();
         }
@@ -1013,6 +1026,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             case BD_FS_LABEL_CHECK:
                 return bd_fs_exfat_check_label (label, error);
             case BD_FS_UUID:
+                break;
+            case BD_FS_UUID_CHECK:
                 break;
             default:
                 g_assert_not_reached ();
@@ -1031,6 +1046,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_btrfs_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_btrfs_set_uuid (device, uuid, error);
+            case BD_FS_UUID_CHECK:
+                return bd_fs_btrfs_check_uuid (uuid, error);
             default:
                 g_assert_not_reached ();
         }
@@ -1048,6 +1065,8 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
                 return bd_fs_udf_check_label (label, error);
             case BD_FS_UUID:
                 return bd_fs_udf_set_uuid (device, uuid, error);
+            case BD_FS_UUID_CHECK:
+                return bd_fs_udf_check_uuid (uuid, error);
             default:
                 g_assert_not_reached ();
         }
@@ -1070,6 +1089,9 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             break;
         case BD_FS_UUID:
             op_name = "Setting UUID of";
+            break;
+        case BD_FS_UUID_CHECK:
+            op_name = "Checking UUID format for";
             break;
         default:
             g_assert_not_reached ();
@@ -1177,6 +1199,30 @@ gboolean bd_fs_check_label (const gchar *fstype, const gchar *label, GError **er
  */
 gboolean bd_fs_set_label (const gchar *device, const gchar *label, const gchar *fstype, GError **error) {
     return device_operation (device, fstype, BD_FS_LABEL, 0, label, NULL, error);
+}
+
+/**
+ * bd_fs_check_uuid:
+ * @fstype: the filesystem type to check @uuid for
+ * @uuid: uuid to check
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * This calls other fs check uuid functions from this plugin based on the provided
+ * filesystem (e.g. bd_fs_xfs_check_uuid for XFS). This function will return
+ * an error for unknown/unsupported filesystems.
+ *
+ * Returns: whether @uuid is a valid UUID for the @fstype file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_check_uuid (const gchar *fstype, const gchar *uuid, GError **error) {
+    if (!fstype) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_NOFS,
+                     "Filesystem type must be specified to check UUID format");
+        return FALSE;
+    }
+    return device_operation (NULL, fstype, BD_FS_UUID_CHECK, 0, NULL, uuid, error);
 }
 
 /**

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -31,6 +31,7 @@ gboolean bd_fs_resize (const gchar *device, guint64 new_size, const gchar *fstyp
 gboolean bd_fs_repair (const gchar *device, const gchar *fstype, GError **error);
 gboolean bd_fs_check (const gchar *device, const gchar *fstype, GError **error);
 gboolean bd_fs_set_label (const gchar *device, const gchar *label, const gchar *fstype, GError **error);
+gboolean bd_fs_check_label (const gchar *fstype, const gchar *label, GError **error);
 gboolean bd_fs_set_uuid (const gchar *device, const gchar *uuid, const gchar *fstype, GError **error);
 guint64 bd_fs_get_size (const gchar *device, const gchar *fstype, GError **error);
 guint64 bd_fs_get_free_space (const gchar *device, const gchar *fstype, GError **error);

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -33,6 +33,7 @@ gboolean bd_fs_check (const gchar *device, const gchar *fstype, GError **error);
 gboolean bd_fs_set_label (const gchar *device, const gchar *label, const gchar *fstype, GError **error);
 gboolean bd_fs_check_label (const gchar *fstype, const gchar *label, GError **error);
 gboolean bd_fs_set_uuid (const gchar *device, const gchar *uuid, const gchar *fstype, GError **error);
+gboolean bd_fs_check_uuid (const gchar *fstype, const gchar *uuid, GError **error);
 guint64 bd_fs_get_size (const gchar *device, const gchar *fstype, GError **error);
 guint64 bd_fs_get_free_space (const gchar *device, const gchar *fstype, GError **error);
 

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -619,6 +619,9 @@ class GenericSetLabel(GenericTestCase):
         succ = mkfs_function(self.loop_dev, None)
         self.assertTrue(succ)
 
+        succ = BlockDev.fs_check_label(fstype, "new_label")
+        self.assertTrue(succ)
+
         # set label (expected to succeed)
         succ = BlockDev.fs_set_label(self.loop_dev, "new_label")
         self.assertTrue(succ)

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -696,6 +696,10 @@ class GenericSetUUID(GenericTestCase):
         succ = BlockDev.fs_set_uuid(self.loop_dev, None, fstype)
         self.assertTrue(succ)
 
+        # check uuid format
+        succ = BlockDev.fs_check_uuid(fstype, test_uuid)
+        self.assertTrue(succ)
+
     def test_ext4_generic_set_uuid(self):
         """Test generic set_uuid function with an ext4 file system"""
         self._test_generic_set_uuid(mkfs_function=BlockDev.fs_ext4_mkfs, fstype="ext4")


### PR DESCRIPTION
Fixes: #776 