### PR TITLE
fs: Remove UUID option from bd_fs_nilfs2_mkfs_options

### DIFF
--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -137,9 +137,6 @@ BDExtraArg __attribute__ ((visibility ("hidden")))
     if (options->label && g_strcmp0 (options->label, "") != 0)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-L", options->label));
 
-    if (options->uuid && g_strcmp0 (options->uuid, "") != 0)
-        g_ptr_array_add (options_array, bd_extra_arg_new ("-U", options->uuid));
-
     if (options->dry_run)
         g_ptr_array_add (options_array, bd_extra_arg_new ("-n", ""));
 


### PR DESCRIPTION
Setting UUID for ntfs.nilfs2 is not supported.

Fixes: #885