### PR TITLE
Revert "tests: Skip DDF RAID tests on rawhide"

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -89,9 +89,3 @@
     - distro: "fedora"
       version: "38"
       reason: "Force-removing PV for the test hangs with kernel 6.0.0"
-
-- test: mdraid_test.MDTestDDFRAID
-  skip_on:
-    - distro: "fedora"
-      version: "38"
-      reason: "Creating DDF containers is broken on rawhide with kernel 6.2.0"


### PR DESCRIPTION
This reverts commit d5e989527d80c1176dcbddcd1140c08de1037a05.

The DDF tests now work with the latest rawhide kernel.