### PR TITLE
fs: Fix nilfs2 mkfs util in BDFSInfo

### DIFF
--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -249,7 +249,7 @@ static const BDFSInfo fs_info[BD_FS_LAST_FS] = {
       .uuid_util = NULL },
     /* NILFS2 */
     { .type = "nilfs2",
-      .mkfs_util = "mkfs.nilfs",
+      .mkfs_util = "mkfs.nilfs2",
       .mkfs_options = fs_features[BD_FS_TECH_NILFS2].mkfs,
       .check_util = NULL,
       .repair_util = NULL,

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -140,6 +140,9 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->uuid)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
 
+    if (options->dry_run)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-n", ""));
+
     if (options->no_discard)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
 


### PR DESCRIPTION
Correct one is mkfs.nilfs2, not mkfs.nilfs.