### PR TITLE
tests: Replace deprecated unittest assert calls

### DIFF
--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -579,7 +579,7 @@ class CryptoTestGetMetadataSize(CryptoTestCase):
         if m is None:
             self.fail("Failed to get LUKS 2 offset information from %s:\n%s %s" % (self.loop_dev, out, err))
         offset = int(m.group(1))
-        self.assertEquals(meta_size, offset, "LUKS 2 metadata sizes differ")
+        self.assertEqual(meta_size, offset, "LUKS 2 metadata sizes differ")
 
     @tag_test(TestTags.SLOW)
     def test_luks_get_metadata_size(self):
@@ -600,7 +600,7 @@ class CryptoTestGetMetadataSize(CryptoTestCase):
         # offset value is in 512B blocks; we need to multiply to get the real metadata size
         offset = int(m.group(1)) * 512
 
-        self.assertEquals(meta_size, offset, "LUKS metadata sizes differ")
+        self.assertEqual(meta_size, offset, "LUKS metadata sizes differ")
 
 class CryptoTestLuksOpenRW(CryptoTestCase):
     def _luks_open_rw(self, create_fn):

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -225,7 +225,7 @@ class SwapUnloadTest(SwapTest):
             self.assertTrue(BlockDev.reinit(self.requested_plugins, True, None))
             self.assertIn("swap", BlockDev.get_available_plugin_names())
 
-            with self.assertRaisesRegexp(GLib.GError, "The 'mkswap' utility is not available"):
+            with self.assertRaisesRegex(GLib.GError, "The 'mkswap' utility is not available"):
                 # the device shouldn't matter, the function should return an
                 # error before any other checks or actions
                 BlockDev.swap_mkswap("/dev/device", "LABEL", None)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -193,11 +193,11 @@ class UtilsExecLoggingTest(UtilsTestCase):
         cnt = 65536
         succ, out = BlockDev.utils_exec_and_capture_output(["bash", "-c", "for i in {1..%d}; do echo -n .; done" % cnt])
         self.assertTrue(succ)
-        self.assertEquals(len(out), cnt)
+        self.assertEqual(len(out), cnt)
 
         succ, out = BlockDev.utils_exec_and_capture_output(["bash", "-c", "for i in {1..%d}; do echo -n .; echo -n \# >&2; done" % cnt])
         self.assertTrue(succ)
-        self.assertEquals(len(out), cnt)
+        self.assertEqual(len(out), cnt)
 
         # now exceed the system pipe buffer size
         # pipe(7): The maximum size (in bytes) of individual pipes that can be set by users without the CAP_SYS_RESOURCE capability.
@@ -206,11 +206,11 @@ class UtilsExecLoggingTest(UtilsTestCase):
 
         succ, out = BlockDev.utils_exec_and_capture_output(["bash", "-c", "for i in {1..%d}; do echo -n .; done" % cnt])
         self.assertTrue(succ)
-        self.assertEquals(len(out), cnt)
+        self.assertEqual(len(out), cnt)
 
         succ, out = BlockDev.utils_exec_and_capture_output(["bash", "-c", "for i in {1..%d}; do echo -n .; echo -n \# >&2; done" % cnt])
         self.assertTrue(succ)
-        self.assertEquals(len(out), cnt)
+        self.assertEqual(len(out), cnt)
 
         # make use of some newlines
         succ, out = BlockDev.utils_exec_and_capture_output(["bash", "-c", "for i in {1..%d}; do echo -n .; if [ $(($i%%500)) -eq 0 ]; then echo ''; fi; done" % cnt])


### PR DESCRIPTION
assertRaisesRegexp and assertEquals were deprecated for some time and are no longer available in Python 3.12.