### PR TITLE
nvme: Fix namespace identifiers

### DIFF
--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -74,7 +74,7 @@ class NVMeTestCase(NVMeTest):
         self.assertTrue (info.features & BlockDev.NVMENamespaceFeature.MULTIPATH_SHARED)
         self.assertFalse(info.features & BlockDev.NVMENamespaceFeature.FORMAT_PROGRESS)
         self.assertFalse(info.features & BlockDev.NVMENamespaceFeature.ROTATIONAL)
-        self.assertEqual(info.eui64, "0000000000000000")
+        self.assertIsNone(info.eui64)
         self.assertEqual(info.format_progress_remaining, 0)
         self.assertEqual(len(info.lba_formats), 1)
         self.assertGreater(len(info.nguid), 0)


### PR DESCRIPTION
Use Namespace Identification Descriptor list (CNS 03h) data when available and NVM Command Set Identify Namespace Data Structure (CNS 00h) as a fallback.

Also, if the CNS 00h EUI64 or NGUID fields equal to zero, return NULL instead of zeroes:
  "If the controller is not able to provide a ... identifier in this field,
   then this field shall be cleared to 0h."