### PR TITLE
loop plugin API changes

### DIFF
--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -78,4 +78,13 @@
   </para>
 
   </simplesect>
+
+  <simplesect><title>Loop plugin</title>
+  <para>
+    <literal>bd_loop_setup</literal> and <literal>bd_loop_setup_from_fd</literal> has a new parameter <literal>sector_size</literal>.
+    Use <literal>0</literal> to preserve the original behaviour.
+  </para>
+
+  </simplesect>
+
 </chapter>

--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -85,6 +85,10 @@
     Use <literal>0</literal> to preserve the original behaviour.
   </para>
 
+  <para>
+    <literal>bd_loop_get_autoclear</literal> has been removed. Use <literal>bd_loop_info</literal> instead.
+  </para>
+
   </simplesect>
 
 </chapter>

--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -86,7 +86,7 @@
   </para>
 
   <para>
-    <literal>bd_loop_get_autoclear</literal> has been removed. Use <literal>bd_loop_info</literal> instead.
+    <literal>bd_loop_get_backing_file</literal> and <literal>bd_loop_get_autoclear</literal> have been removed. Use <literal>bd_loop_info</literal> instead.
   </para>
 
   </simplesect>

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -255,12 +255,13 @@ bd_loop_close
 bd_loop_error_quark
 BD_LOOP_ERROR
 BDLoopError
+BDLoopInfo
+bd_loop_info
 bd_loop_get_backing_file
 bd_loop_get_loop_name
 bd_loop_setup
 bd_loop_setup_from_fd
 bd_loop_teardown
-bd_loop_get_autoclear
 bd_loop_set_autoclear
 BDLoopTech
 BDLoopTechMode

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -257,7 +257,6 @@ BD_LOOP_ERROR
 BDLoopError
 BDLoopInfo
 bd_loop_info
-bd_loop_get_backing_file
 bd_loop_get_loop_name
 bd_loop_setup
 bd_loop_setup_from_fd

--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -64,6 +64,7 @@ gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
  * @size: maximum size of the device (or 0 to leave unspecified)
  * @read_only: whether to setup as read-only (%TRUE) or read-write (%FALSE)
  * @part_scan: whether to enforce partition scan on the newly created device or not
+ * @sector_size: logical sector size for the loop device in bytes (or 0 for default)
  * @loop_name: (optional) (out): if not %NULL, it is used to store the name of the loop device
  * @error: (out) (optional): place to store error (if any)
  *
@@ -71,7 +72,7 @@ gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
  *
  * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_CREATE
  */
-gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, guint64 sector_size, const gchar **loop_name, GError **error);
 
 /**
  * bd_loop_setup_from_fd:
@@ -80,6 +81,7 @@ gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolea
  * @size: maximum size of the device (or 0 to leave unspecified)
  * @read_only: whether to setup as read-only (%TRUE) or read-write (%FALSE)
  * @part_scan: whether to enforce partition scan on the newly created device or not
+ * @sector_size: logical sector size for the loop device in bytes (or 0 for default)
  * @loop_name: (optional) (out): if not %NULL, it is used to store the name of the loop device
  * @error: (out) (optional): place to store error (if any)
  *
@@ -87,7 +89,7 @@ gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolea
  *
  * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_CREATE
  */
-gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, guint64 sector_size, const gchar **loop_name, GError **error);
 
 /**
  * bd_loop_teardown:

--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -34,6 +34,75 @@ typedef enum {
  */
 gboolean bd_loop_is_tech_avail (BDLoopTech tech, guint64 mode, GError **error);
 
