### PR TITLE
Run external programs with the C.UTF-8 locale

### DIFF
--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -212,7 +212,8 @@ gboolean bd_utils_exec_and_report_status_error (const gchar **argv, const BDExtr
     }
 
     old_env = g_get_environ ();
-    new_env = g_environ_setenv (old_env, "LC_ALL", "C", TRUE);
+    new_env = g_environ_setenv (old_env, "LC_ALL", "C.UTF-8", TRUE);
+    new_env = g_environ_unsetenv (new_env, "LANGUAGE");
 
     task_id = log_running (args ? args : argv);
     success = g_spawn_sync (NULL, args ? (gchar **) args : (gchar **) argv, new_env, G_SPAWN_SEARCH_PATH,
@@ -416,7 +417,8 @@ static gboolean _utils_exec_and_report_progress (const gchar **argv, const BDExt
     task_id = log_running (args ? args : argv);
 
     old_env = g_get_environ ();
-    new_env = g_environ_setenv (old_env, "LC_ALL", "C", TRUE);
+    new_env = g_environ_setenv (old_env, "LC_ALL", "C.UTF-8", TRUE);
+    new_env = g_environ_unsetenv (new_env, "LANGUAGE");
 
     ret = g_spawn_async_with_pipes (NULL, args ? (gchar**) args : (gchar**) argv, new_env,
                                     G_SPAWN_DEFAULT|G_SPAWN_SEARCH_PATH|G_SPAWN_DO_NOT_REAP_CHILD,


### PR DESCRIPTION
Also unset the LANGUAGE variable so it doesn't override the default language (https://sourceware.org/bugzilla/show_bug.cgi?id=16621).

This allows passing a UTF-8 label to mkfs.exfat.

`C.UTF-8` is available since glibc 2.35, and many major distros have supported it downstream for years. However if for some reason `C.UTF-8` is not available then the child's `setlocale()` call will fail and remain with the default (`C`) locale.

Fixes #846