### PR TITLE
Add a "force" mkfs option for bd_fs_mkfs

### DIFF
--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -31,6 +31,9 @@ typedef enum {
  * @uuid: uuid of the filesystem
  * @dry_run: whether to run mkfs in dry run mode (no changes written to the device)
  * @no_discard: whether to avoid discarding blocks at mkfs time
+ * @force: whether to run mkfs with the `--force` (or similar) option, the behaviour of this
+ *         option depends on the filesystem, but in general it allows overwriting other
+ *         preexisting formats detected on the device
  * @reserve: reserve for future expansion
  */
 typedef struct BDFSMkfsOptions {
@@ -38,6 +41,7 @@ typedef struct BDFSMkfsOptions {
     const gchar *uuid;
     gboolean dry_run;
     gboolean no_discard;
+    gboolean force;
     guint8 reserve[32];
 } BDFSMkfsOptions;
 
@@ -57,6 +61,7 @@ BDFSMkfsOptions* bd_fs_mkfs_options_copy (BDFSMkfsOptions *data) {
     ret->uuid = data->uuid;
     ret->dry_run = data->dry_run;
     ret->no_discard = data->no_discard;
+    ret->force = data->force;
 
     return ret;
 }
@@ -1135,6 +1140,7 @@ typedef enum {
     BD_FS_MKFS_UUID      = 1 << 1,
     BD_FS_MKFS_DRY_RUN   = 1 << 2,
     BD_FS_MKFS_NODISCARD = 1 << 3,
+    BD_FS_MKFS_FORCE     = 1 << 4,
 } BDFSMkfsOptionsFlags;
 
 /**

--- a/src/plugins/fs/btrfs.c
+++ b/src/plugins/fs/btrfs.c
@@ -150,7 +150,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
  *
  */
 gboolean bd_fs_btrfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
-    const gchar *args[4] = {"mkfs.btrfs", "-f", device, NULL};
+    const gchar *args[3] = {"mkfs.btrfs", device, NULL};
 
     if (!check_deps (&avail_deps, DEPS_MKFSBTRFS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;

--- a/src/plugins/fs/btrfs.c
+++ b/src/plugins/fs/btrfs.c
@@ -127,6 +127,9 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->no_discard)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
 
+    if (options->force)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-f", ""));
+
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)
             g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -253,6 +253,9 @@ static BDExtraArg **ext_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg
     if (options->no_discard)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-E", "nodiscard"));
 
+    if (options->force)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-F", ""));
+
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)
             g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -279,7 +279,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
 }
 
 static gboolean ext_mkfs (const gchar *device, const BDExtraArg **extra, const gchar *ext_version, GError **error) {
-    const gchar *args[6] = {"mke2fs", "-t", ext_version, "-F", device, NULL};
+    const gchar *args[5] = {"mke2fs", "-t", ext_version, device, NULL};
 
     if (!check_deps (&avail_deps, DEPS_MKE2FS_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -183,6 +183,9 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->no_discard)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-t", "nodiscard"));
 
+    if (options->force)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-f", ""));
+
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)
             g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -60,7 +60,8 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
     { 0 }, { 0 },
     /* EXT2 */
     { .resize = BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD |
+              BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
       .features =  BD_FS_FEATURE_OWNERS,
@@ -68,7 +69,8 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "0fc63daf-8483-4772-8e79-3d69d8477de4" },
     /* EXT3 */
     { .resize = BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD |
+              BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
       .features =  BD_FS_FEATURE_OWNERS,
@@ -76,7 +78,8 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "0fc63daf-8483-4772-8e79-3d69d8477de4" },
     /* EXT4 */
     { .resize = BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD |
+              BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
       .features =  BD_FS_FEATURE_OWNERS,
@@ -84,7 +87,8 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "0fc63daf-8483-4772-8e79-3d69d8477de4" },
     /* XFS */
     { .resize = BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD |
+              BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
       .features =  BD_FS_FEATURE_OWNERS,
@@ -92,7 +96,7 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "0fc63daf-8483-4772-8e79-3d69d8477de4" },
     /* VFAT */
     { .resize = BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL,
       .features = 0,
@@ -108,7 +112,7 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
     /* F2FS */
     { .resize = BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_NODISCARD | BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure =  0,
       .features = BD_FS_FEATURE_OWNERS,
@@ -116,7 +120,7 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "0fc63daf-8483-4772-8e79-3d69d8477de4" },
     /* NILFS2 */
     { .resize = BD_FS_ONLINE_GROW | BD_FS_ONLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_DRY_RUN | BD_FS_MKFS_NODISCARD | BD_FS_MKFS_FORCE,
       .fsck = 0,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
       .features = BD_FS_FEATURE_OWNERS,
@@ -132,7 +136,7 @@ static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
       .partition_type = "ebd0a0a2-b9e5-4433-87c0-68b6b72699c7" },
     /* BTRFS */
     { .resize = BD_FS_ONLINE_GROW | BD_FS_ONLINE_SHRINK,
-      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_NODISCARD,
+      .mkfs = BD_FS_MKFS_LABEL | BD_FS_MKFS_UUID | BD_FS_MKFS_NODISCARD | BD_FS_MKFS_FORCE,
       .fsck = BD_FS_FSCK_CHECK | BD_FS_FSCK_REPAIR,
       .configure = BD_FS_SUPPORT_SET_LABEL | BD_FS_SUPPORT_SET_UUID,
       .features = BD_FS_FEATURE_OWNERS,

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -15,6 +15,7 @@ typedef enum {
     BD_FS_MKFS_UUID      = 1 << 1,
     BD_FS_MKFS_DRY_RUN   = 1 << 2,
     BD_FS_MKFS_NODISCARD = 1 << 3,
+    BD_FS_MKFS_FORCE     = 1 << 4,
 } BDFSMkfsOptionsFlags;
 
 typedef struct BDFSMkfsOptions {
@@ -22,6 +23,7 @@ typedef struct BDFSMkfsOptions {
     const gchar *uuid;
     gboolean dry_run;
     gboolean no_discard;
+    gboolean force;
     guint8 reserve[32];
 } BDFSMkfsOptions;
 

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -146,6 +146,9 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->no_discard)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
 
+    if (options->force)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-f", ""));
+
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)
             g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -168,7 +168,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
  * Tech category: %BD_FS_TECH_NILFS2-%BD_FS_TECH_MODE_MKFS
  */
 gboolean bd_fs_nilfs2_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
-    const gchar *args[5] = {"mkfs.nilfs2", "-f", "-q", device, NULL};
+    const gchar *args[4] = {"mkfs.nilfs2", "-q", device, NULL};
 
     if (!check_deps (&avail_deps, DEPS_MKFSNILFS2_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -169,7 +169,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
  * Tech category: %BD_FS_TECH_VFAT-%BD_FS_TECH_MODE_MKFS
  */
 gboolean bd_fs_vfat_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
-    const gchar *args[4] = {"mkfs.vfat", "-I", device, NULL};
+    const gchar *args[3] = {"mkfs.vfat", device, NULL};
 
     if (!check_deps (&avail_deps, DEPS_MKFSVFAT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -145,6 +145,9 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->uuid)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-i", options->uuid));
 
+    if (options->force)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-I", ""));
+
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)
             g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -143,6 +143,9 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->no_discard)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-K", ""));
 
+    if (options->force)
+        g_ptr_array_add (options_array, bd_extra_arg_new ("-f", ""));
+
     if (extra) {
         for (extra_p = extra; *extra_p; extra_p++)
             g_ptr_array_add (options_array, bd_extra_arg_copy ((BDExtraArg *) *extra_p));

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -116,7 +116,7 @@ def _get_extra(extra, kwargs, cmd_extra=True):
 
 
 class FSMkfsOptions(BlockDev.FSMkfsOptions):
-    def __new__(cls, label=None, uuid=None, dry_run=False, no_discard=False):
+    def __new__(cls, label=None, uuid=None, dry_run=False, no_discard=False, force=False):
         ret = BlockDev.FSMkfsOptions()
         ret.__class__ = cls
 
@@ -124,6 +124,7 @@ class FSMkfsOptions(BlockDev.FSMkfsOptions):
         ret.uuid = uuid
         ret.dry_run = dry_run
         ret.no_discard = no_discard
+        ret.force = force
 
         return ret
 FSMkfsOptions = override(FSMkfsOptions)

--- a/tests/fs_tests/btrfs_test.py
+++ b/tests/fs_tests/btrfs_test.py
@@ -43,6 +43,7 @@ class BtrfsTestFeatures(BtrfsNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/fs_tests/ext_test.py
+++ b/tests/fs_tests/ext_test.py
@@ -104,6 +104,7 @@ class ExtTestFeatures(ExtNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/fs_tests/f2fs_test.py
+++ b/tests/fs_tests/f2fs_test.py
@@ -130,6 +130,7 @@ class F2FSTestFeatures(F2FSNoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/fs_tests/nilfs_test.py
+++ b/tests/fs_tests/nilfs_test.py
@@ -87,6 +87,7 @@ class NILFS2TestFeatures(NILFS2NoDevTestCase):
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
 
         self.assertEqual(features.fsck, 0)
 

--- a/tests/fs_tests/vfat_test.py
+++ b/tests/fs_tests/vfat_test.py
@@ -102,6 +102,7 @@ class VfatTestFeatures(VfatNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertFalse(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/fs_tests/xfs_test.py
+++ b/tests/fs_tests/xfs_test.py
@@ -93,6 +93,7 @@ class XfsTestFeatures(XfsNoDevTestCase):
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.UUID)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.DRY_RUN)
         self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.NODISCARD)
+        self.assertTrue(features.mkfs & BlockDev.FSMkfsOptionsFlags.FORCE)
 
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.CHECK)
         self.assertTrue(features.fsck & BlockDev.FSFsckFlags.REPAIR)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -657,7 +657,7 @@ def mount(device, where, ro=False):
 
 def umount(what, retry=True):
     try:
-        os.system("umount %s >/dev/null 2>&1" % what)
+        os.system("umount -A -l %s >/dev/null 2>&1" % what)
         os.rmdir(what)
     except OSError as e:
         # retry the umount if the device is busy


### PR DESCRIPTION
Fixes: #766 

Two "issues" with this one:

- *NTFS*: I've decided to keep running `mkfs.ntfs` with the `-F` option by default and pretend the option doesn't exist for NTFS. `mkfs.ntfs` will overwrite preexisting filesystems without asking so the `-F` option mostly allows us to format non-partition devices.
- *ext*: The `-F` option is basically no-op for most cases, because running `mke2fs` with closed stdin answers *yes* to the "overwrite" question, but I decided to keep the option here, someone might want to use it for the other use cases.