### PR TITLE
fs/ext: Use libext2fs instead of spawning dumpe2fs

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -20,5 +20,6 @@ extraction:
       - "libbytesize-dev"
       - "libnss3-dev"
       - "libndctl-dev"
+      - "libext2fs-dev"
     configure:
       command: "./autogen.sh && ./configure --without-nvme"

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,8 @@ AS_IF([test "x$with_fs" != "xno"],
        LIBBLOCKDEV_PKG_CHECK_MODULES([MOUNT], [mount >= 2.23.0])
        # new versions of libmount has some new functions we can use
        AS_IF([$PKG_CONFIG --atleast-version=2.30.0 mount],
-             [AC_DEFINE([LIBMOUNT_NEW_ERR_API])], [])]
+             [AC_DEFINE([LIBMOUNT_NEW_ERR_API])], [])
+       LIBBLOCKDEV_PKG_CHECK_MODULES([EXT2FS], [ext2fs e2p])]
       [])
 
 AS_IF([test "x$with_tools" != "xno"],

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -275,6 +275,7 @@ with the libblockdev-dm plugin/library.
 BuildRequires: libblkid-devel
 BuildRequires: libmount-devel
 BuildRequires: libuuid-devel
+BuildRequires: e2fsprogs-devel
 Summary:     The FS plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -47,6 +47,7 @@
       - device-mapper-multipath
       - dosfstools
       - e2fsprogs
+      - e2fsprogs-devel
       - f2fs-tools
       - glibc-all-langpacks
       - lvm2-dbusd
@@ -111,6 +112,7 @@
       - device-mapper-multipath
       - dosfstools
       - e2fsprogs
+      - e2fsprogs-devel
       - glibc-all-langpacks
       - kmod-kvdo
       - lvm2-dbusd
@@ -174,6 +176,7 @@
       - cryptsetup
       - dosfstools
       - e2fsprogs
+      - libext2fs-dev
       - f2fs-tools
       - libnss3-tools
       - locales-all

--- a/src/plugins/fs/Makefile.am
+++ b/src/plugins/fs/Makefile.am
@@ -2,8 +2,8 @@ AUTOMAKE_OPTIONS = subdir-objects
 
 lib_LTLIBRARIES = libbd_fs.la
 
-libbd_fs_la_CFLAGS   = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(BLKID_CFLAGS) $(MOUNT_CFLAGS) $(UUID_CFLAGS) -Wall -Wextra -Werror
-libbd_fs_la_LIBADD   = ${builddir}/../../utils/libbd_utils.la $(GLIB_LIBS) $(GIO_LIBS) $(BLKID_LIBS) $(MOUNT_LIBS) $(UUID_LIBS)
+libbd_fs_la_CFLAGS   = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(BLKID_CFLAGS) $(MOUNT_CFLAGS) $(UUID_CFLAGS) $(EXT2FS_CFLAGS) -Wall -Wextra -Werror
+libbd_fs_la_LIBADD   = ${builddir}/../../utils/libbd_utils.la $(GLIB_LIBS) $(GIO_LIBS) $(BLKID_LIBS) $(MOUNT_LIBS) $(UUID_LIBS) $(EXT2FS_LIBS)
 libbd_fs_la_LDFLAGS	 = -L${srcdir}/../../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_fs_la_CPPFLAGS = -I${builddir}/../../../include/ -I${srcdir}/../
 libbd_fs_la_SOURCES  = ../check_deps.c ../check_deps.h \

--- a/tests/fs_tests/ext_test.py
+++ b/tests/fs_tests/ext_test.py
@@ -56,11 +56,6 @@ class ExtTestAvailability(ExtNoDevTestCase):
             with self.assertRaisesRegex(GLib.GError, "The 'e2fsck' utility is not available"):
                 BlockDev.fs_is_tech_avail(tech, BlockDev.FSTechMode.REPAIR)
 
-        # now try without dumpe2fs
-        with utils.fake_path(all_but="dumpe2fs"):
-            with self.assertRaisesRegex(GLib.GError, "The 'dumpe2fs' utility is not available"):
-                BlockDev.fs_is_tech_avail(tech, BlockDev.FSTechMode.QUERY)
-
         # now try without tune2fs
         with utils.fake_path(all_but="tune2fs"):
             with self.assertRaisesRegex(GLib.GError, "The 'tune2fs' utility is not available"):


### PR DESCRIPTION
Spawning and parsing is more expensive, and dumpe2fs has the annoying
bug that it triggers udev events when the MMP feature is enabled on a
filesystem.