### PR TITLE
tests: Temporarily skip LvmTestPartialLVs on rawhide

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -88,3 +88,9 @@
     - distro: "centos"
       version: "9"
       reason: "Creating RAID 1 LV on CentOS/RHEL 9 causes kernel panic"
+
+- test: (lvm_test|lvm_dbus_tests).LvmTestPartialLVs
+  skip_on:
+    - distro: "fedora"
+      version: "38"
+      reason: "Force-removing PV for the test hangs with kernel 6.0.0"

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -94,3 +94,9 @@
     - distro: "fedora"
       version: "38"
       reason: "Force-removing PV for the test hangs with kernel 6.0.0"
+
+- test: kbd_test.KbdTestBcache*
+  skip_on:
+    - distro: "fedora"
+      version: "38"
+      reason: "Bcache attach/detach hangs with kernel 6.0.0"


### PR DESCRIPTION
After latest kernel upgrade the `targetcli` command hangs when trying to remove remove the PV. We should investigate this further (I wasn't able to attach gdb to the process), but for now we need to protect our CI against hanging forever.