### PR TITLE
nvme: Mark private symbols as hidden

### DIFF
--- a/src/plugins/nvme/nvme-private.h
+++ b/src/plugins/nvme/nvme-private.h
@@ -16,10 +16,13 @@
 #define _C_LOCALE (locale_t) 0
 
 /* nvme-error.c */
+G_GNUC_INTERNAL
 void _nvme_status_to_error (gint status, gboolean fabrics, GError **error);
+G_GNUC_INTERNAL
 void _nvme_fabrics_errno_to_gerror (int result, int _errno, GError **error);
 
 /* nvme-info.c */
+G_GNUC_INTERNAL
 gint _open_dev (const gchar *device, GError **error);
 
 #endif  /* BD_NVME_PRIVATE */


### PR DESCRIPTION
This should fix some of the lingering symbols reported in #918