### PR TITLE
tests: Skip test_ext4_check on rawhide

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -73,3 +73,9 @@
     - distro: "centos"
       version: "8"
       reason: "required version of libnvme is not available CentOS 8"
+
+- test: fs_tests.ext_test.ExtTestCheck.test_ext4_check
+  skip_on:
+  - distro: "fedora"
+    version: "39"
+    reason: "Ext4 cannot be checked when mounted with latest with e2fsprogs 1.47"


### PR DESCRIPTION
ext4 cannot be checked when mounted with latest e2fsprogs on rawhide. See https://bugzilla.redhat.com/show_bug.cgi?id=2211420