### PR TITLE
fs: Don't require XFS filesystem to be mounted when getting info

### DIFF
--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -223,9 +223,7 @@ gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **
 
 /**
  * bd_fs_xfs_get_info:
- * @device: the device containing the file system to get info for (device must
-            be mounted, trying to get info for an unmounted device will result
-            in an error)
+ * @device: the device containing the file system to get info for
  * @error: (out): place to store error (if any)
  *
  * Returns: (transfer full): information about the file system on @device or
@@ -241,22 +239,9 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
     gchar **lines = NULL;
     gchar **line_p = NULL;
     gchar *val_start = NULL;
-    g_autofree gchar* mountpoint = NULL;
 
     if (!check_deps (&avail_deps, DEPS_XFS_ADMIN_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
-
-    mountpoint = bd_fs_get_mountpoint (device, error);
-    if (mountpoint == NULL) {
-        if (error != NULL && *error == NULL) {
-            g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_NOT_MOUNTED,
-                         "Can't get xfs file system information for '%s': Device is not mounted.", device);
-            return NULL;
-        } else {
-            g_prefix_error (error, "Error when trying to get mountpoint for '%s': ", device);
-            return NULL;
-        }
-    }
 
     ret = g_new0 (BDFSXfsInfo, 1);
 
@@ -268,7 +253,7 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
     }
 
     args[0] = "xfs_info";
-    args[1] = mountpoint;
+    args[1] = device;
     args[2] = NULL;
     success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
     if (!success) {

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -686,12 +686,7 @@ class XfsGetInfo(FSTestCase):
         succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
         self.assertTrue(succ)
 
-        with six.assertRaisesRegex(self, GLib.GError, "not mounted"):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
-
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
-
+        fi = BlockDev.fs_xfs_get_info(self.loop_dev)
         self.assertEqual(fi.block_size, 4096)
         self.assertEqual(fi.block_count, 500 * 1024**2 / 4096)
         self.assertEqual(fi.label, "")


### PR DESCRIPTION
Backport of #862 to 2.x