### PR TITLE
spec: Require the same version utils from plugins

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -188,7 +188,7 @@ with the libblockdev-utils library.
 %package btrfs
 BuildRequires: libbytesize-devel
 Summary:     The BTRFS plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: btrfs-progs
 
 %description btrfs
@@ -199,7 +199,7 @@ providing the BTRFS-related functionality.
 Summary:     Development files for the libblockdev-btrfs plugin/library
 Requires: %{name}-btrfs%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 
 %description btrfs-devel
 This package contains header files and pkg-config files needed for development
@@ -243,7 +243,7 @@ BuildRequires: dmraid-devel
 %endif
 BuildRequires: systemd-devel
 Summary:     The Device Mapper plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: device-mapper
 %if %{with_dmraid}
 Requires: dmraid
@@ -262,7 +262,7 @@ Requires: systemd-devel
 %if %{with_dmraid}
 Requires: dmraid-devel
 %endif
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 
 %description dm-devel
 This package contains header files and pkg-config files needed for development
@@ -276,7 +276,7 @@ BuildRequires: libblkid-devel
 BuildRequires: libmount-devel
 BuildRequires: libuuid-devel
 Summary:     The FS plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 
 %description fs
 The libblockdev library plugin (and in the same time a standalone library)
@@ -285,7 +285,7 @@ providing the functionality related to operations with file systems.
 %package fs-devel
 Summary:     Development files for the libblockdev-fs plugin/library
 Requires: %{name}-fs%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 Requires: xfsprogs
 Requires: dosfstools
@@ -300,7 +300,7 @@ with the libblockdev-fs plugin/library.
 %package kbd
 BuildRequires: libbytesize-devel
 Summary:     The KBD plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 %if %{with_bcache}
 Requires: bcache-tools >= 1.0.8
 %endif
@@ -313,7 +313,7 @@ Bcache).
 %package kbd-devel
 Summary:     Development files for the libblockdev-kbd plugin/library
 Requires: %{name}-kbd%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description kbd-devel
@@ -325,7 +325,7 @@ with the libblockdev-kbd plugin/library.
 %if %{with_loop}
 %package loop
 Summary:     The loop plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 
 %description loop
 The libblockdev library plugin (and in the same time a standalone library)
@@ -334,7 +334,7 @@ providing the functionality related to loop devices.
 %package loop-devel
 Summary:     Development files for the libblockdev-loop plugin/library
 Requires: %{name}-loop%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description loop-devel
@@ -347,7 +347,7 @@ with the libblockdev-loop plugin/library.
 %package lvm
 BuildRequires: device-mapper-devel
 Summary:     The LVM plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: lvm2
 
 %description lvm
@@ -369,7 +369,7 @@ with the libblockdev-lvm plugin/library.
 %package lvm-dbus
 BuildRequires: device-mapper-devel
 Summary:     The LVM plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 1.4
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: lvm2-dbusd >= 2.02.156
 
 %description lvm-dbus
@@ -392,7 +392,7 @@ with the libblockdev-lvm-dbus plugin/library.
 %package mdraid
 BuildRequires: libbytesize-devel
 Summary:     The MD RAID plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: mdadm
 
 %description mdraid
@@ -402,7 +402,7 @@ providing the functionality related to MD RAID.
 %package mdraid-devel
 Summary:     Development files for the libblockdev-mdraid plugin/library
 Requires: %{name}-mdraid%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description mdraid-devel
@@ -415,7 +415,7 @@ with the libblockdev-mdraid plugin/library.
 %package mpath
 BuildRequires: device-mapper-devel
 Summary:     The multipath plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: device-mapper-multipath
 
 %description mpath
@@ -425,7 +425,7 @@ providing the functionality related to multipath devices.
 %package mpath-devel
 Summary:     Development files for the libblockdev-mpath plugin/library
 Requires: %{name}-mpath%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description mpath-devel
@@ -438,7 +438,7 @@ with the libblockdev-mpath plugin/library.
 BuildRequires: ndctl-devel
 BuildRequires: libuuid-devel
 Summary:     The NVDIMM plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: ndctl
 
 %description nvdimm
@@ -448,7 +448,7 @@ providing the functionality related to operations with NVDIMM devices.
 %package nvdimm-devel
 Summary:     Development files for the libblockdev-nvdimm plugin/library
 Requires: %{name}-nvdimm%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description nvdimm-devel
@@ -462,7 +462,7 @@ with the libblockdev-nvdimm plugin/library.
 BuildRequires: libnvme-devel
 BuildRequires: libuuid-devel
 Summary:     The NVMe plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 
 %description nvme
 The libblockdev library plugin (and in the same time a standalone library)
@@ -471,7 +471,7 @@ providing the functionality related to operations with NVMe devices.
 %package nvme-devel
 Summary:     Development files for the libblockdev-nvme plugin/library
 Requires: %{name}-nvme%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description nvme-devel
@@ -484,7 +484,7 @@ with the libblockdev-nvme plugin/library.
 %package part
 BuildRequires: libfdisk-devel
 Summary:     The partitioning plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: util-linux
 
 %description part
@@ -494,7 +494,7 @@ providing the functionality related to partitioning.
 %package part-devel
 Summary:     Development files for the libblockdev-part plugin/library
 Requires: %{name}-part%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description part-devel
@@ -507,7 +507,7 @@ with the libblockdev-part plugin/library.
 %package swap
 BuildRequires: libblkid-devel
 Summary:     The swap plugin for the libblockdev library
-Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: util-linux
 
 %description swap
@@ -517,7 +517,7 @@ providing the functionality related to swap devices.
 %package swap-devel
 Summary:     Development files for the libblockdev-swap plugin/library
 Requires: %{name}-swap%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description swap-devel
@@ -553,7 +553,7 @@ providing the functionality related to s390 devices.
 %package s390-devel
 Summary:     Development files for the libblockdev-s390 plugin/library
 Requires: %{name}-s390%{?_isa} = %{version}-%{release}
-Requires: %{name}-utils-devel%{?_isa}
+Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
 
 %description s390-devel


### PR DESCRIPTION
We don't want to deal with utils backward compatibility, especially
now with 3.0 around the corner, and rpminspect is also complaining
about this.

Resolves: rhbz#2116544