### PR TITLE
tests: Fix test for inactive LV resize

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -1050,8 +1050,8 @@ class LvmTestLVresize(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
-        # try to resize when deactivated
-        succ = BlockDev.lvm_lvresize("testVG", "testLV", 768 * 1024**2, None)
+        # try to shrink when deactivated
+        succ = BlockDev.lvm_lvresize("testVG", "testLV", 400 * 1024**2, None)
         self.assertTrue(succ)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1109,8 +1109,8 @@ class LvmTestLVresize(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
-        # try to resize when deactivated
-        succ = BlockDev.lvm_lvresize("testVG", "testLV", 768 * 1024**2, None)
+        # try to shrink when deactivated
+        succ = BlockDev.lvm_lvresize("testVG", "testLV", 400 * 1024**2, None)
         self.assertTrue(succ)
 
 class LvmTestLVrename(LvmPVVGLVTestCase):

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -95,3 +95,9 @@
    - distro: "centos"
      version: "8"
      reason: "LVM DBus doesn't include error message from the command line on CentOS/RHEL 8"
+
+- test: (lvm_test|lvm_dbus_tests).LvmTestLVresize.test_lvresize
+  skip_on:
+   - distro: "centos"
+     version: "9"
+     reason: "LVM >= 2.03.19 is not yet available breaking our check for LVM resize on CentOS 9 Stream"


### PR DESCRIPTION
The issue we were fixing in #855 actually happens only when shrinking the LV, so the test actually didn't test anything.