### PR TITLE
Allow resizing of inactive LVs with latest LVM

### DIFF
--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -31,6 +31,8 @@
 #define SECTOR_SIZE 512
 #define VDO_POOL_SUFFIX "vpool"
 
+#define LVM_VERSION_FSRESIZE "2.03.19"
+
 static GMutex global_config_lock;
 static gchar *global_config_str = NULL;
 
@@ -1583,15 +1585,37 @@ gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gcha
  * Tech category: %BD_LVM_TECH_BASIC-%BD_LVM_TECH_MODE_MODIFY
  */
 gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error) {
-    const gchar *args[6] = {"lvresize", "--force", "-L", NULL, NULL, NULL};
+    const gchar *args[8] = {"lvresize", "--force", "-L", NULL, NULL, NULL, NULL, NULL};
     gboolean success = FALSE;
+    guint8 next_arg = 4;
+    g_autofree gchar *lvspec = NULL;
+    BDLVMLVdata *lvinfo = NULL;
+    GError *l_error = NULL;
+
+    lvinfo = bd_lvm_lvinfo (vg_name, lv_name, error);
+    if (!lvinfo)
+        /* error is already populated */
+        return FALSE;
 
     args[3] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size/1024);
-    args[4] = g_strdup_printf ("%s/%s", vg_name, lv_name);
+        if (lvinfo->attr[4] != 'a') {
+        /* starting with 2.03.19 we need to add extra option to allow resizing of inactive LVs */
+        success = bd_utils_check_util_version (deps[DEPS_LVM].name, LVM_VERSION_FSRESIZE,
+                                               deps[DEPS_LVM].ver_arg, deps[DEPS_LVM].ver_regexp, &l_error);
+        if (success) {
+            args[next_arg++] = "--fs";
+            args[next_arg++] = "ignore";
+        }
+        g_clear_error (&l_error);
+    }
+
+    bd_lvm_lvdata_free (lvinfo);
+
+    lvspec = g_strdup_printf ("%s/%s", vg_name, lv_name);
+    args[next_arg++] = lvspec;
 
     success = call_lvm_and_report_error (args, extra, TRUE, error);
     g_free ((gchar *) args[3]);
-    g_free ((gchar *) args[4]);
 
     return success;
 }

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -901,6 +901,10 @@ class LvmTestLVresize(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
+         # try to shrink when deactivated
+        succ = BlockDev.lvm_lvresize("testVG", "testLV", 400 * 1024**2, None)
+        self.assertTrue(succ)
+
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestLVrename(LvmPVVGLVTestCase):
     def test_lvrename(self):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -830,6 +830,10 @@ class LvmTestLVresize(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvdeactivate("testVG", "testLV", None)
         self.assertTrue(succ)
 
+         # try to shrink when deactivated
+        succ = BlockDev.lvm_lvresize("testVG", "testLV", 400 * 1024**2, None)
+        self.assertTrue(succ)
+
 class LvmTestLVrename(LvmPVVGLVTestCase):
     def test_lvrename(self):
         """Verify that it's possible to rename an LV"""

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -111,3 +111,9 @@
    - distro: "centos"
      version: "8"
      reason: "LVM DBus doesn't include error message from the command line on CentOS/RHEL 8"
+
+- test: (lvm_test|lvm_dbus_tests).LvmTestLVresize.test_lvresize
+  skip_on:
+   - distro: "centos"
+     version: "9"
+     reason: "LVM >= 2.03.19 is not yet available breaking our check for LVM resize on CentOS 9 Stream"


### PR DESCRIPTION
Latest LVM doesn't allow resizing of inactive LVs without the "--fs ignore" option to protect users from corrupting their filesystems. As a low level API we don't really want to offer this kind of protection and we should allow to resize an inactive LV.

Backport of #855 and #861 to 2.x