### PR TITLE
ci: Add custom version command for Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -6,6 +6,8 @@ actions:
     - 'make'
     - 'make local'
     - 'bash -c "ls *.tar*"'
+  get-current-version:
+    - 'bash -c "./configure --version | head -n1 | cut -f3 -d\" \""'
 
 jobs:
 - job: copr_build


### PR DESCRIPTION
By default Packit uses the latest tag which doesn't work for the master branch of libblockdev where the working version 2.99.