+#define BD_LOOP_TYPE_INFO (bd_loop_info_get_type ())
+GType bd_loop_info_get_type();
+
+/**
+ * BDLoopInfo:
+ * @backing_file: backing file for the give loop device;
+ * @offset: offset of the start of the device (in @backing_file);
+ * @autoclear: whether the autoclear flag is set or not;
+ * @direct_io: whether direct IO is enabled or not;
+ * @part_scan: whether the partition scan is enforced or not;
+ * @read_only: whether the device is read-only or not;
+ */
+typedef struct BDLoopInfo {
+    gchar *backing_file;
+    guint64 offset;
+    gboolean autoclear;
+    gboolean direct_io;
+    gboolean part_scan;
+    gboolean read_only;
+} BDLoopInfo;
+
+/**
+ * bd_loop_info_free: (skip)
+ * @info: (nullable): %BDLoopInfo to free
+ *
+ * Frees @info.
+ */
+void bd_loop_info_free (BDLoopInfo *info) {
+    if (info == NULL)
+        return;
+
+    g_free (info->backing_file);
+    g_free (info);
+}
+
+/**
+ * bd_loop_info_copy: (skip)
+ * @info: (nullable): %BDLoopInfo to copy
+ *
+ * Creates a new copy of @info.
+ */
+BDLoopInfo* bd_loop_info_copy (BDLoopInfo *info) {
+    if (info == NULL)
+        return NULL;
+
+    BDLoopInfo *new_info = g_new0 (BDLoopInfo, 1);
+
+    new_info->backing_file = g_strdup (info->backing_file);
+    new_info->offset = info->offset;
+    new_info->autoclear = info->autoclear;
+    new_info->direct_io = info->direct_io;
+    new_info->part_scan = info->part_scan;
+    new_info->read_only = info->read_only;
+
+    return new_info;
+}
+
+GType bd_loop_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDLoopInfo",
+                                            (GBoxedCopyFunc) bd_loop_info_copy,
+                                            (GBoxedFreeFunc) bd_loop_info_free);
+    }
+
+    return type;
+}
+
 /**
  * bd_loop_get_backing_file:
  * @dev_name: name of the loop device to get backing file for (e.g. "loop0")
@@ -45,6 +114,17 @@ gboolean bd_loop_is_tech_avail (BDLoopTech tech, guint64 mode, GError **error);
  * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
  */
 gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
