### PR TITLE
utils: Introduce bd_extra_arg_list_free()

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -205,6 +205,7 @@ BDExtraArg
 bd_extra_arg_new
 bd_extra_arg_copy
 bd_extra_arg_free
+bd_extra_arg_list_free
 bd_extra_arg_get_type
 bd_utils_resolve_device
 bd_utils_get_device_symlinks

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -1878,10 +1878,7 @@ gboolean bd_fs_mkfs (const gchar *device, const gchar *fstype, BDFSMkfsOptions *
         return FALSE;
     }
 
-    for (BDExtraArg **arg_p = extra_args; *arg_p; arg_p++)
-        bd_extra_arg_free (*arg_p);
-    g_free (extra_args);
-
+    bd_extra_arg_list_free (extra_args);
     return ret;
 }
 

--- a/src/utils/extra_arg.c
+++ b/src/utils/extra_arg.c
@@ -35,6 +35,23 @@ void bd_extra_arg_free (BDExtraArg *arg) {
     g_free (arg);
 }
 
+/**
+ * bd_extra_arg_list_free:
+ * @args: (nullable) (array zero-terminated=1): A list of %BDExtraArg to free
+ *
+ * Frees @args and all its elements.
+ */
+void bd_extra_arg_list_free (BDExtraArg **args) {
+    BDExtraArg **a;
+
+    if (args == NULL)
+        return;
+
+    for (a = args; *a; a++)
+        bd_extra_arg_free (*a);
+    g_free (args);
+}
+
 GType bd_extra_arg_get_type (void) {
     static GType type = 0;
 

--- a/src/utils/extra_arg.h
+++ b/src/utils/extra_arg.h
@@ -22,6 +22,7 @@ typedef struct BDExtraArg {
 
 BDExtraArg* bd_extra_arg_copy (BDExtraArg *arg);
 void bd_extra_arg_free (BDExtraArg *arg);
+void bd_extra_arg_list_free (BDExtraArg **args);
 BDExtraArg* bd_extra_arg_new (const gchar *opt, const gchar *val);
 
 #endif  /* BD_UTILS_EXTRA_ARG */


### PR DESCRIPTION
A convenient function to free a list of extra arguments.