### PR TITLE
fs: Add a generic function to check for fs info availability

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -552,6 +552,7 @@ bd_fs_can_repair
 bd_fs_can_set_label
 bd_fs_can_get_size
 bd_fs_can_get_free_space
+bd_fs_can_get_info
 bd_fs_can_set_uuid
 bd_fs_set_uuid
 bd_fs_check_uuid

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1156,6 +1156,23 @@ guint64 bd_fs_get_size (const gchar *device, const gchar *fstype, GError **error
 guint64 bd_fs_get_free_space (const gchar *device, const gchar *fstype, GError **error);
 
 /**
+ * bd_fs_can_get_info:
+ * @type: the filesystem type to be tested for info querying support
+ * @required_utility: (out) (transfer full): the utility binary which is required
+ *                                           for info querying (if missing i.e. return FALSE but no error)
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Searches for the required utility to get info of the given filesystem and
+ * returns whether it is installed.
+ * Unknown filesystems or filesystems which do not support info querying result in errors.
+ *
+ * Returns: whether getting filesystem info is available
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_QUERY
+ */
+gboolean bd_fs_can_get_info (const gchar *type, gchar **required_utility, GError **error);
+
+/**
  * BDFSMkfsOptionsFlags:
  * Flags indicating mkfs options are available for given filesystem type.
  */

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -53,6 +53,7 @@ typedef enum {
     BD_FS_UUID,
     BD_FS_UUID_CHECK,
     BD_FS_GET_FREE_SPACE,
+    BD_FS_GET_INFO,
 } BDFSOpType;
 
 static const BDFSFeatures fs_features[BD_FS_LAST_FS] = {
@@ -1518,6 +1519,10 @@ static gboolean query_fs_operation (const gchar *fs_type, BDFSOpType op, gchar *
             op_name = "Getting free space on";
             exec_util = fsinfo->info_util;
             break;
+        case BD_FS_GET_INFO:
+            op_name = "Getting filesystem info of";
+            exec_util = fsinfo->info_util;
+            break;
         default:
             g_assert_not_reached ();
     }
@@ -1699,6 +1704,25 @@ gboolean bd_fs_can_get_free_space (const gchar *type, gchar **required_utility, 
     }
 
     return query_fs_operation (type, BD_FS_GET_FREE_SPACE, required_utility, NULL, NULL, error);
+}
+
+/**
+ * bd_fs_can_get_info:
+ * @type: the filesystem type to be tested for info querying support
+ * @required_utility: (out) (transfer full): the utility binary which is required
+ *                                           for info querying (if missing i.e. return FALSE but no error)
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Searches for the required utility to get info of the given filesystem and
+ * returns whether it is installed.
+ * Unknown filesystems or filesystems which do not support info querying result in errors.
+ *
+ * Returns: whether getting filesystem info is available
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_QUERY
+ */
+gboolean bd_fs_can_get_info (const gchar *type, gchar **required_utility, GError **error) {
+    return query_fs_operation (type, BD_FS_GET_INFO, required_utility, NULL, NULL, error);
 }
 
 static gboolean fs_freeze (const char *mountpoint, gboolean freeze, GError **error) {

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -91,5 +91,6 @@ gboolean bd_fs_can_set_label (const gchar *type, gchar **required_utility, GErro
 gboolean bd_fs_can_set_uuid (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_get_size (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_get_free_space (const gchar *type, gchar **required_utility, GError **error);
+gboolean bd_fs_can_get_info (const gchar *type, gchar **required_utility, GError **error);
 
 #endif  /* BD_FS_GENERIC */

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -310,6 +310,23 @@ class CanResizeRepairCheckLabel(GenericNoDevTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_can_get_free_space("udf")
 
+    def test_can_get_info(self):
+        """Verify that tooling query works for getting info"""
+
+        avail, util = BlockDev.fs_can_get_free_space("ext4")
+        self.assertTrue(avail)
+        self.assertEqual(util, None)
+
+        old_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = ""
+        avail, util = BlockDev.fs_can_get_free_space("ext4")
+        os.environ["PATH"] = old_path
+        self.assertFalse(avail)
+        self.assertEqual(util, "dumpe2fs")
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.fs_can_get_free_space("non-existing-fs")
+
 
 class GenericMkfs(GenericTestCase):
 


### PR DESCRIPTION
We don't have a generic function to get filesystem info, but it would still be usefull to be able to easily query whether the functionality is available or not. This is similar to the existing can_get_size and can_get_free_space functions, but these can have some other limits in them (e.g. XFS not having the free space information) that can make a difference between "I can query this FS" and "I can get size/free space of this FS".