### PR TITLE
Backport exFAT support on top of 2.28 

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -592,6 +592,15 @@ bd_fs_ntfs_repair
 bd_fs_ntfs_resize
 bd_fs_ntfs_set_label
 bd_fs_ntfs_wipe
+BDFSExfatInfo
+bd_fs_exfat_check
+bd_fs_exfat_get_info
+bd_fs_exfat_info_copy
+bd_fs_exfat_info_free
+bd_fs_exfat_mkfs
+bd_fs_exfat_repair
+bd_fs_exfat_set_label
+bd_fs_exfat_wipe
 </SECTION>
 
 <SECTION>

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -343,7 +343,8 @@ typedef enum {
     BD_FS_TECH_EXT4,
     BD_FS_TECH_XFS,
     BD_FS_TECH_VFAT,
-    BD_FS_TECH_NTFS
+    BD_FS_TECH_NTFS,
+    BD_FS_TECH_EXFAT,
 } BDFSTech;
 
 typedef enum {
@@ -355,6 +356,76 @@ typedef enum {
     BD_FS_TECH_MODE_QUERY     = 1 << 5,
     BD_FS_TECH_MODE_RESIZE    = 1 << 6,
 } BDFSTechMode;
+
+#define BD_FS_TYPE_EXFAT_INFO (bd_fs_exfat_info_get_type ())
+GType bd_fs_exfat_info_get_type();
+
+/**
+ * BDFSExfatInfo:
+ * @label: label of the filesystem
+ * @uuid: uuid of the filesystem
+ * @sector_size: sector size used by the filesystem
+ * @cluster_size: cluster size used by the filesystem
+ * @sector_count: number of sectors in the filesystem
+ * @free_sectors: number of free sectors in the filesystem
+ * @cluster_count: number of clusters in the filesystem
+ * @free_clusters: number of free clusters in the filesystem
+ */
+typedef struct BDFSExfatInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 sector_size;
+    guint64 sector_count;
+    guint64 cluster_count;
+} BDFSExfatInfo;
+
+/**
+ * bd_fs_exfat_info_free: (skip)
+ * @data: (allow-none): %BDFSExfatInfo to free
+ *
+ * Frees @data.
+ */
+void bd_fs_exfat_info_free (BDFSExfatInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+/**
+ * bd_fs_exfat_info_copy: (skip)
+ * @data: (allow-none): %BDFSExfatInfo to copy
+ *
+ * Creates a new copy of @data.
+ */
+BDFSExfatInfo* bd_fs_exfat_info_copy (BDFSExfatInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSExfatInfo *ret = g_new0 (BDFSExfatInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->sector_size = data->sector_size;
+    ret->sector_count = data->sector_count;
+    ret->cluster_count = data->cluster_count;
+
+    return ret;
+}
+
+GType bd_fs_exfat_info_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDFSExfatInfo",
+                                            (GBoxedCopyFunc) bd_fs_exfat_info_copy,
+                                            (GBoxedFreeFunc) bd_fs_exfat_info_free);
+    }
+
+    return type;
+}
 
 /**
  * bd_fs_is_tech_avail:
@@ -1205,5 +1276,81 @@ gboolean bd_fs_ntfs_resize (const gchar *device, guint64 new_size, GError **erro
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_QUERY
  */
 BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error);