+
+/**
+ * bd_loop_info:
+ * @loop: name of the loop device to get information about (e.g. "loop0")
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the @loop device or %NULL in case of error
+ *
+ * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
+ */
+BDLoopInfo* bd_loop_info (const gchar *loop, GError **error);
 
 /**
  * bd_loop_get_loop_name:
@@ -101,17 +181,6 @@ gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean 
  * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_DESTROY
  */
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
-
-/**
- * bd_loop_get_autoclear:
- * @loop: path or name of the loop device
- * @error: (out) (optional): place to store error (if any)
- *
- * Returns: whether the autoclear flag is set on the @loop device or not (if %FALSE, @error may be set)
- *
- * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
- */
-gboolean bd_loop_get_autoclear (const gchar *loop, GError **error);
 
 /**
  * bd_loop_set_autoclear:

--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -104,18 +104,6 @@ GType bd_loop_info_get_type () {
 }
 
 /**
- * bd_loop_get_backing_file:
- * @dev_name: name of the loop device to get backing file for (e.g. "loop0")
- * @error: (out) (optional): place to store error (if any)
- *
- * Returns: (transfer full): path of the device's backing file or %NULL if none
- *                           is found
- *
- * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
- */
-gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
-
-/**
  * bd_loop_info:
  * @loop: name of the loop device to get information about (e.g. "loop0")
  * @error: (out) (optional): place to store error (if any)

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -100,17 +100,31 @@ gboolean bd_loop_is_tech_avail (BDLoopTech tech UNUSED, guint64 mode UNUSED, GEr
     return TRUE;
 }
 
-/**
- * bd_loop_get_backing_file:
- * @dev_name: name of the loop device to get backing file for (e.g. "loop0")
- * @error: (out) (optional): place to store error (if any)
- *
- * Returns: (transfer full): path of the device's backing file or %NULL if none
- *                           is found
- *
- * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
- */
-gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error) {
+void bd_loop_info_free (BDLoopInfo *info) {
+    if (info == NULL)
+        return;
+
+    g_free (info->backing_file);
+    g_free (info);
+}
+
+BDLoopInfo* bd_loop_info_copy (BDLoopInfo *info) {
+    if (info == NULL)
+        return NULL;
+
+    BDLoopInfo *new_info = g_new0 (BDLoopInfo, 1);
+
+    new_info->backing_file = g_strdup (info->backing_file);
+    new_info->offset = info->offset;
+    new_info->autoclear = info->autoclear;
+    new_info->direct_io = info->direct_io;
+    new_info->part_scan = info->part_scan;
+    new_info->read_only = info->read_only;
+
+    return new_info;
+}
+
+static gchar* _loop_get_backing_file (const gchar *dev_name, GError **error) {
     gchar *sys_path = g_strdup_printf ("/sys/class/block/%s/loop/backing_file", dev_name);
     gchar *ret = NULL;
     gboolean success = FALSE;
@@ -129,6 +143,80 @@ gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error) {
 
     g_free (sys_path);
     return g_strstrip (ret);
+}
+
+/**
+ * bd_loop_get_backing_file:
+ * @dev_name: name of the loop device to get backing file for (e.g. "loop0")
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: (transfer full): path of the device's backing file or %NULL if none
+ *                           is found
+ *
+ * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
+ */
+gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error) {
+    return _loop_get_backing_file(dev_name, error);
+}
+
+/**
+ * bd_loop_info:
+ * @loop: name of the loop device to get information about (e.g. "loop0")
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the @loop device or %NULL in case of error
+ *
+ * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
+ */
+BDLoopInfo* bd_loop_info (const gchar *loop, GError **error) {
+    BDLoopInfo *info = NULL;
+    g_autofree gchar *dev_loop = NULL;
+    g_autofree gchar *sys_path = NULL;
+    gint fd = -1;
+    struct loop_info64 li64;
+    GError *l_error = NULL;
+
+    if (!g_str_has_prefix (loop, "/dev/"))
+        dev_loop = g_strdup_printf ("/dev/%s", loop);
+
+    fd = open (dev_loop ? dev_loop : loop, O_RDONLY);
+    if (fd < 0) {
+        g_set_error (error, BD_LOOP_ERROR, BD_LOOP_ERROR_DEVICE,
+                     "Failed to open device %s: %m", loop);
+        return NULL;
+    }
+
+    memset (&li64, 0, sizeof (li64));
+    if (ioctl (fd, LOOP_GET_STATUS64, &li64) < 0) {
+        g_set_error (error, BD_LOOP_ERROR, BD_LOOP_ERROR_FAIL,
+                     "Failed to get status of the device %s: %m", loop);
+        close (fd);
+        return NULL;
+    }
+
+    close (fd);
+
+    info = g_new0 (BDLoopInfo, 1);
+    info->offset = li64.lo_offset;
+    if ((li64.lo_flags & LO_FLAGS_AUTOCLEAR) != 0)
+        info->autoclear = TRUE;
+    if ((li64.lo_flags & LO_FLAGS_DIRECT_IO) != 0)
+        info->direct_io = TRUE;
+    if ((li64.lo_flags & LO_FLAGS_PARTSCAN) != 0)
+        info->part_scan = TRUE;
+    if ((li64.lo_flags & LO_FLAGS_READ_ONLY) != 0)
+        info->read_only = TRUE;
+
+    info->backing_file = _loop_get_backing_file (loop, &l_error);
+    if (l_error) {
+        bd_loop_info_free (info);
+        g_set_error (error, BD_LOOP_ERROR, BD_LOOP_ERROR_FAIL,
+                     "Failed to get backing file of the device %s: %s", loop, l_error->message);
+        g_clear_error (&l_error);
+        return NULL;
+    }
+
+    return info;
 }
 
 /**

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -146,20 +146,6 @@ static gchar* _loop_get_backing_file (const gchar *dev_name, GError **error) {
 }
 
 /**
- * bd_loop_get_backing_file:
- * @dev_name: name of the loop device to get backing file for (e.g. "loop0")
- * @error: (out) (optional): place to store error (if any)
- *
- * Returns: (transfer full): path of the device's backing file or %NULL if none
- *                           is found
- *
- * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
- */
-gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error) {
-    return _loop_get_backing_file(dev_name, error);
-}
-
-/**
  * bd_loop_info:
  * @loop: name of the loop device to get information about (e.g. "loop0")
  * @error: (out) (optional): place to store error (if any)

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -22,6 +22,28 @@ typedef enum {
     BD_LOOP_TECH_MODE_QUERY   = 1 << 3,
 } BDLoopTechMode;
 
+/**
+ * BDLoopInfo:
+ * @backing_file: backing file for the give loop device;
+ * @offset: offset of the start of the device (in @backing_file);
+ * @autoclear: whether the autoclear flag is set or not;
+ * @direct_io: whether direct IO is enabled or not;
+ * @part_scan: whether the partition scan is enforced or not;
+ * @read_only: whether the device is read-only or not;
+ */
+typedef struct BDLoopInfo {
+    gchar *backing_file;
+    guint64 offset;
+    gboolean autoclear;
+    gboolean direct_io;
+    gboolean part_scan;
+    gboolean read_only;
+} BDLoopInfo;
+
+
+void bd_loop_info_free (BDLoopInfo *info);
+BDLoopInfo* bd_loop_info_copy (BDLoopInfo *info);
+
 
 /*
  * If using the plugin as a standalone library, the following functions should
@@ -39,12 +61,13 @@ void bd_loop_close (void);
 gboolean bd_loop_is_tech_avail (BDLoopTech tech, guint64 mode, GError **error);
 
 gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
+BDLoopInfo* bd_loop_info (const gchar *loop, GError **error);
+
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, guint64 sector_size, const gchar **loop_name, GError **error);
 gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, guint64 sector_size, const gchar **loop_name, GError **error);
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
 
-gboolean bd_loop_get_autoclear (const gchar *loop, GError **error);
 gboolean bd_loop_set_autoclear (const gchar *loop, gboolean autoclear, GError **error);
 
 #endif  /* BD_LOOP */

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -60,7 +60,6 @@ void bd_loop_close (void);
 
 gboolean bd_loop_is_tech_avail (BDLoopTech tech, guint64 mode, GError **error);
 
-gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 BDLoopInfo* bd_loop_info (const gchar *loop, GError **error);
 
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -40,8 +40,8 @@ gboolean bd_loop_is_tech_avail (BDLoopTech tech, guint64 mode, GError **error);
 
 gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
-gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
-gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, guint64 sector_size, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, guint64 sector_size, const gchar **loop_name, GError **error);
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
 
 gboolean bd_loop_get_autoclear (const gchar *loop, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -370,8 +370,8 @@ __all__.append("dm_get_member_raid_sets")
 
 _loop_setup = BlockDev.loop_setup
 @override(BlockDev.loop_setup)
-def loop_setup(file, offset=0, size=0, read_only=False, part_scan=True):
-    return _loop_setup(file, offset, size, read_only, part_scan)
+def loop_setup(file, offset=0, size=0, read_only=False, part_scan=True, sector_size=0):
+    return _loop_setup(file, offset, size, read_only, part_scan, sector_size)
 __all__.append("loop_setup")
 
 

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -1081,6 +1081,16 @@ def plugin_specs_from_names(plugin_names):
 __all__.append("plugin_specs_from_names")
 
 
+## for backward compatibility only, remove before 3.0 release
+def loop_get_backing_file(dev_name):
+    try:
+        info = BlockDev.loop_info(dev_name)
+    except Exception as e:
+        return None
+    return info.backing_file
+__all__.append("loop_get_backing_file")
+
+
 XRule = namedtuple("XRule", ["orig_exc", "regexp", "code", "new_exc"])
 # XXX: how to document namedtuple fields?
 """

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -1123,9 +1123,10 @@ class CryptoTestLuksSectorSize(CryptoTestCase):
         self.dev_file2 = create_sparse_tempfile("crypto_test", 1024**3)
 
         # create a 4k sector loop device
-        ret, out, err = run_command("losetup -f %s --show --sector-size 4096" % self.dev_file)
-        self.assertEqual(ret, 0, "Failed to setup loop device for testing: %s" % err)
-        self.loop_dev = out.strip()
+        succ, loop = BlockDev.loop_setup(self.dev_file, sector_size=4096)
+        if not succ:
+            raise RuntimeError("Failed to setup loop device for testing")
+        self.loop_dev = "/dev/%s" % loop
 
         succ, loop = BlockDev.loop_setup(self.dev_file2)
         if not succ:

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -107,7 +107,30 @@ class LoopTestSetupSectorSize(LoopTestCase):
         with open("/sys/block/%s/queue/logical_block_size" % self.loop, "r") as f:
             self.assertEqual(f.read().strip(), "4096")
 
-# XXX: any sane way how to test part_probe=True/False?
+class LoopTestSetupPartprobe(LoopTestCase):
+    def testLoop_setup_partprobe(self):
+        """Verify that loop_setup with part_scan specified works as expected"""
+        # part scan on
+        succ, self.loop = BlockDev.loop_setup(self.dev_file, part_scan=True)
+        self.assertTrue(succ)
+        self.assertTrue(self.loop)
+
+        with open("/sys/block/%s/loop/partscan" % self.loop, "r") as f:
+            self.assertEqual(f.read().strip(), "1")
+
+        succ = BlockDev.loop_teardown(self.loop)
+        self.assertTrue(succ)
+
+        # part scan off
+        succ, self.loop = BlockDev.loop_setup(self.dev_file, part_scan=False)
+        self.assertTrue(succ)
+        self.assertTrue(self.loop)
+
+        with open("/sys/block/%s/loop/partscan" % self.loop, "r") as f:
+            self.assertEqual(f.read().strip(), "0")
+
+        succ = BlockDev.loop_teardown(self.loop)
+        self.assertTrue(succ)
 
 class LoopTestGetLoopName(LoopTestCase):
     @tag_test(TestTags.CORE)

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -30,9 +30,10 @@ class LoopTestCase(unittest.TestCase):
             pass
         os.unlink(self.dev_file)
 
+
 class LoopTestSetupBasic(LoopTestCase):
     @tag_test(TestTags.CORE)
-    def testLoop_setup_teardown_basic(self):
+    def test_loop_setup_teardown_basic(self):
         """Verify that basic loop_setup and loop_teardown work as expected"""
 
         succ, self.loop = BlockDev.loop_setup(self.dev_file)
@@ -48,8 +49,9 @@ class LoopTestSetupBasic(LoopTestCase):
         b_file = BlockDev.loop_get_backing_file(self.loop)
         self.assertIsNone(b_file)
 
+
 class LoopTestSetupOffset(LoopTestCase):
-    def testLoop_setup_with_offset(self):
+    def test_loop_setup_with_offset(self):
         """Verify that loop_setup with offset specified works as expected"""
 
         # now test with the offset
@@ -67,7 +69,7 @@ class LoopTestSetupOffset(LoopTestCase):
 
 
 class LoopTestSetupOffsetSize(LoopTestCase):
-    def testLoop_setup_with_offset_and_size(self):
+    def test_loop_setup_with_offset_and_size(self):
         """Verify that loop_setup with offset and size specified works as expected"""
 
         # now test with the offset and size
@@ -83,8 +85,9 @@ class LoopTestSetupOffsetSize(LoopTestCase):
         succ = BlockDev.loop_teardown(self.loop)
         self.assertTrue(succ)
 
+
 class LoopTestSetupReadOnly(LoopTestCase):
-    def testLoop_setup_read_only(self):
+    def test_loop_setup_read_only(self):
         """Verify that loop_setup with read_only specified works as expected"""
         # test read-only
         succ, self.loop = BlockDev.loop_setup(self.dev_file, 0, 0, True)
@@ -95,8 +98,9 @@ class LoopTestSetupReadOnly(LoopTestCase):
         with open("/sys/block/%s/ro" % self.loop, "r") as f:
             self.assertEqual(f.read().strip(), "1")
 
+
 class LoopTestSetupSectorSize(LoopTestCase):
-    def testLoop_setup_sector_size(self):
+    def test_loop_setup_sector_size(self):
         """Verify that loop_setup with sector_size specified works as expected"""
         # test 4k sector size
         succ, self.loop = BlockDev.loop_setup(self.dev_file, sector_size=4096)
@@ -107,8 +111,9 @@ class LoopTestSetupSectorSize(LoopTestCase):
         with open("/sys/block/%s/queue/logical_block_size" % self.loop, "r") as f:
             self.assertEqual(f.read().strip(), "4096")
 
+
 class LoopTestSetupPartprobe(LoopTestCase):
-    def testLoop_setup_partprobe(self):
+    def test_loop_setup_partprobe(self):
         """Verify that loop_setup with part_scan specified works as expected"""
         # part scan on
         succ, self.loop = BlockDev.loop_setup(self.dev_file, part_scan=True)
@@ -132,30 +137,39 @@ class LoopTestSetupPartprobe(LoopTestCase):
         succ = BlockDev.loop_teardown(self.loop)
         self.assertTrue(succ)
 
+
 class LoopTestGetLoopName(LoopTestCase):
     @tag_test(TestTags.CORE)
-    def testLoop_get_loop_name(self):
+    def test_loop_get_loop_name(self):
         """Verify that loop_get_loop_name works as expected"""
 
         self.assertIs(BlockDev.loop_get_loop_name("/non/existing"), None)
 
         succ, self.loop = BlockDev.loop_setup(self.dev_file)
+        self.assertTrue(succ)
+        self.assertTrue(self.loop)
+
         ret_loop = BlockDev.loop_get_loop_name(self.dev_file)
         self.assertEqual(ret_loop, self.loop)
 
+
 class LoopTestGetBackingFile(LoopTestCase):
     @tag_test(TestTags.CORE)
-    def testLoop_get_backing_file(self):
+    def test_loop_get_backing_file(self):
         """Verify that loop_get_backing_file works as expected"""
 
         self.assertIs(BlockDev.loop_get_backing_file("/non/existing"), None)
 
         succ, self.loop = BlockDev.loop_setup(self.dev_file)
+        self.assertTrue(succ)
+        self.assertTrue(self.loop)
+
         f_name = BlockDev.loop_get_backing_file(self.loop)
         self.assertEqual(f_name, self.dev_file)
 
+
 class LoopTestGetSetAutoclear(LoopTestCase):
-    def testLoop_get_set_autoclear(self):
+    def test_loop_get_set_autoclear(self):
         """Verify that getting and setting the autoclear flag works as expected"""
 
         with self.assertRaises(GLib.Error):
@@ -165,6 +179,9 @@ class LoopTestGetSetAutoclear(LoopTestCase):
             BlockDev.loop_set_autoclear("/non/existing", True)
 
         succ, self.loop = BlockDev.loop_setup(self.dev_file)
+        self.assertTrue(succ)
+        self.assertTrue(self.loop)
+
         self.assertFalse(BlockDev.loop_get_autoclear(self.loop))
 
         # open the loop device so that it doesn't disappear once we set

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -172,21 +172,6 @@ class LoopTestGetLoopName(LoopTestCase):
         self.assertEqual(ret_loop, self.loop)
 
 
-class LoopTestGetBackingFile(LoopTestCase):
-    @tag_test(TestTags.CORE)
-    def test_loop_get_backing_file(self):
-        """Verify that loop_get_backing_file works as expected"""
-
-        self.assertIs(BlockDev.loop_get_backing_file("/non/existing"), None)
-
-        succ, self.loop = BlockDev.loop_setup(self.dev_file)
-        self.assertTrue(succ)
-        self.assertTrue(self.loop)
-
-        f_name = BlockDev.loop_get_backing_file(self.loop)
-        self.assertEqual(f_name, self.dev_file)
-
-
 class LoopTestGetSetAutoclear(LoopTestCase):
     def test_loop_get_set_autoclear(self):
         """Verify that getting and setting the autoclear flag works as expected"""

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -95,6 +95,18 @@ class LoopTestSetupReadOnly(LoopTestCase):
         with open("/sys/block/%s/ro" % self.loop, "r") as f:
             self.assertEqual(f.read().strip(), "1")
 
+class LoopTestSetupSectorSize(LoopTestCase):
+    def testLoop_setup_sector_size(self):
+        """Verify that loop_setup with sector_size specified works as expected"""
+        # test 4k sector size
+        succ, self.loop = BlockDev.loop_setup(self.dev_file, sector_size=4096)
+        self.assertTrue(succ)
+        self.assertTrue(self.loop)
+
+        # logical_block_size should be 4096
+        with open("/sys/block/%s/queue/logical_block_size" % self.loop, "r") as f:
+            self.assertEqual(f.read().strip(), "4096")
+
 # XXX: any sane way how to test part_probe=True/False?
 
 class LoopTestGetLoopName(LoopTestCase):


### PR DESCRIPTION
New argument for `bd_loop_setup` and a new function to get information about loop devices. UDisks needs to be adjusted to the new API before merging this.

Fixes: #685 