### PR TITLE
ci: Add a GH actions job to build UDisks on PRs

### DIFF
--- a/.github/workflows/udisks-build.yml
+++ b/.github/workflows/udisks-build.yml
@@ -1,0 +1,45 @@
+name: UDisks build
+
+on:
+  pull_request:
+    branches:
+     - master
+
+jobs:
+  build:
+    name: udisks-build
+    runs-on: ubuntu-22.04
+    env:
+      CI_CONTAINER: libblockdev-ci-udisks-build
+    steps:
+      - name: Checkout libblockdev repository
+        uses: actions/checkout@v3
+
+      - name: Install podman
+        run: |
+          sudo apt -qq update
+          sudo apt -y -qq install podman
+
+      - name: Build the container
+        run: |
+          podman build --no-cache -t ${{ env.CI_CONTAINER }} -f misc/ci.Dockerfile .
+
+      - name: Start the container
+        run: |
+          podman run -d -t --name ${{ env.CI_CONTAINER }} --privileged --volume "$(pwd):/app" --workdir "/app" ${{ env.CI_CONTAINER }}
+
+      - name: Install UDisks build dependencies in the container
+        run: |
+          podman exec -it ${{ env.CI_CONTAINER }} bash -c "dnf -y builddep --skip-unavailable /udisks/packaging/udisks2.spec"
+
+      - name: Install libblockdev build dependencies in the container
+        run: |
+          podman exec -it ${{ env.CI_CONTAINER }} bash -c "ansible-playbook -i "localhost," -c local misc/install-test-dependencies.yml -e 'test_dependencies=false'"
+
+      - name: Build and install libblockdev in the container
+        run: |
+          podman exec -it ${{ env.CI_CONTAINER }} bash -c "./autogen.sh && ./configure --prefix=/usr && make -j && make install"
+
+      - name: Build UDisks in the container
+        run: |
+          podman exec -it ${{ env.CI_CONTAINER }} bash -c "cd /udisks && ./autogen.sh --enable-modules && make -j"

--- a/misc/ci.Dockerfile
+++ b/misc/ci.Dockerfile
@@ -3,8 +3,9 @@
 FROM registry.fedoraproject.org/fedora:latest
 
 RUN set -e; \
-  dnf install -y ansible python3-pip rpm-build mock csmock git; \
+  dnf install -y ansible python3-pip rpm-build mock csmock git dnf-plugins-core; \
   pip3 install copr-builder; \
-  git clone --depth 1 https://github.com/storaged-project/ci.git;
+  git clone --depth 1 https://github.com/storaged-project/ci.git; \
+  git clone --depth 1 https://github.com/storaged-project/udisks.git;
 
 WORKDIR /


### PR DESCRIPTION
The idea is to make sure that changes (especially API changes for the upcoming 3.0 release) won't break UDisks.