### PR TITLE
spec: Obsolete vdo plugin packages

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -103,6 +103,10 @@ Provides: libblockdev-kbd = %{version}-%{release}
 Obsoletes: libblockdev-kbd < %{version}-%{release}
 Provides: libblockdev-kbd-devel = %{version}-%{release}
 Obsoletes: libblockdev-kbd-devel < %{version}-%{release}
+Provides: libblockdev-vdo = %{version}-%{release}
+Obsoletes: libblockdev-vdo < %{version}-%{release}
+Provides: libblockdev-vdo-devel = %{version}-%{release}
+Obsoletes: libblockdev-vdo-devel < %{version}-%{release}
 
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 


### PR DESCRIPTION
We stopped building the VDO plugin in Fedora 34 but never made it obsolete and it is now breaking upgrades.

Resolves: rhbz#2237477