### PR TITLE
Distutils deprecation

### DIFF
--- a/src/python/gi/overrides/Makefile.am
+++ b/src/python/gi/overrides/Makefile.am
@@ -6,7 +6,7 @@ dist_overrides_DATA = BlockDev.py
 endif
 
 if WITH_PYTHON3
-py3libdir = $(shell python3 -c "import distutils.sysconfig; print(distutils.sysconfig.get_python_lib(1,0,prefix='${exec_prefix}'))")
+py3libdir = $(shell python3 -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'platbase': '${exec_prefix}'}))")
 py3overridesdir = $(py3libdir)/gi/overrides
 nodist_py3overrides_DATA = BlockDev.py
 endif

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -4,10 +4,10 @@ import unittest
 import os
 import six
 import re
+import shutil
 import time
 
 from distutils.version import LooseVersion
-from distutils.spawn import find_executable
 
 import overrides_hack
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, mount, umount, run_command, TestTags, tag_test
@@ -29,7 +29,7 @@ class BtrfsTestCase(unittest.TestCase):
         if not BlockDev.utils_have_kernel_module("btrfs"):
             raise unittest.SkipTest('Btrfs kernel module not available, skipping.')
 
-        if not find_executable("btrfs"):
+        if not shutil.which("btrfs"):
             raise unittest.SkipTest("btrfs executable not foundin $PATH, skipping.")
 
         if not BlockDev.is_initialized():

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -7,7 +7,7 @@ import re
 import shutil
 import time
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import overrides_hack
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, mount, umount, run_command, TestTags, tag_test
@@ -71,7 +71,7 @@ class BtrfsTestCase(unittest.TestCase):
         m = re.search(r"[Bb]trfs.* v([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine btrfs version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
 class BtrfsTestCreateQuerySimple(BtrfsTestCase):
     @tag_test(TestTags.CORE)
@@ -186,7 +186,7 @@ class BtrfsTestCreateDeleteSubvolume(BtrfsTestCase):
         """Verify that it is possible to create/delete subvolume"""
 
         btrfs_version = self._get_btrfs_version()
-        if btrfs_version >= LooseVersion('4.13.2'):
+        if btrfs_version >= Version('4.13.2'):
             self.skipTest('subvolumes list is broken with btrfs-progs v4.13.2')
 
         succ = BlockDev.btrfs_create_volume([self.loop_dev], "myShinyBtrfs", None, None, None)

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -10,7 +10,7 @@ import re
 import six
 import overrides_hack
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from gi.repository import BlockDev, GLib
 
@@ -41,7 +41,7 @@ def _get_dosfstools_version():
     m = re.search(r"mkfs\.fat ([\d\.]+)", out)
     if not m or len(m.groups()) != 1:
         raise RuntimeError("Failed to determine dosfstools version from: %s" % out)
-    return LooseVersion(m.groups()[0])
+    return Version(m.groups()[0])
 
 
 def _get_xfs_version():
@@ -49,7 +49,7 @@ def _get_xfs_version():
     m = re.search(r"mkfs\.xfs version ([\d\.]+)", out)
     if not m or len(m.groups()) != 1:
         raise RuntimeError("Failed to determine xfsprogs version from: %s" % out)
-    return LooseVersion(m.groups()[0])
+    return Version(m.groups()[0])
 
 
 class FSTestCase(unittest.TestCase):
@@ -91,7 +91,7 @@ class FSTestCase(unittest.TestCase):
 
         self.mount_dir = tempfile.mkdtemp(prefix="libblockdev.", suffix="ext4_test")
 
-        if self._vfat_version <= LooseVersion("4.1"):
+        if self._vfat_version <= Version("4.1"):
             self._mkfs_options = None
         else:
             self._mkfs_options = [BlockDev.ExtraArg.new("--mbr=n", "")]
@@ -150,7 +150,7 @@ class TestGenericWipe(FSTestCase):
 
         # vfat has multiple signatures on the device so it allows us to test the
         # 'all' argument of fs_wipe()
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1 --mbr=n" % self.loop_dev)
         else:
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1" % self.loop_dev)
@@ -175,7 +175,7 @@ class TestGenericWipe(FSTestCase):
         self.assertEqual(fs_type, b"")
 
         # now do the wipe all in a one step
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1 --mbr=n" % self.loop_dev)
         else:
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1" % self.loop_dev)
@@ -233,7 +233,7 @@ class TestClean(FSTestCase):
 
         # vfat has multiple signatures on the device so it allows us to test
         # that clean removes all signatures
-        if self._vfat_version >= LooseVersion("4.2"):
+        if self._vfat_version >= Version("4.2"):
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1 --mbr=n" % self.loop_dev)
         else:
             ret = utils.run("mkfs.vfat -I %s >/dev/null 2>&1" % self.loop_dev)
@@ -760,7 +760,7 @@ class XfsResize(FSTestCase):
 
         # (still) impossible to shrink an XFS file system
         xfs_version = _get_xfs_version()
-        if xfs_version < LooseVersion("5.1.12"):
+        if xfs_version < Version("5.1.12"):
             with mounted(lv, self.mount_dir):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_resize(lv, 40 * 1024**2)
@@ -1465,7 +1465,7 @@ class GenericResize(FSTestCase):
     def test_vfat_generic_resize(self):
         """Test generic resize function with a vfat file system"""
         def mkfs_vfat(device, options=None):
-            if self._vfat_version >= LooseVersion("4.2"):
+            if self._vfat_version >= Version("4.2"):
                 if options:
                     return BlockDev.fs_vfat_mkfs(device, options + [BlockDev.ExtraArg.new("--mbr=n", "")])
                 else:
@@ -1512,7 +1512,7 @@ class GenericResize(FSTestCase):
 
         # (still) impossible to shrink an XFS file system
         xfs_version = _get_xfs_version()
-        if xfs_version < LooseVersion("5.1.12"):
+        if xfs_version < Version("5.1.12"):
             with mounted(lv, self.mount_dir):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_resize(lv, 40 * 1024**2)

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -164,8 +164,8 @@ class KbdZRAMStatsTestCase(KbdZRAMTestCase):
         """Verify that it is possible to get stats for a zram device"""
 
         # location of some sysfs files we use is different since linux 4.11
-        kernel_version = os.uname()[2]
-        if Version(kernel_version) >= Version("4.11"):
+        ver = BlockDev.utils_get_linux_version()
+        if Version("%d.%d.%d" % (ver.major, ver.minor, ver.micro)) >= Version("4.11"):
             self._zram_get_stats_new()
         else:
             self._zram_get_stats_old()

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import time
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, wipe_all, fake_path, read_file, TestTags, tag_test
 from bytesize import bytesize
 import overrides_hack
@@ -165,7 +165,7 @@ class KbdZRAMStatsTestCase(KbdZRAMTestCase):
 
         # location of some sysfs files we use is different since linux 4.11
         kernel_version = os.uname()[2]
-        if LooseVersion(kernel_version) >= LooseVersion("4.11"):
+        if Version(kernel_version) >= Version("4.11"):
             self._zram_get_stats_new()
         else:
             self._zram_get_stats_old()

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -1,10 +1,10 @@
 import unittest
 import os
 import re
+import shutil
 import time
 from contextlib import contextmanager
 from distutils.version import LooseVersion
-from distutils.spawn import find_executable
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, wipe_all, fake_path, read_file, TestTags, tag_test
 from bytesize import bytesize
 import overrides_hack
@@ -261,7 +261,7 @@ class KbdBcacheNodevTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not find_executable("make-bcache"):
+        if not shutil.which("make-bcache"):
             raise unittest.SkipTest("make-bcache executable not found in $PATH, skipping.")
 
         if not BlockDev.is_initialized():
@@ -291,7 +291,7 @@ class KbdBcacheTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not find_executable("make-bcache"):
+        if not shutil.which("make-bcache"):
             raise unittest.SkipTest("make-bcache executable not found in $PATH, skipping.")
 
         if not BlockDev.is_initialized():

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import time
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 from itertools import chain
 
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, run_command, TestTags, tag_test
@@ -56,7 +56,7 @@ class LVMTestCase(unittest.TestCase):
         m = re.search(r"LVM version:\s+([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine LVM version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmNoDevTestCase(LVMTestCase):
@@ -1377,7 +1377,7 @@ class LvmPVVGcachedLVpoolTestCase(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.06"):
+        if lvm_version < Version("2.03.06"):
             cpool_name = "testCache"
         else:
             # since 2.03.06 LVM adds _cpool suffix to the cache pool after attaching it
@@ -1531,7 +1531,7 @@ class LVMVDOTest(LVMTestCase):
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         lvm_version = cls._get_lvm_version()
-        if lvm_version < LooseVersion("2.3.07"):
+        if lvm_version < Version("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")
 
         super().setUpClass()

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import time
 from contextlib import contextmanager
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command
 from gi.repository import BlockDev, GLib
@@ -50,7 +50,7 @@ class LVMTestCase(unittest.TestCase):
         m = re.search(r"LVM version:\s+([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine LVM version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
 
 class LvmNoDevTestCase(LVMTestCase):
@@ -1330,7 +1330,7 @@ class LvmPVVGcachedLVpoolTestCase(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         lvm_version = self._get_lvm_version()
-        if lvm_version < LooseVersion("2.03.06"):
+        if lvm_version < Version("2.03.06"):
             cpool_name = "testCache"
         else:
             # since 2.03.06 LVM adds _cpool suffix to the cache pool after attaching it
@@ -1491,7 +1491,7 @@ class LVMVDOTest(LVMTestCase):
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
         lvm_version = cls._get_lvm_version()
-        if lvm_version < LooseVersion("2.3.07"):
+        if lvm_version < Version("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")
 
         super().setUpClass()

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -5,7 +5,7 @@ import shutil
 import unittest
 import overrides_hack
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from utils import run_command, read_file, fake_path, TestTags, tag_test
 from gi.repository import BlockDev, GLib
@@ -43,7 +43,7 @@ class NVDIMMNamespaceTestCase(NVDIMMTestCase):
         m = re.search(r"([\d\.]+)", out)
         if not m or len(m.groups()) != 1:
             raise RuntimeError("Failed to determine ndctl version from: %s" % out)
-        return LooseVersion(m.groups()[0])
+        return Version(m.groups()[0])
 
     def setUp(self):
         self.sys_info = self._get_nvdimm_info()
@@ -165,7 +165,7 @@ class NVDIMMNamespaceTestCase(NVDIMMTestCase):
         # ndctl renamed the modes from 'memory' and 'dax' to 'fsdax' and 'devdax'
         # in version 60, so we need to choose different mode based on version
         ndctl_version = self._get_ndctl_version()
-        if ndctl_version >= LooseVersion("60.0"):
+        if ndctl_version >= Version("60.0"):
             mode = BlockDev.NVDIMMNamespaceMode.FSDAX
         else:
             mode = BlockDev.NVDIMMNamespaceMode.MEMORY

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import unittest
 import overrides_hack
 
@@ -8,7 +9,6 @@ from distutils.version import LooseVersion
 
 from utils import run_command, read_file, fake_path, TestTags, tag_test
 from gi.repository import BlockDev, GLib
-from distutils.spawn import find_executable
 
 
 class NVDIMMTestCase(unittest.TestCase):
@@ -17,7 +17,7 @@ class NVDIMMTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not find_executable("ndctl"):
+        if not shutil.which("ndctl"):
             raise unittest.SkipTest("ndctl executable not foundin $PATH, skipping.")
 
         if not BlockDev.is_initialized():

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -7,12 +7,12 @@ import datetime
 import os
 import re
 import six
+import shutil
 import subprocess
 import sys
 import unittest
 import yaml
 
-from distutils.spawn import find_executable
 
 LIBDIRS = 'src/utils/.libs:src/plugins/.libs:src/plugins/fs/.libs:src/lib/.libs'
 GIDIR = 'src/lib'
@@ -278,7 +278,7 @@ if __name__ == '__main__':
     result = unittest.TextTestRunner(verbosity=2, failfast=args.stop).run(suite)
 
     # dump cropped journal to log file
-    if find_executable('journalctl'):
+    if shutil.which('journalctl'):
         with open('journaldump.log', 'w') as outfile:
             subprocess.call(['journalctl', '-S', start_time], stdout=outfile)
 

--- a/tests/vdo_test.py
+++ b/tests/vdo_test.py
@@ -5,11 +5,11 @@ import yaml
 import unittest
 import overrides_hack
 import six
+import shutil
 
 from utils import run_command, read_file, fake_path, create_sparse_tempfile, create_lio_device, delete_lio_device, TestTags, tag_test
 from gi.repository import BlockDev, GLib
 from bytesize import bytesize
-from distutils.spawn import find_executable
 
 
 class VDOTestCase(unittest.TestCase):
@@ -29,7 +29,7 @@ class VDOTestCase(unittest.TestCase):
             if "File exists" not in e.message:
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")
 
-        if not find_executable("vdo"):
+        if not shutil.which("vdo"):
             raise unittest.SkipTest("vdo executable not foundin $PATH, skipping.")
 
         if not BlockDev.is_initialized():


### PR DESCRIPTION
Backport of #657, Fedora is already testing Python 3.12 builds.