### PR TITLE
fs: Allow specifying extra options to all check/repair functions

### DIFF
--- a/docs/3.0-api-changes.xml
+++ b/docs/3.0-api-changes.xml
@@ -116,6 +116,11 @@
     Affected functions: <literal>bd_fs_btrfs_wipe</literal>, <literal>bd_fs_ext2_wipe</literal>, <literal>bd_fs_ext3_wipe</literal>, <literal>bd_fs_ext4_wipe</literal>, <literal>bd_fs_exfat_wipe</literal>, <literal>bd_fs_f2fs_wipe</literal>, <literal>bd_fs_nilfs2_wipe</literal>, <literal>bd_fs_ntfs_wipe</literal>, <literal>bd_fs_vfat_wipe</literal>, <literal>bd_fs_udf_wipe</literal>, <literal>bd_fs_xfs_wipe</literal>
   </para>
 
+  <para>
+   <literal>bd_fs_ntfs_check</literal>, <literal>bd_fs_ntfs_repair</literal> and <literal>bd_fs_xfs_check</literal> have a new parameter <literal>extra</literal>
+   that allows specifying extra options for the fsck tools. This makes the functionality consistent with the other filesystems.
+  </para>
+
   </simplesect>
 
   <simplesect><title>Part plugin</title>

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1699,6 +1699,8 @@ gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError *
 /**
  * bd_fs_xfs_check:
  * @device: the device containing the file system to check
+ * @extra: (nullable) (array zero-terminated=1): extra options for the repair (right now
+ *                                               passed to the 'xfs_repair' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether an xfs file system on the @device is clean or not
@@ -1708,7 +1710,7 @@ gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError *
  *
  * Tech category: %BD_FS_TECH_XFS-%BD_FS_TECH_MODE_CHECK
  */
