### PR TITLE
lvm: Add 'shared' parameter to lvm_lvactivate

### DIFF
--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -26,6 +26,10 @@
     <literal>BD_LVM_DEFAULT_PE_START</literal> and <literal>BD_LVM_DEFAULT_PE_SIZE</literal>.
   </para>
 
+  <para>
+    <literal>bd_lvm_lvactivate()</literal> has a new parameter <literal>shared</literal>, use <literal>FALSE</literal> to preserve the original behaviour.
+  </para>
+
   </simplesect>
 
   <simplesect><title>VDO plugin</title>

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -1243,6 +1243,8 @@ gboolean bd_lvm_lvrepair (const gchar *vg_name, const gchar *lv_name, const gcha
  * @vg_name: name of the VG containing the to-be-activated LV
  * @lv_name: name of the to-be-activated LV
  * @ignore_skip: whether to ignore the skip flag or not
+ * @shared: whether to activate the LV in shared mode (used for shared LVM setups with lvmlockd,
+ *          use %FALSE if not sure)
  * @extra: (nullable) (array zero-terminated=1): extra options for the LV activation
  *                                                 (just passed to LVM as is)
  * @error: (out) (optional): place to store error (if any)
@@ -1251,7 +1253,7 @@ gboolean bd_lvm_lvrepair (const gchar *vg_name, const gchar *lv_name, const gcha
  *
  * Tech category: %BD_LVM_TECH_BASIC-%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, gboolean shared, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvdeactivate:

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -2693,6 +2693,8 @@ gboolean bd_lvm_lvrepair (const gchar *vg_name UNUSED, const gchar *lv_name UNUS
  * @vg_name: name of the VG containing the to-be-activated LV
  * @lv_name: name of the to-be-activated LV
  * @ignore_skip: whether to ignore the skip flag or not
+ * @shared: whether to activate the LV in shared mode (used for shared LVM setups with lvmlockd,
+ *          use %FALSE if not sure)
  * @extra: (nullable) (array zero-terminated=1): extra options for the LV activation
  *                                                 (just passed to LVM as is)
  * @error: (out) (optional): place to store error (if any)
@@ -2701,10 +2703,15 @@ gboolean bd_lvm_lvrepair (const gchar *vg_name UNUSED, const gchar *lv_name UNUS
  *
  * Tech category: %BD_LVM_TECH_BASIC-%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error) {
-    GVariant *params = g_variant_new ("(t)", (guint64) 0);
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, gboolean shared, const BDExtraArg **extra, GError **error) {
+    GVariant *params = NULL;
     GVariantBuilder builder;
     GVariant *extra_params = NULL;
+
+    if (shared)
+        params = g_variant_new ("(t)", (guint64) 1 << 6);
+    else
+        params = g_variant_new ("(t)", (guint64) 0);
 
     if (ignore_skip) {
         g_variant_builder_init (&builder, G_VARIANT_TYPE_DICTIONARY);

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -1980,6 +1980,8 @@ gboolean bd_lvm_lvrepair (const gchar *vg_name, const gchar *lv_name, const gcha
  * @vg_name: name of the VG containing the to-be-activated LV
  * @lv_name: name of the to-be-activated LV
  * @ignore_skip: whether to ignore the skip flag or not
+ * @shared: whether to activate the LV in shared mode (used for shared LVM setups with lvmlockd,
+ *          use %FALSE if not sure)
  * @extra: (nullable) (array zero-terminated=1): extra options for the LV activation
  *                                                 (just passed to LVM as is)
  * @error: (out) (optional): place to store error (if any)
@@ -1988,10 +1990,15 @@ gboolean bd_lvm_lvrepair (const gchar *vg_name, const gchar *lv_name, const gcha
  *
  * Tech category: %BD_LVM_TECH_BASIC-%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error) {
-    const gchar *args[5] = {"lvchange", "-ay", NULL, NULL, NULL};
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, gboolean shared, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"lvchange", NULL, NULL, NULL, NULL};
     guint8 next_arg = 2;
     gboolean success = FALSE;
+
+    if (shared)
+        args[1] = "-asy";
+    else
+        args[1] = "-ay";
 
     if (ignore_skip) {
         args[next_arg] = "-K";

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -260,7 +260,7 @@ gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean f
 gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gchar *new_name, const BDExtraArg **extra, GError **error);
 gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error);
 gboolean bd_lvm_lvrepair (const gchar *vg_name, const gchar *lv_name, const gchar **pv_list, const BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, gboolean shared, const BDExtraArg **extra, GError **error);
 gboolean bd_lvm_lvdeactivate (const gchar *vg_name, const gchar *lv_name, const BDExtraArg **extra, GError **error);
 gboolean bd_lvm_lvsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, guint64 size, const BDExtraArg **extra, GError **error);
 gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_name, const BDExtraArg **extra, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -803,9 +803,9 @@ __all__.append("lvm_lvresize")
 
 _lvm_lvactivate = BlockDev.lvm_lvactivate
 @override(BlockDev.lvm_lvactivate)
-def lvm_lvactivate(vg_name, lv_name, ignore_skip=False, extra=None, **kwargs):
+def lvm_lvactivate(vg_name, lv_name, ignore_skip=False, shared=False, extra=None, **kwargs):
     extra = _get_extra(extra, kwargs)
-    return _lvm_lvactivate(vg_name, lv_name, ignore_skip, extra)
+    return _lvm_lvactivate(vg_name, lv_name, ignore_skip, shared, extra)
 __all__.append("lvm_lvactivate")
 
 _lvm_lvdeactivate = BlockDev.lvm_lvdeactivate

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -979,15 +979,15 @@ class LvmTestLVactivateDeactivate(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.lvm_lvactivate("nonexistingVG", "testLV", True, None)
+            BlockDev.lvm_lvactivate("nonexistingVG", "testLV", True)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.lvm_lvactivate("testVG", "nonexistingLV", True, None)
+            BlockDev.lvm_lvactivate("testVG", "nonexistingLV", True)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.lvm_lvactivate("nonexistingVG", "nonexistingLV", True, None)
+            BlockDev.lvm_lvactivate("nonexistingVG", "nonexistingLV", True)
 
-        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True, None)
+        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True)
         self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
@@ -1002,7 +1002,15 @@ class LvmTestLVactivateDeactivate(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
-        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True, None)
+        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
+        self.assertTrue(succ)
+
+        # try activating in shared mode, unfortunately no way to check whether it really
+        # works or not
+        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True, True)
         self.assertTrue(succ)
 
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1039,15 +1039,15 @@ class LvmTestLVactivateDeactivate(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.lvm_lvactivate("nonexistingVG", "testLV", True, None)
+            BlockDev.lvm_lvactivate("nonexistingVG", "testLV", True)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.lvm_lvactivate("testVG", "nonexistingLV", True, None)
+            BlockDev.lvm_lvactivate("testVG", "nonexistingLV", True)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.lvm_lvactivate("nonexistingVG", "nonexistingLV", True, None)
+            BlockDev.lvm_lvactivate("nonexistingVG", "nonexistingLV", True)
 
-        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True, None)
+        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True)
         self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
@@ -1062,7 +1062,15 @@ class LvmTestLVactivateDeactivate(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
-        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True, None)
+        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
+        self.assertTrue(succ)
+
+        # try activating in shared mode, unfortunately no way to check whether it really
+        # works or not
+        succ = BlockDev.lvm_lvactivate("testVG", "testLV", True, True)
         self.assertTrue(succ)
 
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)


### PR DESCRIPTION
Needed by the new blivet feature to support shared LVM setups.