### PR TITLE
fs: Fix calling bd_fs_mkfs with empty label or UUID

### DIFF
--- a/src/plugins/fs/btrfs.c
+++ b/src/plugins/fs/btrfs.c
@@ -118,10 +118,10 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
 
-    if (options->uuid)
+    if (options->uuid && g_strcmp0 (options->uuid, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
 
     if (options->no_discard)

--- a/src/plugins/fs/exfat.c
+++ b/src/plugins/fs/exfat.c
@@ -135,7 +135,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-n", options->label));
 
     if (extra) {

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -241,10 +241,10 @@ static BDExtraArg **ext_mkfs_options (BDFSMkfsOptions *options, const BDExtraArg
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
 
-    if (options->uuid)
+    if (options->uuid && g_strcmp0 (options->uuid, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
 
     if (options->dry_run)

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -177,7 +177,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-l", options->label));
 
     if (options->no_discard)

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -134,10 +134,10 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
 
-    if (options->uuid)
+    if (options->uuid && g_strcmp0 (options->uuid, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
 
     if (options->dry_run)

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -120,7 +120,7 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     GPtrArray *options_array = g_ptr_array_new ();
     const BDExtraArg **extra_p = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
 
     if (options->dry_run)

--- a/src/plugins/fs/udf.c
+++ b/src/plugins/fs/udf.c
@@ -179,14 +179,14 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     const BDExtraArg **extra_p = NULL;
     g_autofree gchar *vid = NULL;
 
-    if (options->label) {
+    if (options->label && g_strcmp0 (options->label, "") != 0) {
         vid = get_vid (options->label);
 
         g_ptr_array_add (options_array, bd_extra_arg_new ("--lvid", options->label));
         g_ptr_array_add (options_array, bd_extra_arg_new ("--vid", vid));
     }
 
-    if (options->uuid)
+    if (options->uuid && g_strcmp0 (options->uuid, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-u", options->uuid));
 
     if (extra) {

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -137,14 +137,14 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     UtilDep dep = {"mkfs.vfat", "4.2", "--help", "mkfs.fat\\s+([\\d\\.]+).+"};
     gboolean new_vfat = FALSE;
 
-    if (options->label) {
+    if (options->label && g_strcmp0 (options->label, "") != 0) {
         /* convert the label uppercase */
         label = g_ascii_strup (options->label, -1);
         g_ptr_array_add (options_array, bd_extra_arg_new ("-n", label));
         g_free (label);
     }
 
-    if (options->uuid)
+    if (options->uuid && g_strcmp0 (options->uuid, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-i", options->uuid));
 
     if (options->force)

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -128,10 +128,10 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     const BDExtraArg **extra_p = NULL;
     gchar *uuid_option = NULL;
 
-    if (options->label)
+    if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
 
-    if (options->uuid) {
+    if (options->uuid && g_strcmp0 (options->uuid, "") != 0) {
         uuid_option = g_strdup_printf ("uuid=%s", options->uuid);
         g_ptr_array_add (options_array, bd_extra_arg_new ("-m", uuid_option));
         g_free (uuid_option);

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -313,7 +313,7 @@ class CanResizeRepairCheckLabel(GenericNoDevTestCase):
 
 class GenericMkfs(GenericTestCase):
 
-    def _test_ext_generic_mkfs(self, fsname, info_fn, label=None, uuid=None, force=False, extra=None):
+    def _test_ext_generic_mkfs(self, fsname, info_fn, label=None, uuid=None, force=False, extra=None, default_label=None):
         # clean the device
         succ = BlockDev.fs_clean(self.loop_dev)
         self.assertTrue(succ)
@@ -341,8 +341,14 @@ class GenericMkfs(GenericTestCase):
 
         info = info_fn(self.loop_dev)
         self.assertIsNotNone(info)
-        if label:
-            self.assertEqual(info.label, label)
+        if label is not None:
+            if label == "":
+                if default_label:
+                    self.assertEqual(info.label, default_label)
+                else:
+                    self.assertEqual(info.label, "")
+            else:
+                self.assertEqual(info.label, label)
         if uuid:
             self.assertEqual(info.uuid, uuid)
 
@@ -400,15 +406,29 @@ class GenericMkfs(GenericTestCase):
         uuid = "8802574c-587b-43b9-a6be-9de77759d2c5"
         self._test_ext_generic_mkfs("ext3", BlockDev.fs_ext3_get_info, label, uuid, False)
 
+        # now try with empty label and UUID
+        label = ""
+        uuid = ""
+        self._test_ext_generic_mkfs("ext3", BlockDev.fs_ext3_get_info, label, uuid, False)
+
     def test_ext4_generic_mkfs(self):
         """ Test generic mkfs with ext4 """
         label = "label"
         uuid = "8802574c-587b-43b9-a6be-9de77759d2c5"
         self._test_ext_generic_mkfs("ext4", BlockDev.fs_ext4_get_info, label, uuid, False)
 
+        # now try with empty label and UUID
+        label = ""
+        uuid = ""
+        self._test_ext_generic_mkfs("ext4", BlockDev.fs_ext4_get_info, label, uuid, False)
+
     def test_f2fs_generic_mkfs(self):
         """ Test generic mkfs with F2FS """
         label = "label"
+        self._test_ext_generic_mkfs("f2fs", BlockDev.fs_f2fs_get_info, label, None, True)
+
+        # now try with empty label
+        label = ""
         self._test_ext_generic_mkfs("f2fs", BlockDev.fs_f2fs_get_info, label, None, True)
 
     def test_nilfs2_generic_mkfs(self):
@@ -418,11 +438,19 @@ class GenericMkfs(GenericTestCase):
         label = "label"
         self._test_ext_generic_mkfs("nilfs2", BlockDev.fs_nilfs2_get_info, label, None, True)
 
+        # now try with empty label
+        label = ""
+        self._test_ext_generic_mkfs("nilfs2", BlockDev.fs_nilfs2_get_info, label, None, True)
+
     def test_ntfs_generic_mkfs(self):
         """ Test generic mkfs with NTFS """
         if not self.ntfs_avail:
             self.skipTest("skipping NTFS: not available")
         label = "label"
+        self._test_ext_generic_mkfs("ntfs", BlockDev.fs_ntfs_get_info, label, None)
+
+        # now try with empty label
+        label = ""
         self._test_ext_generic_mkfs("ntfs", BlockDev.fs_ntfs_get_info, label, None)
 
     def test_vfat_generic_mkfs(self):
@@ -432,6 +460,10 @@ class GenericMkfs(GenericTestCase):
             extra = [BlockDev.ExtraArg.new("--mbr=n", "")]
         else:
             extra = None
+        self._test_ext_generic_mkfs("vfat", BlockDev.fs_vfat_get_info, label, None, False, extra)
+
+        # now try with empty label
+        label = ""
         self._test_ext_generic_mkfs("vfat", BlockDev.fs_vfat_get_info, label, None, False, extra)
 
     def test_vfat_generic_mkfs_no_pt(self):
@@ -460,6 +492,11 @@ class GenericMkfs(GenericTestCase):
 
         self._test_ext_generic_mkfs("xfs", _xfs_info, label, uuid, True)
 
+        # now try with empty label and UUID
+        label = ""
+        uuid = ""
+        self._test_ext_generic_mkfs("xfs", _xfs_info, label, uuid, True)
+
     def test_btrfs_generic_mkfs(self):
         """ Test generic mkfs with Btrfs """
         if not self.btrfs_avail:
@@ -474,12 +511,21 @@ class GenericMkfs(GenericTestCase):
 
         self._test_ext_generic_mkfs("btrfs", _btrfs_info, label, uuid, True)
 
+        # now try with empty label and UUID
+        label = ""
+        uuid = ""
+        self._test_ext_generic_mkfs("btrfs", _btrfs_info, label, uuid, True)
+
     def test_udf_generic_mkfs(self):
         """ Test generic mkfs with udf """
         if not self.udf_avail:
             self.skipTest("skipping UDF: not available")
         label = "LABEL"
         self._test_ext_generic_mkfs("udf", BlockDev.fs_udf_get_info, label, None)
+
+        # now try with empty label
+        label = ""
+        self._test_ext_generic_mkfs("udf", BlockDev.fs_udf_get_info, label, None, default_label="LinuxUDF")
 
     def test_generic_mkfs_no_options(self):
         """ Test that fs_mkfs works without options specified """


### PR DESCRIPTION
Empty string for label/UUID doesn't make sense with mkfs so we need to skip the extra option.