### PR TITLE
tests: Fail early when recompilation fails in library_test

### DIFF
--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -186,7 +186,8 @@ class PluginsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?MAX_LV_SIZE;?1024;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        ret = os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        self.assertEqual(ret, 0, "Failed to recompile libblockdev for reload test")
 
         # library should successfully reinitialize without reloading plugins
         self.assertTrue(BlockDev.reinit(self.requested_plugins, False, None))
@@ -224,14 +225,16 @@ class PluginsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?MAX_LV_SIZE;?1024;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        ret = os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        self.assertEqual(ret, 0, "Failed to recompile libblockdev for force plugin test")
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so")
 
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
-        os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        ret = os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        self.assertEqual(ret, 0, "Failed to recompile libblockdev for force plugin test")
 
         # force the new plugin to be used
         ps = BlockDev.PluginSpec()
@@ -267,14 +270,16 @@ class PluginsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?MAX_LV_SIZE;?1024;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        ret = os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        self.assertEqual(ret, 0, "Failed to recompile libblockdev for plugin priority test")
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so.3")
 
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
-        os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        ret = os.system("make -C src/plugins/ libbd_lvm.la >/dev/null 2>&1")
+        self.assertEqual(ret, 0, "Failed to recompile libblockdev for plugin priority test")
 
         # now reinit the library with the config preferring the new build
         orig_conf_dir = os.environ.get("LIBBLOCKDEV_CONFIG_DIR")


### PR DESCRIPTION
The tests in PluginsTestCase recompile the library and if this step fails the test case can fail with an unexpected error that is hard to debug so we should just fail early with some reasonable message instead.

Fixes: #944