### PR TITLE
fs: Add a function to check label format for F2FS

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -651,6 +651,7 @@ bd_fs_f2fs_check
 bd_fs_f2fs_repair
 bd_fs_f2fs_get_info
 bd_fs_f2fs_resize
+bd_fs_f2fs_check_label
 BDFSNILFS2Info
 bd_fs_nilfs2_get_info
 bd_fs_nilfs2_info_copy

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -2116,6 +2116,18 @@ BDFSF2FSInfo* bd_fs_f2fs_get_info (const gchar *device, GError **error);
 gboolean bd_fs_f2fs_resize (const gchar *device, guint64 new_size, gboolean safe, const BDExtraArg **extra, GError **error);
 
 /**
+ * bd_fs_f2fs_check_label:
+ * @label: label to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label is a valid label for the f2fs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_f2fs_check_label (const gchar *label, GError **error);
+
+/**
  * bd_fs_nilfs2_mkfs:
  * @device: the device to create a new nilfs fs on
  * @extra: (nullable) (array zero-terminated=1): extra options for the creation (right now

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -420,3 +420,26 @@ gboolean bd_fs_f2fs_resize (const gchar *device, guint64 new_size, gboolean safe
     g_free (size_str);
     return ret;
 }
+
+/**
+ * bd_fs_f2fs_check_label:
+ * @label: label to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label is a valid label for the f2fs file system or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_fs_f2fs_check_label (const gchar *label, GError **error) {
+    size_t len = 0;
+
+    len = strlen (label);
+    if (len > 512) {
+        g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_LABEL_INVALID,
+                     "Label for F2FS filesystem must be at most 512 characters long.");
+        return FALSE;
+    }
+
+    return TRUE;
+}

--- a/src/plugins/fs/f2fs.h
+++ b/src/plugins/fs/f2fs.h
@@ -36,5 +36,6 @@ gboolean bd_fs_f2fs_check (const gchar *device, const BDExtraArg **extra, GError
 gboolean bd_fs_f2fs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 BDFSF2FSInfo* bd_fs_f2fs_get_info (const gchar *device, GError **error);
 gboolean bd_fs_f2fs_resize (const gchar *device, guint64 new_size, gboolean safe, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_f2fs_check_label (const gchar *label, GError **error);
 
 #endif  /* BD_FS_F2FS */

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -999,7 +999,7 @@ static gboolean device_operation (const gchar *device, const gchar *fstype, BDFS
             case BD_FS_LABEL:
                 break;
             case BD_FS_LABEL_CHECK:
-                break;
+                return bd_fs_f2fs_check_label (label, error);
             case BD_FS_UUID:
                 break;
             case BD_FS_UUID_CHECK:

--- a/tests/fs_tests/f2fs_test.py
+++ b/tests/fs_tests/f2fs_test.py
@@ -160,6 +160,12 @@ class F2FSMkfsWithLabel(F2FSTestCase):
     def test_f2fs_mkfs_with_label(self):
         """Verify that it is possible to create an f2fs file system with label"""
 
+        succ = BlockDev.fs_f2fs_check_label("TEST_LABEL")
+        self.assertTrue(succ)
+
+        with self.assertRaisesRegex(GLib.GError, "at most 512 characters long."):
+            BlockDev.fs_f2fs_check_label(513 * "a")
+
         ea = BlockDev.ExtraArg.new("-l", "TEST_LABEL")
         succ = BlockDev.fs_f2fs_mkfs(self.loop_dev, [ea])
         self.assertTrue(succ)


### PR DESCRIPTION
F2FS doesn't support changing the label for existing filesystems but we still want to be able to check the format when using a custom label for mkfs.