### PR TITLE
Allow resizing of inactive LVs with latest LVM

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1050,6 +1050,10 @@ class LvmTestLVresize(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
+        # try to resize when deactivated
+        succ = BlockDev.lvm_lvresize("testVG", "testLV", 768 * 1024**2, None)
+        self.assertTrue(succ)
+
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestLVrename(LvmPVVGLVTestCase):
     def test_lvrename(self):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1108,6 +1108,10 @@ class LvmTestLVresize(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
+        # try to resize when deactivated
+        succ = BlockDev.lvm_lvresize("testVG", "testLV", 768 * 1024**2, None)
+        self.assertTrue(succ)
+
 class LvmTestLVrename(LvmPVVGLVTestCase):
     def test_lvrename(self):
         """Verify that it's possible to rename an LV"""


### PR DESCRIPTION
Fixes: #841 

This should be a relatively safe change -- we add the `--fs ignore` option only for inactive LVs basically restoring the old LVM behaviour.