### PR TITLE
loop: define LOOP_SET_BLOCK_SIZE is not defined

### DIFF
--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -28,6 +28,10 @@
 #include <blockdev/utils.h>
 #include "loop.h"
 
+#ifndef LOOP_SET_BLOCK_SIZE
+#define LOOP_SET_BLOCK_SIZE	0x4C09
+#endif
+
 /**
  * SECTION: loop
  * @short_description: plugin for operations with loop devices


### PR DESCRIPTION
It can happen that linux header linux/loop.h doesn't include LOOP_SET_BLOCK_SIZE definition, so let's define it locally in such case.