+
+/**
+ * bd_fs_exfat_mkfs:
+ * @device: the device to create a new exfat fs on
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
+ *                                                 passed to the 'mkexfatfs' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a new exfat fs was successfully created on @device or not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_MKFS
+ */
+gboolean bd_fs_exfat_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_exfat_wipe:
+ * @device: the device to wipe a exfat signature from
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the exfat signature was successfully wiped from the @device or
+ *          not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_exfat_wipe (const gchar *device, GError **error);
+
+/**
+ * bd_fs_exfat_check:
+ * @device: the device containing the file system to check
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the repair (right now
+ *                                                 passed to the 'exfatfsck' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the exfat file system on the @device is clean or not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_CHECK
+ */
+gboolean bd_fs_exfat_check (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_exfat_repair:
+ * @device: the device containing the file system to repair
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the repair (right now
+ *                                                 passed to the 'exfatfsck' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the exfat file system on the @device was successfully repaired
+ *          (if needed) or not (error is set in that case)
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_REPAIR
+ */
+gboolean bd_fs_exfat_repair (const gchar *device, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_fs_exfat_set_label:
+ * @device: the device containing the file system to set label for
+ * @label: label to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the label of exfat file system on the @device was
+ *          successfully set or not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_SET_LABEL
+ */
+gboolean bd_fs_exfat_set_label (const gchar *device, const gchar *label, GError **error);
+
+/**
+ * bd_fs_exfat_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the file system on @device or
+ *                           %NULL in case of error
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSExfatInfo* bd_fs_exfat_get_info (const gchar *device, GError **error);
 
 #endif  /* BD_FS_API */

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -38,6 +38,7 @@ extern gboolean bd_fs_ext_is_tech_avail (BDFSTech tech, guint64 mode, GError **e
 extern gboolean bd_fs_xfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_vfat_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 extern gboolean bd_fs_ntfs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
+extern gboolean bd_fs_exfat_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 
 /**
  * bd_fs_error_quark: (skip)
@@ -82,6 +83,17 @@ gboolean bd_fs_check_deps (void) {
         g_warning ("%s", error->message);
         g_clear_error (&error);
     }
+
+    ret = ret && bd_fs_exfat_is_tech_avail (BD_FS_TECH_EXFAT,
+                                            BD_FS_TECH_MODE_MKFS | BD_FS_TECH_MODE_WIPE |
+                                            BD_FS_TECH_MODE_CHECK | BD_FS_TECH_MODE_REPAIR |
+                                            BD_FS_TECH_MODE_SET_LABEL | BD_FS_TECH_MODE_QUERY,
+                                            &error);
+    if (!ret && error) {
+        g_warning ("%s", error->message);
+        g_clear_error (&error);
+    }
+
     return ret;
 }
 
@@ -139,6 +151,8 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error) {
             return bd_fs_vfat_is_tech_avail (tech, mode, error);
         case BD_FS_TECH_NTFS:
             return bd_fs_ntfs_is_tech_avail (tech, mode, error);
+        case BD_FS_TECH_EXFAT:
+            return bd_fs_exfat_is_tech_avail (tech, mode, error);
         /* coverity[dead_error_begin] */
         default:
             /* this should never be reached (see the comparison with LAST_FS

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -21,7 +21,7 @@ typedef enum {
 
 /* XXX: where the file systems start at the enum of technologies */
 #define BD_FS_OFFSET 2
-#define BD_FS_LAST_FS 7
+#define BD_FS_LAST_FS 8
 typedef enum {
     BD_FS_TECH_GENERIC = 0,
     BD_FS_TECH_MOUNT   = 1,
@@ -31,6 +31,7 @@ typedef enum {
     BD_FS_TECH_XFS     = 5,
     BD_FS_TECH_VFAT    = 6,
     BD_FS_TECH_NTFS    = 7,
+    BD_FS_TECH_EXFAT   = 8
 } BDFSTech;
 
 /* XXX: number of the highest bit of all modes */
@@ -69,3 +70,4 @@ gboolean bd_fs_is_tech_avail (BDFSTech tech, guint64 mode, GError **error);
 #include "fs/ntfs.h"
 #include "fs/vfat.h"
 #include "fs/xfs.h"
+#include "fs/exfat.h"

--- a/src/plugins/fs/Makefile.am
+++ b/src/plugins/fs/Makefile.am
@@ -14,7 +14,8 @@ libbd_fs_la_SOURCES  = ../check_deps.c ../check_deps.h \
 						mount.c   mount.h   \
 						ntfs.c    ntfs.h    \
 						vfat.c    vfat.h    \
-						xfs.c     xfs.h
+						xfs.c     xfs.h     \
+						exfat.c   exfat.h
 
 libincludefsdir = $(includedir)/blockdev/fs/
 libincludefs_HEADERS = ext.h     \
@@ -22,4 +23,5 @@ libincludefs_HEADERS = ext.h     \
 					mount.h   \
 					ntfs.h    \
 					vfat.h    \
-					xfs.h
+					xfs.h     \
+					exfat.h

--- a/src/plugins/fs/exfat.c
+++ b/src/plugins/fs/exfat.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright (C) 2020  Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vojtech Trefny <vtrefny@redhat.com>
+ */
+
+#include <blockdev/utils.h>
+#include <check_deps.h>
+
+#include "exfat.h"
+#include "fs.h"
+#include "common.h"
+
+static volatile guint avail_deps = 0;
+static GMutex deps_check_lock;
+
+#define DEPS_MKEXFAT 0
+#define DEPS_MKEXFAT_MASK (1 << DEPS_MKEXFAT)
+#define DEPS_FSCKEXFAT 1
+#define DEPS_FSCKEXFAT_MASK (1 << DEPS_FSCKEXFAT)
+#define DEPS_TUNEEXFAT 2
+#define DEPS_TUNEEXFAT_MASK (1 <<  DEPS_TUNEEXFAT)
+
+#define DEPS_LAST 5
+
+static const UtilDep deps[DEPS_LAST] = {
+    {"mkfs.exfat", NULL, NULL, NULL},
+    {"fsck.exfat", NULL, NULL, NULL},
+    {"tune.exfat", NULL, NULL, NULL},
+    {"tune.exfat", NULL, NULL, NULL},
+};
+
+static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
+    DEPS_MKEXFAT_MASK,      /* mkfs */
+    0,                      /* wipe */
+    DEPS_FSCKEXFAT_MASK,    /* check */
+    DEPS_FSCKEXFAT_MASK,    /* repair */
+    DEPS_TUNEEXFAT_MASK,    /* set-label */
+    DEPS_TUNEEXFAT_MASK,    /* query */
+    0,                      /* resize */
+};
+
+#define UNUSED __attribute__((unused))
+
+/**
+ * bd_fs_exfat_is_tech_avail:
+ * @tech: the queried tech
+ * @mode: a bit mask of queried modes of operation (#BDFSTechMode) for @tech
+ * @error: (out): place to store error (details about why the @tech-@mode combination is not available)
+ *
+ * Returns: whether the @tech-@mode combination is available -- supported by the
+ *          plugin implementation and having all the runtime dependencies available
+ */
+gboolean __attribute__ ((visibility ("hidden")))
+bd_fs_exfat_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+    guint32 required = 0;
+    guint i = 0;
+
+    if (mode & BD_FS_TECH_MODE_RESIZE) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_TECH_UNAVAIL,
+                     "exFAT currently doesn't support resizing.");
+        return FALSE;
+    }
+
+    for (i = 0; i <= BD_FS_MODE_LAST; i++)
+        if (mode & (1 << i))
+            required |= fs_mode_util[i];
+
+    return check_deps (&avail_deps, required, deps, DEPS_LAST, &deps_check_lock, error);
+}
+
+/**
+ * bd_fs_exfat_info_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDFSExfatInfo* bd_fs_exfat_info_copy (BDFSExfatInfo *data) {
+    if (data == NULL)
+        return NULL;
+
+    BDFSExfatInfo *ret = g_new0 (BDFSExfatInfo, 1);
+
+    ret->label = g_strdup (data->label);
+    ret->uuid = g_strdup (data->uuid);
+    ret->sector_size = data->sector_size;
+    ret->sector_count = data->sector_count;
+    ret->cluster_count = data->cluster_count;
+
+    return ret;
+}
+
+/**
+ * bd_fs_exfat_info_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_fs_exfat_info_free (BDFSExfatInfo *data) {
+    if (data == NULL)
+        return;
+
+    g_free (data->label);
+    g_free (data->uuid);
+    g_free (data);
+}
+
+/**
+ * bd_fs_exfat_mkfs:
+ * @device: the device to create a new exfat fs on
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
+ *                                                 passed to the 'mkfs.exfat' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a new exfat fs was successfully created on @device or not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_MKFS
+ */
+gboolean bd_fs_exfat_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[3] = {"mkfs.exfat", device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_MKEXFAT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (args, extra, error);
+}
+
+/**
+ * bd_fs_exfat_wipe:
+ * @device: the device to wipe a exfat signature from
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the exfat signature was successfully wiped from the @device or
+ *          not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_WIPE
+ */
+gboolean bd_fs_exfat_wipe (const gchar *device, GError **error) {
+    return wipe_fs (device, "exfat", FALSE, error);
+}
+
+/**
+ * bd_fs_exfat_check:
+ * @device: the device containing the file system to check
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the repair (right now
+ *                                                 passed to the 'fsck.exfat' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the exfat file system on the @device is clean or not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_CHECK
+ */
+gboolean bd_fs_exfat_check (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[4] = {"fsck.exfat", "-n", device, NULL};
+    gint status = 0;
+    gboolean ret = FALSE;
+
+    if (!check_deps (&avail_deps, DEPS_FSCKEXFAT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    ret = bd_utils_exec_and_report_status_error (args, extra, &status, error);
+    if (!ret && (status == 1)) {
+        /* no error should be reported for exit code 1 */
+        g_clear_error (error);
+    }
+    return ret;
+}
+
+/**
+ * bd_fs_exfat_repair:
+ * @device: the device containing the file system to repair
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the repair (right now
+ *                                                 passed to the 'fsck.exfat' utility)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the exfat file system on the @device was successfully repaired
+ *          (if needed) or not (error is set in that case)
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_REPAIR
+ */
+gboolean bd_fs_exfat_repair (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[4] = {"fsck.exfat", "-y", device, NULL};
+    gint status = 0;
+    gboolean ret = FALSE;
+
+    if (!check_deps (&avail_deps, DEPS_FSCKEXFAT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    ret = bd_utils_exec_and_report_status_error (args, extra, &status, error);
+    if (!ret && (status == 1)) {
+        /* no error should be reported for exit code 1 */
+        g_clear_error (error);
+        ret = TRUE;
+    }
+
+    return ret;
+}
+
+/**
+ * bd_fs_exfat_set_label:
+ * @device: the device containing the file system to set label for
+ * @label: label to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the label of exfat file system on the @device was
+ *          successfully set or not
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_SET_LABEL
+ */
+gboolean bd_fs_exfat_set_label (const gchar *device, const gchar *label, GError **error) {
+    const gchar *args[5] = {"tune.exfat", "-L", label, device, NULL};
+
+    if (!check_deps (&avail_deps, DEPS_TUNEEXFAT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return FALSE;
+
+    return bd_utils_exec_and_report_error (args, NULL, error);
+}
+
+/**
+ * bd_fs_exfat_get_info:
+ * @device: the device containing the file system to get info for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): information about the file system on @device or
+ *                           %NULL in case of error
+ *
+ * Tech category: %BD_FS_TECH_EXFAT-%BD_FS_TECH_MODE_QUERY
+ */
+BDFSExfatInfo* bd_fs_exfat_get_info (const gchar *device, GError **error) {
+    const gchar *args[4] = {"tune.exfat", "-v", device, NULL};
+    gboolean success = FALSE;
+    gchar *output = NULL;
+    BDFSExfatInfo *ret = NULL;
+    gchar **lines = NULL;
+    gchar **line_p = NULL;
+    gboolean have_ss = FALSE;
+    gboolean have_sc = FALSE;
+    gboolean have_cc = FALSE;
+    gchar *val_start = NULL;
+
+    if (!check_deps (&avail_deps, DEPS_TUNEEXFAT_MASK, deps, DEPS_LAST, &deps_check_lock, error))
+        return NULL;
+
+    ret = g_new0 (BDFSExfatInfo, 1);
+
+    success = get_uuid_label (device, &(ret->uuid), &(ret->label), error);
+    if (!success) {
+        /* error is already populated */
+        bd_fs_exfat_info_free (ret);
+        return NULL;
+    }
+
+    success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
+    if (!success) {
+        /* error is already populated */
+        bd_fs_exfat_info_free (ret);
+        return NULL;
+    }
+
+    lines = g_strsplit (output, "\n", 0);
+    g_free (output);
+
+    for (line_p=lines; *line_p; line_p++) {
+        if (!have_ss) {
+            val_start = g_strrstr (*line_p, "Block sector size : ");
+            if (val_start) {
+                ret->sector_size = g_ascii_strtoull (val_start + 20, NULL, 0);
+                have_ss = TRUE;
+            }
+        }
+
+        if (!have_sc) {
+            val_start = g_strrstr (*line_p, "Number of the sectors : ");
+            if (val_start) {
+                ret->sector_count = g_ascii_strtoull (val_start + 24, NULL, 0);
+                have_sc = TRUE;
+            }
+        }
+
+        if (!have_cc) {
+            val_start = g_strrstr (*line_p, "Number of the clusters : ");
+            if (val_start) {
+                ret->cluster_count = g_ascii_strtoull (val_start + 25, NULL, 0);
+                have_cc = TRUE;
+            }
+        }
+
+        if (have_ss && have_sc && have_cc)
+            break;
+    }
+    g_strfreev (lines);
+
+    if (!have_ss || !have_sc || !have_cc) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
+                     "Failed to to parse exFAT info.");
+        bd_fs_exfat_info_free (ret);
+        return NULL;
+    }
+
+    return ret;
+}

--- a/src/plugins/fs/exfat.h
+++ b/src/plugins/fs/exfat.h
@@ -1,0 +1,25 @@
+#include <glib.h>
+#include <blockdev/utils.h>
+
+#ifndef BD_FS_EXFAT
+#define BD_FS_EXFAT
+
+typedef struct BDFSExfatInfo {
+    gchar *label;
+    gchar *uuid;
+    guint64 sector_size;
+    guint64 sector_count;
+    guint64 cluster_count;
+} BDFSExfatInfo;
+
+BDFSExfatInfo* bd_fs_exfat_info_copy (BDFSExfatInfo *data);
+void bd_fs_exfat_info_free (BDFSExfatInfo *data);
+
+gboolean bd_fs_exfat_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_exfat_wipe (const gchar *device, GError **error);
+gboolean bd_fs_exfat_check (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_exfat_repair (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_exfat_set_label (const gchar *device, const gchar *label, GError **error);
+BDFSExfatInfo* bd_fs_exfat_get_info (const gchar *device, GError **error);
+
+#endif  /* BD_FS_EXFAT */

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -69,6 +69,7 @@ const BDFSInfo fs_info[] = {
     {"ext4", "e2fsck", "e2fsck", "resize2fs", BD_FS_ONLINE_GROW | BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK, "tune2fs"},
     {"vfat", "fsck.vfat", "fsck.vfat", "", BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK, "fatlabel"},
     {"ntfs", "ntfsfix", "ntfsfix", "ntfsresize", BD_FS_OFFLINE_GROW | BD_FS_OFFLINE_SHRINK, "ntfslabel"},
+    {"exfat", "fsck.exfat", "fsck.exfat", NULL, 0, "exfatlabel"},
     {NULL, NULL, NULL, NULL, 0, NULL}
 };
 
@@ -513,6 +514,19 @@ static gboolean device_operation (const gchar *device, BDFsOpType op, guint64 ne
                 return bd_fs_ntfs_check (device, error);
             case BD_FS_LABEL:
                 return bd_fs_ntfs_set_label (device, label, error);
+        }
+    } else if (g_strcmp0 (fstype, "exfat") == 0) {
+        switch (op) {
+            case BD_FS_RESIZE:
+                break;
+            case BD_FS_REPAIR:
+                return bd_fs_exfat_repair (device, NULL, error);
+            case BD_FS_CHECK:
+                return bd_fs_exfat_check (device, NULL, error);
+            case BD_FS_LABEL:
+                return bd_fs_exfat_set_label (device, label, error);
+            default:
+                g_assert_not_reached ();
         }
     }
     switch (op) {

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -76,6 +76,15 @@ class FSTestCase(unittest.TestCase):
         except:
             cls.ntfs_avail = False
 
+        try:
+            cls.exfat_avail = BlockDev.fs_is_tech_avail(BlockDev.FSTech.EXFAT,
+                                                        BlockDev.FSTechMode.MKFS |
+                                                        BlockDev.FSTechMode.REPAIR |
+                                                        BlockDev.FSTechMode.CHECK |
+                                                        BlockDev.FSTechMode.SET_LABEL)
+        except Exception :
+            cls.exfat_avail = False
+
     def setUp(self):
         self.addCleanup(self._clean_up)
         self.dev_file = utils.create_sparse_tempfile("fs_test", self._loop_size)
@@ -948,6 +957,141 @@ class VfatResize(FSTestCase):
         succ = BlockDev.fs_vfat_resize(self.loop_dev, 0)
         self.assertTrue(succ)
 
+
+class ExfatTestCase(FSTestCase):
+    def setUp(self):
+        if not self.exfat_avail:
+            self.skipTest("skipping exFAT: not available")
+
+        super(ExfatTestCase, self).setUp()
+
+class ExfatTestMkfs(ExfatTestCase):
+    def test_exfat_mkfs(self):
+        """Verify that it is possible to create a new exfat file system"""
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_exfat_mkfs("/non/existing/device", None)
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        # just try if we can mount the file system
+        with mounted(self.loop_dev, self.mount_dir):
+            pass
+
+        # check the fstype
+        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        self.assertEqual(fstype, "exfat")
+
+        BlockDev.fs_wipe(self.loop_dev, True)
+
+class ExfatMkfsWithLabel(ExfatTestCase):
+    def test_exfat_mkfs_with_label(self):
+        """Verify that it is possible to create an exfat file system with label"""
+
+        ea = BlockDev.ExtraArg.new("-n", "test_label")
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, [ea])
+        self.assertTrue(succ)
+
+        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "test_label")
+
+class ExfatTestWipe(ExfatTestCase):
+    def test_exfat_wipe(self):
+        """Verify that it is possible to wipe an exfat file system"""
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_exfat_wipe(self.loop_dev)
+        self.assertTrue(succ)
+
+        # already wiped, should fail this time
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_exfat_wipe(self.loop_dev)
+
+        run("pvcreate -ff -y %s >/dev/null" % self.loop_dev)
+
+        # LVM PV signature, not an exfat file system
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_exfat_wipe(self.loop_dev)
+
+        BlockDev.fs_wipe(self.loop_dev, True)
+
+        run("mkfs.ext2 -F %s >/dev/null 2>&1" % self.loop_dev)
+
+        # ext2, not an exfat file system
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_exfat_wipe(self.loop_dev)
+
+        BlockDev.fs_wipe(self.loop_dev, True)
+
+class ExfatTestCheck(ExfatTestCase):
+    def test_exfat_check(self):
+        """Verify that it is possible to check an exfat file system"""
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_exfat_check(self.loop_dev, None)
+        self.assertTrue(succ)
+
+class ExfatTestRepair(ExfatTestCase):
+    def test_exfat_repair(self):
+        """Verify that it is possible to repair an exfat file system"""
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.fs_exfat_repair(self.loop_dev, None)
+        self.assertTrue(succ)
+
+class ExfatGetInfo(ExfatTestCase):
+    def test_exfat_get_info(self):
+        """Verify that it is possible to get info about an exfat file system"""
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "")
+        # should be an non-empty string
+        self.assertTrue(fi.uuid)
+        self.assertGreater(fi.sector_size, 0)
+        self.assertGreater(fi.sector_count, 0)
+        self.assertGreater(fi.cluster_count, 0)
+
+class ExfatSetLabel(ExfatTestCase):
+    def test_exfat_set_label(self):
+        """Verify that it is possible to set label of an exfat file system"""
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "")
+
+        succ = BlockDev.fs_exfat_set_label(self.loop_dev, "test_label")
+        self.assertTrue(succ)
+        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "test_label")
+
+        succ = BlockDev.fs_exfat_set_label(self.loop_dev, "test_label2")
+        self.assertTrue(succ)
+        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "test_label2")
+
+        succ = BlockDev.fs_exfat_set_label(self.loop_dev, "")
+        self.assertTrue(succ)
+        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        self.assertTrue(fi)
+        self.assertEqual(fi.label, "")
+
 class CanResizeRepairCheckLabel(FSTestCase):
     def test_can_resize(self):
         """Verify that tooling query works for resize"""
@@ -1341,6 +1485,12 @@ class GenericCheck(FSTestCase):
             self.skipTest("skipping NTFS: not available")
         self._test_generic_check(mkfs_function=BlockDev.fs_ntfs_mkfs)
 
+    def test_exfat_generic_check(self):
+        """Test generic check function with an exfat file system"""
+        if not self.exfat_avail:
+            self.skipTest("skipping exFAT: not available")
+        self._test_generic_check(mkfs_function=BlockDev.fs_exfat_mkfs)
+
 class GenericRepair(FSTestCase):
     _loop_size = 500 * 1024**2
 
@@ -1369,6 +1519,12 @@ class GenericRepair(FSTestCase):
             self.skipTest("skipping NTFS: not available")
         self._test_generic_repair(mkfs_function=BlockDev.fs_ntfs_mkfs)
 
+    def test_exfat_generic_repair(self):
+        """Test generic repair function with an exfat file system"""
+        if not self.exfat_avail:
+            self.skipTest("skipping exFAT: not available")
+        self._test_generic_repair(mkfs_function=BlockDev.fs_exfat_mkfs)
+
 class GenericSetLabel(FSTestCase):
     _loop_size = 500 * 1024**2
 
@@ -1396,6 +1552,12 @@ class GenericSetLabel(FSTestCase):
         if not self.ntfs_avail:
             self.skipTest("skipping NTFS: not available")
         self._test_generic_set_label(mkfs_function=BlockDev.fs_ntfs_mkfs)
+
+    def test_exfat_generic_set_label(self):
+        """Test generic set_label function with a exfat file system"""
+        if not self.exfat_avail:
+            self.skipTest("skipping exFAT: not available")
+        self._test_generic_set_label(mkfs_function=BlockDev.fs_exfat_mkfs)
 
 class GenericResize(FSTestCase):
     _loop_size = 500 * 1024**2
@@ -1545,7 +1707,22 @@ class GenericResize(FSTestCase):
             fi = BlockDev.fs_xfs_get_info(lv)
         self.assertTrue(fi)
         self.assertEqual(fi.block_size * fi.block_count, 450 * 1024**2)
+        # self.assertEqual(fi.block_size * fi.block_count, 90 * 1024**2)
 
+    def test_exfat_generic_resize(self):
+        """Test generic resize function with an exfat file system"""
+        if not self.exfat_avail:
+            self.skipTest("skipping exFAT: not available")
+
+        # clean the device
+        succ = BlockDev.fs_clean(self.loop_dev)
+
+        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        self.assertTrue(succ)
+
+        # no resize support for exFAT
+        with six.assertRaisesRegex(self, GLib.GError, "Resizing filesystem 'exfat' is not supported."):
+            BlockDev.fs_resize(self.loop_dev, 80 * 1024**2)
 
 class FSFreezeTest(FSTestCase):
     _loop_size = 500 * 1024**2


### PR DESCRIPTION
It looks like master is brewing for a 3.x release, with API changes and further changes required in downstream projects, and 2.28 is the last stable release. Since I wanted to have exFAT support without waiting for the upcoming release, I've back-ported a patch to a branch based on 2.28-1.