### PR TITLE
tests: Skip test_ext4_check on rawhide

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -117,3 +117,9 @@
    - distro: "centos"
      version: "9"
      reason: "LVM >= 2.03.19 is not yet available breaking our check for LVM resize on CentOS 9 Stream"
+
+- test: fs_test.ExtTestCheck.test_ext4_check
+  skip_on:
+  - distro: "fedora"
+    version: "39"
+    reason: "Ext4 cannot be checked when mounted with latest with e2fsprogs 1.47"


### PR DESCRIPTION
ext4 cannot be checked when mounted with latest e2fsprogs on rawhide. See https://bugzilla.redhat.com/show_bug.cgi?id=2211420