### PR TITLE
vdo_stats: Remove unused libparted include

### DIFF
--- a/src/plugins/vdo_stats.c
+++ b/src/plugins/vdo_stats.c
@@ -18,7 +18,6 @@
  */
 
 #include <glib.h>
-#include <parted/parted.h>
 #include <blockdev/utils.h>
 
 #include "vdo_stats.h"


### PR DESCRIPTION
I have no idea where this came from, but we don't need (and never did) libparted in vdo_stats.

Fixes: #916