### PR TITLE
lib: Silence the missing DEFAULT_CONF_DIR_PATH

### DIFF
--- a/src/lib/blockdev.c.in
+++ b/src/lib/blockdev.c.in
@@ -296,7 +296,7 @@ static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload, g
 
         g_sequence_free (config_files);
     } else
-        bd_utils_log_format (BD_UTILS_LOG_WARNING, "Failed to load config files: %s. Using the built-in config",
+        bd_utils_log_format (BD_UTILS_LOG_INFO, "Failed to load config files: %s. Using the built-in config",
                              error->message);
     g_clear_error (&error);
 


### PR DESCRIPTION
In preparation for the library going config-less (with builtin config only) let's lower severity of the missing config dir error, reported on udisksd startup:

  ** (udisksd:31627): WARNING **: 16:16:26.927: Failed to load config files: Failed to get contents of the config dir (/etc/libblockdev/3/conf.d/)Error opening directory ?/etc/libblockdev/3/conf.d/?: No such file or directory. Using the built-in config