### PR TITLE
fs/xfs: Open device read-only for xfs_info

### DIFF
--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -330,7 +330,7 @@ gboolean bd_fs_xfs_check_uuid (const gchar *uuid, GError **error) {
  * Tech category: %BD_FS_TECH_XFS-%BD_FS_TECH_MODE_QUERY
  */
 BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
-    const gchar *args[3] = ZERO_INIT;
+    const gchar *args[6] = ZERO_INIT;
     gboolean success = FALSE;
     gchar *output = NULL;
     BDFSXfsInfo *ret = NULL;
@@ -350,9 +350,12 @@ BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
         return NULL;
     }
 
-    args[0] = "xfs_info";
-    args[1] = device;
-    args[2] = NULL;
+    args[0] = "xfs_db";
+    args[1] = "-r";
+    args[2] = "-c";
+    args[3] = "info";
+    args[4] = device;
+    args[5] = NULL;
     success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
     if (!success) {
         /* error is already populated */


### PR DESCRIPTION
Running xfs_infor for a device that is not mounted ultimately executes "xfs_db -c info". Unfortunately, xfs_db opens the device read-write by default. This results in a udev event.

The udev event in turn might result in another call to xfs_info via UDisks2 and Cockpit, which conspire the requests the size of a filesystem for each uevent on it.

Luckily, xfs_db can be told to open the device read-only, with the "-r" option.