### PR TITLE
spec: Stop building dm plugin with dmraid support on Fedora >= 38

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -60,7 +60,7 @@
 %endif
 
 # dmraid is not available on RHEL > 7
-%if 0%{?rhel} > 7
+%if 0%{?rhel} > 7 || 0%{?fedora} > 37
 %define with_dmraid 0
 %endif
 


### PR DESCRIPTION
The dmraid support is no longer needed: blivet (the only user of the API) dropped dmraid support in F38.