### PR TITLE
fs: Add a mkfs option to disable creating partition table

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -34,6 +34,7 @@ typedef enum {
  * @force: whether to run mkfs with the `--force` (or similar) option, the behaviour of this
  *         option depends on the filesystem, but in general it allows overwriting other
  *         preexisting formats detected on the device
+ * @no_pt: whether to disable (protective) partition table creation during mkfs
  * @reserve: reserve for future expansion
  */
 typedef struct BDFSMkfsOptions {
@@ -42,6 +43,7 @@ typedef struct BDFSMkfsOptions {
     gboolean dry_run;
     gboolean no_discard;
     gboolean force;
+    gboolean no_pt;
     guint8 reserve[32];
 } BDFSMkfsOptions;
 
@@ -62,6 +64,7 @@ BDFSMkfsOptions* bd_fs_mkfs_options_copy (BDFSMkfsOptions *data) {
     ret->dry_run = data->dry_run;
     ret->no_discard = data->no_discard;
     ret->force = data->force;
+    ret->no_pt = data->no_pt;
 
     return ret;
 }
@@ -1141,6 +1144,7 @@ typedef enum {
     BD_FS_MKFS_DRY_RUN   = 1 << 2,
     BD_FS_MKFS_NODISCARD = 1 << 3,
     BD_FS_MKFS_FORCE     = 1 << 4,
+    BD_FS_MKFS_NOPT      = 1 << 5,
 } BDFSMkfsOptionsFlags;
 
 /**
@@ -2453,7 +2457,8 @@ typedef enum {
 } BDFSFsckFlags;
 
 typedef enum {
-    BD_FS_FEATURE_OWNERS  = 1 << 1
+    BD_FS_FEATURE_OWNERS  = 1 << 1,
+    BD_FS_FEATURE_PARTITION_TABLE = 1 << 2
 } BDFSFeatureFlags;
 
 /**

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -96,10 +96,10 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "0fc63daf-8483-4772-8e79-3d69d8477de4" },
     /* VFAT */
     { .resize = BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_FORCE,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_FORCE | BD_FS_MKFS_NOPT,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL,
-      .features = 0,
+      .features = BD_FS_FEATURE_PARTITION_TABLE,
       .partition_id = "0x0c",
       .partition_type = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
     /* NTFS */
@@ -147,7 +147,7 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID,
       .fsck = 0,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
-      .features = BD_FS_FEATURE_OWNERS,
+      .features = BD_FS_FEATURE_OWNERS | BD_FS_FEATURE_PARTITION_TABLE,
       .partition_id = "0x07",
       .partition_type = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
 };

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -16,6 +16,7 @@ typedef enum {
     BD_FS_MKFS_DRY_RUN   = 1 << 2,
     BD_FS_MKFS_NODISCARD = 1 << 3,
     BD_FS_MKFS_FORCE     = 1 << 4,
+    BD_FS_MKFS_NOPT      = 1 << 5,
 } BDFSMkfsOptionsFlags;
 
 typedef struct BDFSMkfsOptions {
@@ -24,6 +25,7 @@ typedef struct BDFSMkfsOptions {
     gboolean dry_run;
     gboolean no_discard;
     gboolean force;
+    gboolean no_pt;
     guint8 reserve[32];
 } BDFSMkfsOptions;
 
@@ -60,6 +62,7 @@ typedef enum {
 
 typedef enum {
     BD_FS_FEATURE_OWNERS  = 1 << 1,
+    BD_FS_FEATURE_PARTITION_TABLE = 1 << 2,
 } BDFSFeatureFlags;
 
 typedef struct BDFSFeatures {

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -134,6 +134,8 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
     gchar *label;
+    UtilDep dep = {"mkfs.vfat", "4.2", "--help", "mkfs.fat\\s+([\\d\\.]+).+"};
+    gboolean new_vfat = FALSE;
 
     if (options->label) {
         /* convert the label uppercase */
@@ -147,6 +149,15 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
 
     if (options->force)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-I", ""));
+
+    if (options->no_pt) {
+        /* only mkfs.vfat >= 4.2 (sometimes) creates the partition table */
+        new_vfat = bd_utils_check_util_version (dep.name, dep.version,
+                                                dep.ver_arg, dep.ver_regexp,
+                                                NULL);
+        if (new_vfat)
+            g_ptr_array_add (options_array, bd_extra_arg_new ("--mbr=no", ""));
+    }
 
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -116,7 +116,7 @@ def _get_extra(extra, kwargs, cmd_extra=True):
 
 
 class FSMkfsOptions(BlockDev.FSMkfsOptions):
-    def __new__(cls, label=None, uuid=None, dry_run=False, no_discard=False, force=False):
+    def __new__(cls, label=None, uuid=None, dry_run=False, no_discard=False, force=False, no_pt=False):
         ret = BlockDev.FSMkfsOptions()
         ret.__class__ = cls
 
@@ -125,6 +125,7 @@ class FSMkfsOptions(BlockDev.FSMkfsOptions):
         ret.dry_run = dry_run
         ret.no_discard = no_discard
         ret.force = force
+        ret.no_pt = no_pt
 
         return ret
 FSMkfsOptions = override(FSMkfsOptions)
@@ -1361,7 +1362,3 @@ __all__.append("s390")
 
 utils = ErrorProxy("utils", BlockDev, [(GLib.Error, UtilsError)])
 __all__.append("utils")
-
-
-# for enums with only single member GIO doesn't create the "short" name, so lets add it here
-BlockDev.FSFeatureFlags.OWNERS = BlockDev.FSFeatureFlags.FS_FEATURE_OWNERS

--- a/tests/fs_tests/btrfs_test.py
+++ b/tests/fs_tests/btrfs_test.py
@@ -44,6 +44,7 @@ class BtrfsTestFeatures(BtrfsNoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)
@@ -52,6 +53,7 @@ class BtrfsTestFeatures(BtrfsNoDevTestCase):
         self.assertTrue(features.configure & BlockDev.FSConfigureFlags.UUID)
 
         self.assertTrue(features.features & BlockDev.FSFeatureFlags.OWNERS)
+        self.assertFalse(features.features & BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x83")
         self.assertEqual(features.partition_type, "0fc63daf-8483-4772-8e79-3d69d8477de4")

--- a/tests/fs_tests/exfat_test.py
+++ b/tests/fs_tests/exfat_test.py
@@ -89,6 +89,7 @@ class ExfatTestFeatures(ExfatNoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/fs_tests/ext_test.py
+++ b/tests/fs_tests/ext_test.py
@@ -100,6 +100,7 @@ class ExtTestFeatures(ExtNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)
@@ -108,6 +109,7 @@ class ExtTestFeatures(ExtNoDevTestCase):
         self.assertTrue(features.configure & BlockDev.FSConfigureFlags.UUID)
 
         self.assertTrue(features.features & BlockDev.FSFeatureFlags.OWNERS)
+        self.assertFalse(features.features & BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x83")
         self.assertEqual(features.partition_type, "0fc63daf-8483-4772-8e79-3d69d8477de4")

--- a/tests/fs_tests/f2fs_test.py
+++ b/tests/fs_tests/f2fs_test.py
@@ -131,6 +131,7 @@ class F2FSTestFeatures(F2FSNoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)
@@ -138,6 +139,7 @@ class F2FSTestFeatures(F2FSNoDevTestCase):
         self.assertEqual(features.configure, 0)
 
         self.assertTrue(features.features & BlockDev.FSFeatureFlags.OWNERS)
+        self.assertFalse(features.features & BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x83")
         self.assertEqual(features.partition_type, "0fc63daf-8483-4772-8e79-3d69d8477de4")

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -434,6 +434,20 @@ class GenericMkfs(GenericTestCase):
             extra = None
         self._test_ext_generic_mkfs("vfat", BlockDev.fs_vfat_get_info, label, None, False, extra)
 
+    def test_vfat_generic_mkfs_no_pt(self):
+        """ Test generic mkfs with vfat and mbr=no """
+
+        options = BlockDev.FSMkfsOptions(no_pt=True)
+
+        succ = BlockDev.fs_mkfs(self.loop_dev, "vfat", options, None)
+        self.assertTrue(succ)
+
+        fstype = BlockDev.fs_get_fstype (self.loop_dev)
+        self.assertEqual(fstype, "vfat")
+
+        # there should be no partition
+        self.assertFalse(os.path.exists(self.loop_dev + "1"))
+
     def test_xfs_generic_mkfs(self):
         """ Test generic mkfs with XFS """
         label = "label"

--- a/tests/fs_tests/nilfs_test.py
+++ b/tests/fs_tests/nilfs_test.py
@@ -88,6 +88,7 @@ class NILFS2TestFeatures(NILFS2NoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertEqual(features.fsck, 0)
 
@@ -95,6 +96,7 @@ class NILFS2TestFeatures(NILFS2NoDevTestCase):
         self.assertTrue(features.configure & BlockDev.FSConfigureFlags.UUID)
 
         self.assertTrue(features.features & BlockDev.FSFeatureFlags.OWNERS)
+        self.assertFalse(features.features & BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x83")
         self.assertEqual(features.partition_type, "0fc63daf-8483-4772-8e79-3d69d8477de4")

--- a/tests/fs_tests/ntfs_test.py
+++ b/tests/fs_tests/ntfs_test.py
@@ -96,6 +96,7 @@ class NTFSTestFeatures(NTFSNoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/fs_tests/udf_test.py
+++ b/tests/fs_tests/udf_test.py
@@ -40,6 +40,7 @@ class UdfTestFeatures(UdfNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertEqual(features.fsck, 0)
 
@@ -47,6 +48,7 @@ class UdfTestFeatures(UdfNoDevTestCase):
         self.assertTrue(features.configure & BlockDev.FSConfigureFlags.UUID)
 
         self.assertTrue(features.features & BlockDev.FSFeatureFlags.OWNERS)
+        self.assertTrue(features.features & BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x07")
         self.assertEqual(features.partition_type, "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7")

--- a/tests/fs_tests/vfat_test.py
+++ b/tests/fs_tests/vfat_test.py
@@ -103,6 +103,7 @@ class VfatTestFeatures(VfatNoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)
@@ -110,7 +111,7 @@ class VfatTestFeatures(VfatNoDevTestCase):
         self.assertTrue(features.configure & BlockDev.FSConfigureFlags.LABEL)
         self.assertFalse(features.configure & BlockDev.FSConfigureFlags.UUID)
 
-        self.assertEqual(features.features, 0)
+        self.assertEqual(features.features, BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x0c")
         self.assertEqual(features.partition_type, "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7")

--- a/tests/fs_tests/xfs_test.py
+++ b/tests/fs_tests/xfs_test.py
@@ -94,6 +94,7 @@ class XfsTestFeatures(XfsNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
+        self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NOPT)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)
@@ -102,6 +103,7 @@ class XfsTestFeatures(XfsNoDevTestCase):
         self.assertTrue(features.configure & BlockDev.FSConfigureFlags.UUID)
 
         self.assertTrue(features.features & BlockDev.FSFeatureFlags.OWNERS)
+        self.assertFalse(features.features & BlockDev.FSFeatureFlags.PARTITION_TABLE)
 
         self.assertEqual(features.partition_id, "0x83")
         self.assertEqual(features.partition_type, "0fc63daf-8483-4772-8e79-3d69d8477de4")


### PR DESCRIPTION
Currectly UDF and VFAT create (sometimes) a partition table on
the device when running mkfs and only VFAT allows controlling this
behaviour.

Fixes: #767