### PR TITLE
spec: Remove dependency on dosfstools and xfsprogs from fs-devel

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -264,8 +264,6 @@ Summary:     Development files for the libblockdev-fs plugin/library
 Requires: %{name}-fs%{?_isa} = %{version}-%{release}
 Requires: %{name}-utils-devel%{?_isa} = %{version}-%{release}
 Requires: glib2-devel
-Requires: xfsprogs
-Requires: dosfstools
 
 %description fs-devel
 This package contains header files and pkg-config files needed for development


### PR DESCRIPTION
This was originally added in d617ba370d2df5dad4a1070aaaf751bba46301c5 but we don't really want to depend on the runtime dependencies and definitely not in the devel package. Libblockdev users needs to deal with the dependencies themselves and use the dependency checks in libblockdev to check for runtime dependencies.