### PR TITLE
nvme: Extend BDNVMELBAFormat with metadata_size

### DIFF
--- a/src/lib/plugin_apis/nvme.api
+++ b/src/lib/plugin_apis/nvme.api
@@ -258,10 +258,12 @@ GType bd_nvme_lba_format_get_type ();
  * BDNVMELBAFormat:
  * Namespace LBA Format Data Structure.
  * @data_size: LBA data size (i.e. a sector size) in bytes.
+ * @metadata_size: metadata size in bytes or `0` in case of no metadata support.
  * @relative_performance: Relative Performance index, see #BDNVMELBAFormatRelativePerformance.
  */
 typedef struct BDNVMELBAFormat {
     guint16 data_size;
+    guint16 metadata_size;
     BDNVMELBAFormatRelativePerformance relative_performance;
 } BDNVMELBAFormat;
 
@@ -289,6 +291,7 @@ BDNVMELBAFormat * bd_nvme_lba_format_copy (BDNVMELBAFormat *fmt) {
 
     new_fmt = g_new0 (BDNVMELBAFormat, 1);
     new_fmt->data_size = fmt->data_size;
+    new_fmt->metadata_size = fmt->metadata_size;
     new_fmt->relative_performance = fmt->relative_performance;
 
     return new_fmt;
@@ -1219,6 +1222,7 @@ gboolean bd_nvme_device_self_test (const gchar *device, BDNVMESelfTestAction act
  * bd_nvme_format:
  * @device: NVMe namespace or controller device to format (e.g. `/dev/nvme0n1`)
  * @lba_data_size: desired LBA data size (i.e. a sector size) in bytes or `0` to keep current. See #BDNVMELBAFormat and bd_nvme_get_namespace_info().
+ * @metadata_size: desired metadata size in bytes or `0` for default. See #BDNVMELBAFormat and bd_nvme_get_namespace_info().
  * @secure_erase: optional secure erase action to take.
  * @error: (out) (nullable): place to store error (if any)
  *
@@ -1244,7 +1248,7 @@ gboolean bd_nvme_device_self_test (const gchar *device, BDNVMESelfTestAction act
  *
  * Tech category: %BD_NVME_TECH_NVME-%BD_NVME_TECH_MODE_MANAGE
  */
-gboolean bd_nvme_format (const gchar *device, guint16 lba_data_size, BDNVMEFormatSecureErase secure_erase, GError **error);
+gboolean bd_nvme_format (const gchar *device, guint16 lba_data_size, guint16 metadata_size, BDNVMEFormatSecureErase secure_erase, GError **error);
 
 /**
  * bd_nvme_sanitize:

--- a/src/plugins/nvme/nvme-info.c
+++ b/src/plugins/nvme/nvme-info.c
@@ -103,6 +103,7 @@ BDNVMELBAFormat * bd_nvme_lba_format_copy (BDNVMELBAFormat *fmt) {
 
     new_fmt = g_new0 (BDNVMELBAFormat, 1);
     new_fmt->data_size = fmt->data_size;
+    new_fmt->metadata_size = fmt->metadata_size;
     new_fmt->relative_performance = fmt->relative_performance;
 
     return new_fmt;
@@ -625,10 +626,12 @@ BDNVMENamespaceInfo *bd_nvme_get_namespace_info (const gchar *device, GError **e
     for (i = 0; i <= ns_info.nlbaf + ns_info.nulbaf; i++) {
         BDNVMELBAFormat *lbaf = g_new0 (BDNVMELBAFormat, 1);
         lbaf->data_size = 1 << ns_info.lbaf[i].ds;
+        lbaf->metadata_size = GUINT16_FROM_LE (ns_info.lbaf[i].ms);
         lbaf->relative_performance = ns_info.lbaf[i].rp + 1;
         g_ptr_array_add (ptr_array, lbaf);
         if (i == flbas) {
             info->current_lba_format.data_size = lbaf->data_size;
+            info->current_lba_format.metadata_size = lbaf->metadata_size;
             info->current_lba_format.relative_performance = lbaf->relative_performance;
         }
     }

--- a/src/plugins/nvme/nvme.h
+++ b/src/plugins/nvme/nvme.h
@@ -185,10 +185,12 @@ typedef enum {
  * BDNVMELBAFormat:
  * Namespace LBA Format Data Structure.
  * @data_size: LBA data size (i.e. a sector size) in bytes.
+ * @metadata_size: metadata size in bytes or `0` in case of no metadata support.
  * @relative_performance: Relative Performance index, see #BDNVMELBAFormatRelativePerformance.
  */
 typedef struct BDNVMELBAFormat {
     guint16 data_size;
+    guint16 metadata_size;
     BDNVMELBAFormatRelativePerformance relative_performance;
 } BDNVMELBAFormat;
 
@@ -643,6 +645,7 @@ gboolean               bd_nvme_device_self_test      (const gchar               
 
 gboolean               bd_nvme_format                (const gchar                  *device,
                                                       guint16                       lba_data_size,
+                                                      guint16                       metadata_size,
                                                       BDNVMEFormatSecureErase       secure_erase,
                                                       GError                      **error);
 gboolean               bd_nvme_sanitize              (const gchar                  *device,

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -84,6 +84,7 @@ class NVMeTestCase(NVMeTest):
         self.assertGreater(len(info.uuid), 0)
         self.assertFalse(info.write_protected)
         self.assertEqual(info.current_lba_format.data_size, 512)
+        self.assertEqual(info.current_lba_format.metadata_size, 0)
         self.assertEqual(info.current_lba_format.relative_performance, BlockDev.NVMELBAFormatRelativePerformance.BEST)
 
     @tag_test(TestTags.CORE)
@@ -238,20 +239,20 @@ class NVMeTestCase(NVMeTest):
         """Test issuing the format command"""
 
         with self.assertRaisesRegexp(GLib.GError, r".*Failed to open device .*': No such file or directory"):
-            BlockDev.nvme_format("/dev/nonexistent", 0, BlockDev.NVMEFormatSecureErase.NONE)
+            BlockDev.nvme_format("/dev/nonexistent", 0, 0, BlockDev.NVMEFormatSecureErase.NONE)
 
         message = r"Couldn't match desired LBA data block size in a device supported LBA format data sizes"
         with self.assertRaisesRegexp(GLib.GError, message):
-            BlockDev.nvme_format(self.nvme_ns_dev, 123, BlockDev.NVMEFormatSecureErase.NONE)
+            BlockDev.nvme_format(self.nvme_ns_dev, 123, 0, BlockDev.NVMEFormatSecureErase.NONE)
         with self.assertRaisesRegexp(GLib.GError, message):
-            BlockDev.nvme_format(self.nvme_dev, 123, BlockDev.NVMEFormatSecureErase.NONE)
+            BlockDev.nvme_format(self.nvme_dev, 123, 0, BlockDev.NVMEFormatSecureErase.NONE)
 
         # format doesn't really work on the kernel loop target
         message = r"Format NVM command error: Invalid Command Opcode: A reserved coded value or an unsupported value in the command opcode field|Format NVM command error: Invalid Queue Identifier: The creation of the I/O Completion Queue failed due to an invalid queue identifier specified as part of the command"
         with self.assertRaisesRegexp(GLib.GError, message):
-            BlockDev.nvme_format(self.nvme_ns_dev, 0, BlockDev.NVMEFormatSecureErase.NONE)
+            BlockDev.nvme_format(self.nvme_ns_dev, 0, 0, BlockDev.NVMEFormatSecureErase.NONE)
         with self.assertRaisesRegexp(GLib.GError, message):
-            BlockDev.nvme_format(self.nvme_dev, 0, BlockDev.NVMEFormatSecureErase.NONE)
+            BlockDev.nvme_format(self.nvme_dev, 0, 0, BlockDev.NVMEFormatSecureErase.NONE)
 
 
     @tag_test(TestTags.CORE)


### PR DESCRIPTION
The metadata size field was originally intentionally omitted for the libblockdev API, hiding low-level implementation details that seemed unimportant. Turned out that some drives expose several metadata sizes for the same lba data size, leading to seemingly duplicate entries in the list, causing confusion in upper layers. As this is used for namespace formatting that is a destructive operation, it's wiser to expose this detail to higher levels after all.