-gboolean bd_fs_xfs_check (const gchar *device, GError **error);
+gboolean bd_fs_xfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_xfs_repair:
@@ -1927,17 +1929,21 @@ gboolean bd_fs_ntfs_mkfs (const gchar *device, const BDExtraArg **extra, GError 
 /**
  * bd_fs_ntfs_check:
  * @device: the device containing the file system to check
+ * @extra: (nullable) (array zero-terminated=1): extra options for the repair (right now
+ *                                               passed to the 'ntfsfix' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether an ntfs file system on the @device is clean or not
  *
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_CHECK
  */
-gboolean bd_fs_ntfs_check (const gchar *device, GError **error);
+gboolean bd_fs_ntfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_ntfs_repair:
  * @device: the device containing the file system to repair
+ * @extra: (nullable) (array zero-terminated=1): extra options for the repair (right now
+ *                                               passed to the 'ntfsfix' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether an NTFS file system on the @device was successfully repaired
@@ -1945,7 +1951,7 @@ gboolean bd_fs_ntfs_check (const gchar *device, GError **error);
  *
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_REPAIR
  */
-gboolean bd_fs_ntfs_repair (const gchar *device, GError **error);
+gboolean bd_fs_ntfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_ntfs_set_label:

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -956,7 +956,7 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             case BD_FS_REPAIR:
                 return bd_fs_xfs_repair (device, NULL, error);
             case BD_FS_CHECK:
-                return bd_fs_xfs_check (device, error);
+                return bd_fs_xfs_check (device, NULL, error);
             case BD_FS_LABEL:
                 return bd_fs_xfs_set_label (device, label, error);
             case BD_FS_LABEL_CHECK:
@@ -992,9 +992,9 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFs
             case BD_FS_RESIZE:
                 return bd_fs_ntfs_resize (device, new_size, error);
             case BD_FS_REPAIR:
-                return bd_fs_ntfs_repair (device, error);
+                return bd_fs_ntfs_repair (device, NULL, error);
             case BD_FS_CHECK:
-                return bd_fs_ntfs_check (device, error);
+                return bd_fs_ntfs_check (device, NULL, error);
             case BD_FS_LABEL_CHECK:
                 return bd_fs_ntfs_check_label (label, error);
             case BD_FS_LABEL:

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -159,13 +159,15 @@ gboolean bd_fs_ntfs_mkfs (const gchar *device, const BDExtraArg **extra, GError 
 /**
  * bd_fs_ntfs_check:
  * @device: the device containing the file system to check
+ * @extra: (nullable) (array zero-terminated=1): extra options for the repair (right now
+ *                                               passed to the 'ntfsfix' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether an ntfs file system on the @device is clean or not
  *
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_CHECK
  */
-gboolean bd_fs_ntfs_check (const gchar *device, GError **error) {
+gboolean bd_fs_ntfs_check (const gchar *device, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"ntfsfix", "-n", device, NULL};
     gint status = 0;
     gboolean ret = FALSE;
@@ -173,7 +175,7 @@ gboolean bd_fs_ntfs_check (const gchar *device, GError **error) {
     if (!check_deps (&avail_deps, DEPS_NTFSFIX_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
 
-    ret = bd_utils_exec_and_report_status_error (args, NULL, &status, error);
+    ret = bd_utils_exec_and_report_status_error (args, extra, &status, error);
     if (!ret && (status == 1)) {
         /* no error should be reported for exit code 1 -- Recoverable errors have been detected */
         g_clear_error (error);
@@ -184,6 +186,8 @@ gboolean bd_fs_ntfs_check (const gchar *device, GError **error) {
 /**
  * bd_fs_ntfs_repair:
  * @device: the device containing the file system to repair
+ * @extra: (nullable) (array zero-terminated=1): extra options for the repair (right now
+ *                                               passed to the 'ntfsfix' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether an NTFS file system on the @device was successfully repaired
@@ -191,13 +195,13 @@ gboolean bd_fs_ntfs_check (const gchar *device, GError **error) {
  *
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_REPAIR
  */
-gboolean bd_fs_ntfs_repair (const gchar *device, GError **error) {
+gboolean bd_fs_ntfs_repair (const gchar *device, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"ntfsfix", "-d", device, NULL};
 
     if (!check_deps (&avail_deps, DEPS_NTFSFIX_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
 
-    return bd_utils_exec_and_report_error (args, NULL, error);
+    return bd_utils_exec_and_report_error (args, extra, error);
 }
 
 /**

--- a/src/plugins/fs/ntfs.h
+++ b/src/plugins/fs/ntfs.h
@@ -15,8 +15,8 @@ BDFSNtfsInfo* bd_fs_ntfs_info_copy (BDFSNtfsInfo *data);
 void bd_fs_ntfs_info_free (BDFSNtfsInfo *data);
 
 gboolean bd_fs_ntfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
-gboolean bd_fs_ntfs_check (const gchar *device, GError **error);
-gboolean bd_fs_ntfs_repair (const gchar *device, GError **error);
+gboolean bd_fs_ntfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_ntfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ntfs_set_label (const gchar *device, const gchar *label, GError **error);
 gboolean bd_fs_ntfs_check_label (const gchar *label, GError **error);
 gboolean bd_fs_ntfs_set_uuid (const gchar *device, const gchar *uuid, GError **error);

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -180,6 +180,8 @@ gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError *
 /**
  * bd_fs_xfs_check:
  * @device: the device containing the file system to check
+ * @extra: (nullable) (array zero-terminated=1): extra options for the repair (right now
+ *                                               passed to the 'xfs_repair' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether an xfs file system on the @device is clean or not
@@ -189,7 +191,7 @@ gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError *
  *
  * Tech category: %BD_FS_TECH_XFS-%BD_FS_TECH_MODE_CHECK
  */
-gboolean bd_fs_xfs_check (const gchar *device, GError **error) {
+gboolean bd_fs_xfs_check (const gchar *device, const BDExtraArg **extra, GError **error) {
     const gchar *args[4] = {"xfs_repair", "-n", device, NULL};
     gboolean ret = FALSE;
     GError *l_error = NULL;
@@ -197,7 +199,7 @@ gboolean bd_fs_xfs_check (const gchar *device, GError **error) {
     if (!check_deps (&avail_deps, DEPS_XFS_REPAIR_MASK, deps, DEPS_LAST, &deps_check_lock, error))
         return FALSE;
 
-    ret = bd_utils_exec_and_report_error (args, NULL, &l_error);
+    ret = bd_utils_exec_and_report_error (args, extra, &l_error);
     if (!ret) {
         if (l_error && g_error_matches (l_error, BD_UTILS_EXEC_ERROR, BD_UTILS_EXEC_ERROR_FAILED)) {
             /* non-zero exit status -> the fs is not clean, but not an error */

--- a/src/plugins/fs/xfs.h
+++ b/src/plugins/fs/xfs.h
@@ -15,7 +15,7 @@ BDFSXfsInfo* bd_fs_xfs_info_copy (BDFSXfsInfo *data);
 void bd_fs_xfs_info_free (BDFSXfsInfo *data);
 
 gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
-gboolean bd_fs_xfs_check (const gchar *device, GError **error);
+gboolean bd_fs_xfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_xfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **error);
 gboolean bd_fs_xfs_check_label (const gchar *label, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -519,6 +519,13 @@ def fs_xfs_mkfs(device, extra=None, **kwargs):
     return _fs_xfs_mkfs(device, extra)
 __all__.append("fs_xfs_mkfs")
 
+_fs_xfs_check = BlockDev.fs_xfs_check
+@override(BlockDev.fs_xfs_check)
+def fs_xfs_check(device, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_xfs_check(device, extra)
+__all__.append("fs_xfs_check")
+
 _fs_xfs_repair = BlockDev.fs_xfs_repair
 @override(BlockDev.fs_xfs_repair)
 def fs_xfs_repair(device, extra=None, **kwargs):
@@ -532,6 +539,20 @@ def fs_xfs_resize(device, size, extra=None, **kwargs):
     extra = _get_extra(extra, kwargs)
     return _fs_xfs_resize(device, size, extra)
 __all__.append("fs_xfs_resize")
+
+_fs_ntfs_check = BlockDev.fs_ntfs_check
+@override(BlockDev.fs_ntfs_check)
+def fs_ntfs_check(device, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_ntfs_check(device, extra)
+__all__.append("fs_ntfs_check")
+
+_fs_ntfs_repair = BlockDev.fs_ntfs_repair
+@override(BlockDev.fs_ntfs_repair)
+def fs_ntfs_repair(device, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _fs_ntfs_repair(device, extra)
+__all__.append("fs_ntfs_repair")
 
 _fs_vfat_mkfs = BlockDev.fs_vfat_mkfs
 @override(BlockDev.fs_vfat_mkfs)


### PR DESCRIPTION
bd_fs_xfs_check and bd_fs_ntfs_check and repair didn't allow extra options

Fixes: #475