### PR TITLE
tests: Skip lvm_dbus_tests.LvmTestLVcreateRemove on CentOS 8

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -89,3 +89,9 @@
     - distro: "fedora"
       version: "38"
       reason: "Force-removing PV for the test hangs with kernel 6.0.0"
+
+- test: lvm_dbus_tests.LvmTestLVcreateRemove
+  skip_on:
+   - distro: "centos"
+     version: "8"
+     reason: "LVM DBus doesn't include error message from the command line on CentOS/RHEL 8"


### PR DESCRIPTION
This is already fixed in latest LVM in CentOS 9, but the fix didn't make it to 8.