### PR TITLE
tests: Make sure the "fake" PATH for tests exists

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,6 +62,8 @@ def udev_settle():
 
 @contextmanager
 def fake_utils(path="."):
+    if not os.path.exists(path):
+        raise RuntimeError("Path '%s' not found" % path)
     old_path = os.environ.get("PATH", "")
     if old_path:
         new_path = path + ":" + old_path


### PR DESCRIPTION
It's better to fail with an error that run the test case that expects $PATH to be set to a specific (possibly nonexisting) path.