### PR TITLE
fs: Don't require XFS filesystem to be mounted when getting info

### DIFF
--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -321,9 +321,7 @@ gboolean bd_fs_xfs_check_uuid (const gchar *uuid, GError **error) {
 
 /**
  * bd_fs_xfs_get_info:
- * @device: the device containing the file system to get info for (device must
-            be mounted, trying to get info for an unmounted device will result
-            in an error)
+ * @device: the device containing the file system to get info for
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: (transfer full): information about the file system on @device or
@@ -339,23 +337,9 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
     gchar **lines = NULL;
     gchar **line_p = NULL;
     gchar *val_start = NULL;
-    g_autofree gchar* mountpoint = NULL;
-    GError *l_error = NULL;
 
     if (!check_deps (&avail_deps, DEPS_XFS_ADMIN_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return NULL;
-
-    mountpoint = bd_fs_get_mountpoint (device, &l_error);
-    if (mountpoint == NULL) {
-        if (l_error == NULL) {
-            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_NOT_MOUNTED,
-                         "Can't get xfs file system information for '%s': Device is not mounted.", device);
-            return NULL;
-        } else {
-            g_propagate_prefixed_error (error, l_error, "Error when trying to get mountpoint for '%s': ", device);
-            return NULL;
-        }
-    }
 
     ret = g_new0 (BDFSXfsInfo, 1);
 
@@ -367,7 +351,7 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
     }
 
     args[0] = "xfs_info";
-    args[1] = mountpoint;
+    args[1] = device;
     args[2] = NULL;
     success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
     if (!success) {

--- a/tests/fs_tests/xfs_test.py
+++ b/tests/fs_tests/xfs_test.py
@@ -177,12 +177,7 @@ class XfsGetInfo(XfsTestCase):
         succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
         self.assertTrue(succ)
 
-        with self.assertRaisesRegex(GLib.GError, "not mounted"):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
-
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
-
+        fi = BlockDev.fs_xfs_get_info(self.loop_dev)
         self.assertEqual(fi.block_size, 4096)
         self.assertEqual(fi.block_count, self.loop_size / 4096)
         self.assertEqual(fi.label, "")


### PR DESCRIPTION
It's not necessary and potentially interferes with other activities on the system.

(For example, when Cockpit is open while a new Stratis snapshot is created, there will be a well timed request to UDisks2 that ultimately mounts the new snapshot filesystem to get its size, right when Stratis runs xfs_db to change the UUID, which will fail because it is unexpectedly mounted.  Amazingly narrow race, but it happens.)