### PR TITLE
ci: Manually prepare spec file for Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,8 +8,6 @@ actions:
     - 'make'
     - 'make local'
     - 'bash -c "ls *.tar*"'
-  get-current-version:
-    - 'bash -c "./configure --version | head -n1 | cut -f3 -d\" \""'
 
 jobs:
 - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,8 +1,10 @@
 actions:
   post-upstream-clone:
+    - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
+    - 'sed -i -E "s/@WITH_.+@/1/g" dist/libblockdev.spec'
+  create-archive:
     - './autogen.sh'
     - './configure'
-  create-archive:
     - 'make'
     - 'make local'
     - 'bash -c "ls *.tar*"'


### PR DESCRIPTION
We can't run ./configure for some jobs in Packit, but we don't really need to -- we can replace the constants manually with sed, because for the Packit builds, we always want to build the entire project.

Fixes: #975