### PR TITLE
spec: Remove dependency on dmraid

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -283,9 +283,6 @@ BuildRequires: systemd-devel
 Summary:     The Device Mapper plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: device-mapper
-%if %{with_dmraid}
-Requires: dmraid
-%endif
 
 %description dm
 The libblockdev library plugin (and in the same time a standalone library)


### PR DESCRIPTION
We don't need the dmraid package which provides the dmraid binary and systemd services, the library is provided by dmraid-libs.