### PR TITLE
Fix BlockDev.DMTech enum after removing DM RAID support

### DIFF
--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -370,6 +370,12 @@ def dm_create_linear(map_name, device, length, uuid=None):
 __all__.append("dm_create_linear")
 
 
+# XXX enums with just one member are broken with GI
+class DMTech():
+    MAP = BlockDev.DMTech.DM_TECH_MAP
+__all__.append("DMTech")
+
+
 _loop_setup = BlockDev.loop_setup
 @override(BlockDev.loop_setup)
 def loop_setup(file, offset=0, size=0, read_only=False, part_scan=True, sector_size=0):

--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -156,3 +156,8 @@ class DMUnloadTest(DevMapperTestCase):
         # load the plugins back
         self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
         self.assertIn("dm", BlockDev.get_available_plugin_names())
+
+    @tag_test(TestTags.NOSTORAGE)
+    def test_check_dm_tech(self):
+        """ Verify that BlockDev.DMTech works from Python as expected """
+        self.assertTrue(hasattr(BlockDev.DMTech, "MAP"))


### PR DESCRIPTION
GI creates wrong member names for enums with just one member, so after removing the RAID technology we get DMTech.DM_TECH_MAP instead of DMTech.MAP.