### PR TITLE
Ignore exit code of fsck.vfat when retrieving info

### DIFF
--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -419,7 +419,7 @@ gboolean bd_fs_vfat_check_uuid (const gchar *uuid, GError **error) {
  * Tech category: %BD_FS_TECH_VFAT-%BD_FS_TECH_MODE_QUERY
  */
 BDFSVfatInfo* bd_fs_vfat_get_info (const gchar *device, GError **error) {
-    const gchar *args[4] = {"fsck.vfat", "-nv", device, NULL};
+    const gchar *args[] = {"sh", "-c", "fsck.vfat -nv \"$0\"; true", device, NULL};
     gboolean success = FALSE;
     BDFSVfatInfo *ret = NULL;
     gchar *output = NULL;


### PR DESCRIPTION
fsck.vfat will return exit code 1 even though it will print the size information when the partition wasn't properly unmounted (dirty flag set).
Because of this, get_size will return 0 and udisks2 will not cache its result, leading to a run of fsck.vfat each time `udisksctl status` is run (and in other use cases too).

As we just need the size information, we don't care that the FS has issues, as long as there are the required lines about the sizes.

Here is a sample output:
```
# fsck.vfat -nv /dev/sda3;  echo "exit code: $?"
fsck.fat 4.2 (2021-01-31)
Checking we can access the last sector of the filesystem
There are differences between boot sector and its backup.
This is mostly harmless. Differences: (offset:original/backup)
  65:01/00
  Not automatically fixing this.
Boot sector contents:
System ID "MSDOS5.0"
Media byte 0xf8 (hard disk)
       512 bytes per logical sector
       512 bytes per cluster
      8318 reserved sectors
First FAT starts at byte 4258816 (sector 8318)
         2 FATs, 32 bit entries
   2064896 bytes per FAT (= 4033 sectors)
Root directory start at cluster 2 (arbitrary size)
Data area starts at byte 8388608 (sector 16384)
    516096 data clusters (264241152 bytes)
63 sectors/track, 255 heads
   3553280 hidden sectors
    532480 sectors total
Checking for unused clusters.
Dirty bit is set. Fs was not properly unmounted and some data may be corrupt.
 Automatically removing dirty bit.
Checking free cluster summary.

Leaving filesystem unchanged.
/dev/sda3: 328 files, 180484/516096 clusters
exit code: 1
```

Alternatives solutions:

- Make udisks2 cache failures too (when `bd_fs_get_size` return 0) so tools are not called again if they fail
- Change `bd_utils_exec_and_capture_output` to always return `output` even when exit code is not 0 (see below)

Maybe there is a better way to do this, but `bd_utils_exec_and_capture_output` discard output when the exit code is not 0 (output is left to NULL).

An alternative solution would be change `bd_utils_exec_and_capture_output` to always set `output` with the process output even if the exit code is not 0, but that will require every call to that function to properly free `output` even when `success == 0` (much more impact to other parts of the code).