### PR TITLE
btrfs: Fix parsing snapshot info without valid otime

### DIFF
--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -691,7 +691,7 @@ BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboole
     gchar **line_p = NULL;
     gchar const * const pattern = "ID\\s+(?P<id>\\d+)\\s+gen\\s+\\d+\\s+(cgen\\s+\\d+\\s+)?" \
                                   "parent\\s+(?P<parent_id>\\d+)\\s+top\\s+level\\s+\\d+\\s+" \
-                                  "(otime\\s+\\d{4}-\\d{2}-\\d{2}\\s+\\d\\d:\\d\\d:\\d\\d\\s+)?"\
+                                  "(otime\\s+(\\d{4}-\\d{2}-\\d{2}\\s+\\d\\d:\\d\\d:\\d\\d|-)\\s+)?"\
                                   "path\\s+(?P<path>\\S+)";
     GRegex *regex = NULL;
     GMatchInfo *match_info = NULL;


### PR DESCRIPTION
With latest btrfs-progs the "otime" value for snapshots can be empty so we need to adjust our regex for parsing the subvolume information.

With btrfs 6.1:
ID 256 ...level 5 otime - path snap1

With btrfs 5.18:
ID 256 ... level 5 otime 2023-01-04 14:11:41 path snap1