### PR TITLE
Drop skip_patterns from configure.ac and plugin_apis/Makefile.am

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,8 +56,6 @@ case $host_cpu in
   *) on_s390=no ;;
 esac
 
-skip_patterns=""
-
 AC_ARG_WITH([s390],
     AS_HELP_STRING([--with-s390], [support s390 @<:@default=check@:>@]),
     [],
@@ -260,7 +258,6 @@ AS_IF([test "x$with_nvme" != "xno"],
       ],
       [])
 
-AC_SUBST([skip_patterns], [$skip_patterns])
 AC_SUBST([MAJOR_VER], [\"2\"])
 
 CFLAGS="$CFLAGS -std=gnu99"

--- a/src/lib/plugin_apis/Makefile.am
+++ b/src/lib/plugin_apis/Makefile.am
@@ -5,7 +5,7 @@ HEADER_FILES := $(patsubst %.api,%.h,${API_FILES})
 all-local: generate_boilerplate
 
 %.c %.h: %.api ${srcdir}/../../../scripts/boilerplate_generator.py
-	${PYTHON} ${srcdir}/../../../scripts/boilerplate_generator.py $*.api ./ ${skip_patterns}
+	${PYTHON} ${srcdir}/../../../scripts/boilerplate_generator.py $*.api ./
 
 generate_boilerplate: ${SOURCE_FILES} ${HEADER_FILES}
 


### PR DESCRIPTION
It's no longer used.