### PR TITLE
docs: Fix test quotation

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -2,7 +2,7 @@ all-local: html-doc.stamp
 
 html-doc.stamp: ${srcdir}/libblockdev-docs.xml ${srcdir}/libblockdev-sections.txt ${srcdir}/3.0-api-changes.xml $(wildcard ${srcdir}/../src/plugins/*.[ch]) $(wildcard ${srcdir}/../src/lib/*.[ch]) $(wildcard ${srcdir}/../src/utils/*.[ch])
 	touch ${builddir}/html-doc.stamp
-	test ${builddir} = ${srcdir} || cp ${srcdir}/libblockdev-sections.txt ${srcdir}/libblockdev-docs.xml ${builddir}
+	test "${builddir}" = "${srcdir}" || cp ${srcdir}/libblockdev-sections.txt ${srcdir}/libblockdev-docs.xml ${builddir}
 	gtkdoc-scan --rebuild-types --module=libblockdev --source-dir=${srcdir}/../src/plugins/ --source-dir=${srcdir}/../src/lib/ --source-dir=${srcdir}/../src/utils/ --ignore-headers="${srcdir}/../src/plugins/check_deps.h ${srcdir}/../src/plugins/dm_logging.h ${srcdir}/../src/plugins/vdo_stats.h ${srcdir}/../src/plugins/fs/common.h"
 	gtkdoc-mkdb --module=libblockdev --output-format=xml --source-dir=${srcdir}/../src/plugins/ --source-dir=${srcdir}/../src/lib/ --source-dir=${srcdir}/../src/utils/ --source-suffixes=c,h
 	test -d ${builddir}/html || mkdir ${builddir}/html
@@ -13,7 +13,7 @@ clean-local:
 	-rm -rf ${builddir}/html
 	-rm -rf ${builddir}/xml
 	test ! -f ${builddir}/html-doc.stamp || rm ${builddir}/html-doc.stamp
-	test ${builddir} = ${srcdir} || rm -f ${builddir}/libblockdev-sections.txt ${builddir}/libblockdev-docs.xml ${builddir}/3.0-api-changes.xml
+	test "${builddir}" = "${srcdir}" || rm -f ${builddir}/libblockdev-sections.txt ${builddir}/libblockdev-docs.xml ${builddir}/3.0-api-changes.xml
 
 install-data-local:
 	test -d ${DESTDIR}${datadir}/gtk-doc/html/libblockdev || mkdir -p ${DESTDIR}${datadir}/gtk-doc/html/libblockdev


### PR DESCRIPTION
Shamelessly picked up from Gentoo Portage:

bash is fine with "test . == ." but e.g. dash fails on not having the two dots quoted as strings.

https://gitweb.gentoo.org/repo/gentoo.git/commit/sys-libs/libblockdev?id=4d0304347f57f44cb1ba4f015aad75ca12e1596a