### PR TITLE
packit: Add configuration for downstream builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -38,6 +38,23 @@ jobs:
   branch: master
   preserve_project: true
 
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+    - fedora-development
+    - fedora-latest
+
+- job: koji_build
+  trigger: commit
+  dist_git_branches:
+    - fedora-development
+    - fedora-latest
+
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-branched
+
 srpm_build_deps:
  - make
  - gcc


### PR DESCRIPTION
With 3.0 being released and available in Fedora rawhide and 39 we can now have builds done by Packit for new upstream releases.