### PR TITLE
mount: Initialize libmount debugging

### DIFF
--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -18,6 +18,7 @@
  */
 
 #include <blockdev/utils.h>
+#include <libmount/libmount.h>
 
 #include <check_deps.h>
 #include "fs.h"
@@ -57,6 +58,9 @@ GQuark bd_fs_error_quark (void)
  *
  */
 gboolean bd_fs_init (void) {
+    /* tell libmount to honour the LIBMOUNT_DEBUG env var */
+    mnt_init_debug (0);
+
     return TRUE;
 }
 


### PR DESCRIPTION
This little trick makes libmount to initialize debugging through the LIBMOUNT_DEBUG environment variable.

Tested on UDisks, setting this env. var. in the daemon environment prints lots of information that can be later retrieved from syslog/journal. Daemon restart required.