### PR TITLE
spec: Obsolte the kbd and kbd-devel subpackages

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -120,6 +120,10 @@ BuildRequires: gtk-doc
 BuildRequires: glib2-doc
 BuildRequires: autoconf-archive
 
+# obsolete removed subpackages to allow upgrades
+Obsoletes: libblockdev-kbd
+Obsoletes: libblockdev-kbd-devel
+
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 
 %description


### PR DESCRIPTION
Without obsoleting the subpackages upgrading to the latest build won't work without "--best --allowerasing".