### PR TITLE
fs: Fix allowed UUID for generic mkfs with VFAT

### DIFF
--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -466,6 +466,9 @@ class GenericMkfs(GenericTestCase):
         label = ""
         self._test_ext_generic_mkfs("vfat", BlockDev.fs_vfat_get_info, label, None, False, extra)
 
+        # now try with UUID
+        self._test_ext_generic_mkfs("vfat", BlockDev.fs_vfat_get_info, None, "2E24-EC82", False, extra)
+
     def test_vfat_generic_mkfs_no_pt(self):
         """ Test generic mkfs with vfat and mbr=no """
 


### PR DESCRIPTION
We allow using UUID with dash in the middle for VFAT in both check and set_uuid so we should allow it also with the generic mkfs calls.