### PR TITLE
fs: Add support for getting filesystem min size for NTFS and Ext

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -546,12 +546,14 @@ bd_fs_set_label
 bd_fs_check_label
 bd_fs_get_size
 bd_fs_get_free_space
+bd_fs_get_min_size
 bd_fs_can_resize
 bd_fs_can_check
 bd_fs_can_repair
 bd_fs_can_set_label
 bd_fs_can_get_size
 bd_fs_can_get_free_space
+bd_fs_can_get_min_size
 bd_fs_can_get_info
 bd_fs_can_set_uuid
 bd_fs_set_uuid
@@ -581,6 +583,7 @@ bd_fs_ext2_set_label
 bd_fs_ext2_check_label
 bd_fs_ext2_set_uuid
 bd_fs_ext2_check_uuid
+bd_fs_ext2_get_min_size
 bd_fs_ext3_check
 bd_fs_ext3_get_info
 bd_fs_ext3_info_copy
@@ -592,6 +595,7 @@ bd_fs_ext3_set_label
 bd_fs_ext3_check_label
 bd_fs_ext3_set_uuid
 bd_fs_ext3_check_uuid
+bd_fs_ext3_get_min_size
 bd_fs_ext4_check
 bd_fs_ext4_get_info
 bd_fs_ext4_info_copy
@@ -603,6 +607,7 @@ bd_fs_ext4_set_label
 bd_fs_ext4_check_label
 bd_fs_ext4_set_uuid
 bd_fs_ext4_check_uuid
+bd_fs_ext4_get_min_size
 BDFSXfsInfo
 bd_fs_xfs_check
 bd_fs_xfs_get_info
@@ -643,6 +648,7 @@ bd_fs_ntfs_info_copy
 bd_fs_ntfs_info_free
 bd_fs_ntfs_set_uuid
 bd_fs_ntfs_check_uuid
+bd_fs_ntfs_get_min_size
 BDFSF2FSInfo
 BDFSF2FSFeature
 bd_fs_f2fs_info_copy

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -1156,6 +1156,22 @@ guint64 bd_fs_get_size (const gchar *device, const gchar *fstype, GError **error
 guint64 bd_fs_get_free_space (const gchar *device, const gchar *fstype, GError **error);
 
 /**
+ * bd_fs_get_min_size:
+ * @device: the device with file system to get minimum size for
+ * @fstype: (nullable): the filesystem type on @device or %NULL to detect
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Get minimum size for filesystem on @device. This calls other fs info functions from this
+ * plugin based on detected filesystem (e.g. bd_fs_ext4_get_min_size for ext4). This
+ * function will return an error for unknown/unsupported filesystems.
+ *
+ * Returns: minimum size of filesystem on @device, 0 in case of error.
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_RESIZE
+ */
+guint64 bd_fs_get_min_size (const gchar *device, const gchar *fstype, GError **error);
+
+/**
  * bd_fs_can_get_info:
  * @type: the filesystem type to be tested for info querying support
  * @required_utility: (out) (transfer full): the utility binary which is required
@@ -1329,6 +1345,23 @@ gboolean bd_fs_can_get_size (const gchar *type, gchar **required_utility, GError
  * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_QUERY
  */
 gboolean bd_fs_can_get_free_space (const gchar *type, gchar **required_utility, GError **error);
+
+/**
+ * bd_fs_can_get_min_size:
+ * @type: the filesystem type to be tested for installed minimum size querying support
+ * @required_utility: (out) (transfer full): the utility binary which is required
+ *                                           for size querying (if missing i.e. return FALSE but no error)
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Searches for the required utility to get minimum size of the given filesystem and
+ * returns whether it is installed.
+ * Unknown filesystems or filesystems which do not support minimum size querying result in errors.
+ *
+ * Returns: whether getting filesystem size is available
+ *
+ * Tech category: %BD_FS_TECH_GENERIC-%BD_FS_TECH_MODE_QUERY
+ */
+gboolean bd_fs_can_get_min_size (const gchar *type, gchar **required_utility, GError **error);
 
 /**
  * bd_fs_mkfs:
@@ -1718,6 +1751,42 @@ gboolean bd_fs_ext3_resize (const gchar *device, guint64 new_size, const BDExtra
 gboolean bd_fs_ext4_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
 
 /**
+ * bd_fs_ext2_get_min_size:
+ * @device: the device containing the file system to get min size for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: smallest shrunken filesystem size as reported by ntfsresize
+ *          in case of error 0 is returned and @error is set
+ *
+ * Tech category: %BD_FS_TECH_EXT2-%BD_FS_TECH_MODE_RESIZE
+ */
+guint64 bd_fs_ext2_get_min_size (const gchar *device, GError **error);
+
+/**
+ * bd_fs_ext3_get_min_size:
+ * @device: the device containing the file system to get min size for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: smallest shrunken filesystem size as reported by ntfsresize
+ *          in case of error 0 is returned and @error is set
+ *
+ * Tech category: %BD_FS_TECH_EXT3-%BD_FS_TECH_MODE_RESIZE
+ */
+guint64 bd_fs_ext3_get_min_size (const gchar *device, GError **error);
+
+/**
+ * bd_fs_ext4_get_min_size:
+ * @device: the device containing the file system to get min size for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: smallest shrunken filesystem size as reported by ntfsresize
+ *          in case of error 0 is returned and @error is set
+ *
+ * Tech category: %BD_FS_TECH_EXT4-%BD_FS_TECH_MODE_RESIZE
+ */
+guint64 bd_fs_ext4_get_min_size (const gchar *device, GError **error);
+
+/**
  * bd_fs_xfs_mkfs:
  * @device: the device to create a new xfs fs on
  * @extra: (nullable) (array zero-terminated=1): extra options for the creation (right now
@@ -2063,6 +2132,18 @@ gboolean bd_fs_ntfs_resize (const gchar *device, guint64 new_size, GError **erro
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_QUERY
  */
 BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error);
+
+/**
+ * bd_fs_ntfs_get_min_size:
+ * @device: the device containing the file system to get min size for
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: smallest shrunken filesystem size as reported by ntfsresize
+ *          in case of error 0 is returned and @error is set
+ *
+ * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_RESIZE
+ */
+guint64 bd_fs_ntfs_get_min_size (const gchar *device, GError **error);
 
 /**
  * bd_fs_f2fs_mkfs:

--- a/src/plugins/fs/ext.h
+++ b/src/plugins/fs/ext.h
@@ -35,6 +35,7 @@ gboolean bd_fs_ext2_set_uuid (const gchar *device, const gchar *uuid, GError **e
 gboolean bd_fs_ext2_check_uuid (const gchar *uuid, GError **error);
 BDFSExt2Info* bd_fs_ext2_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ext2_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
+guint64 bd_fs_ext2_get_min_size (const gchar *device, GError **error);
 
 gboolean bd_fs_ext3_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext3_check (const gchar *device, const BDExtraArg **extra, GError **error);
@@ -45,6 +46,7 @@ gboolean bd_fs_ext3_set_label (const gchar *device, const gchar *label, GError *
 gboolean bd_fs_ext3_check_label (const gchar *label, GError **error);
 BDFSExt3Info* bd_fs_ext3_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ext3_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
+guint64 bd_fs_ext3_get_min_size (const gchar *device, GError **error);
 
 gboolean bd_fs_ext4_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_fs_ext4_check (const gchar *device, const BDExtraArg **extra, GError **error);
@@ -55,5 +57,6 @@ gboolean bd_fs_ext4_set_uuid (const gchar *device, const gchar *uuid, GError **e
 gboolean bd_fs_ext4_check_uuid (const gchar *uuid, GError **error);
 BDFSExt4Info* bd_fs_ext4_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ext4_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
+guint64 bd_fs_ext4_get_min_size (const gchar *device, GError **error);
 
 #endif  /* BD_FS_EXT */

--- a/src/plugins/fs/generic.h
+++ b/src/plugins/fs/generic.h
@@ -45,6 +45,7 @@ gboolean bd_fs_set_uuid (const gchar *device, const gchar *uuid, const gchar *fs
 gboolean bd_fs_check_uuid (const gchar *fstype, const gchar *uuid, GError **error);
 guint64 bd_fs_get_size (const gchar *device, const gchar *fstype, GError **error);
 guint64 bd_fs_get_free_space (const gchar *device, const gchar *fstype, GError **error);
+guint64 bd_fs_get_min_size (const gchar *device, const gchar *fstype, GError **error);
 
 typedef enum {
     BD_FS_OFFLINE_SHRINK = 1 << 1,
@@ -92,5 +93,6 @@ gboolean bd_fs_can_set_uuid (const gchar *type, gchar **required_utility, GError
 gboolean bd_fs_can_get_size (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_get_free_space (const gchar *type, gchar **required_utility, GError **error);
 gboolean bd_fs_can_get_info (const gchar *type, gchar **required_utility, GError **error);
+gboolean bd_fs_can_get_min_size (const gchar *type, gchar **required_utility, GError **error);
 
 #endif  /* BD_FS_GENERIC */

--- a/src/plugins/fs/ntfs.h
+++ b/src/plugins/fs/ntfs.h
@@ -23,5 +23,6 @@ gboolean bd_fs_ntfs_set_uuid (const gchar *device, const gchar *uuid, GError **e
 gboolean bd_fs_ntfs_check_uuid ( const gchar *uuid, GError **error);
 BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error);
 gboolean bd_fs_ntfs_resize (const gchar *device, guint64 new_size, GError **error);
+guint64 bd_fs_ntfs_get_min_size (const gchar *device, GError **error);
 
 #endif  /* BD_FS_NTFS */

--- a/tests/fs_tests/ext_test.py
+++ b/tests/fs_tests/ext_test.py
@@ -336,7 +336,7 @@ class ExtSetLabel(ExtTestCase):
 
 
 class ExtResize(ExtTestCase):
-    def _test_ext_resize(self, mkfs_function, info_function, resize_function):
+    def _test_ext_resize(self, mkfs_function, info_function, resize_function, minsize_function):
         succ = mkfs_function(self.loop_dev, None)
         self.assertTrue(succ)
 
@@ -382,23 +382,33 @@ class ExtResize(ExtTestCase):
         # at least 90 % should be available, so it should be reported
         self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
+        # get min size and resize to it
+        size = minsize_function(self.loop_dev)
+        self.assertNotEqual(size, 0)
+
+        succ = resize_function(self.loop_dev, size)
+        self.assertTrue(succ)
+
     def test_ext2_resize(self):
         """Verify that it is possible to resize an ext2 file system"""
         self._test_ext_resize(mkfs_function=BlockDev.fs_ext2_mkfs,
                               info_function=BlockDev.fs_ext2_get_info,
-                              resize_function=BlockDev.fs_ext2_resize)
+                              resize_function=BlockDev.fs_ext2_resize,
+                              minsize_function=BlockDev.fs_ext2_get_min_size)
 
     def test_ext3_resize(self):
         """Verify that it is possible to resize an ext3 file system"""
         self._test_ext_resize(mkfs_function=BlockDev.fs_ext3_mkfs,
                               info_function=BlockDev.fs_ext3_get_info,
-                              resize_function=BlockDev.fs_ext3_resize)
+                              resize_function=BlockDev.fs_ext3_resize,
+                              minsize_function=BlockDev.fs_ext3_get_min_size)
 
     def test_ext4_resize(self):
         """Verify that it is possible to resize an ext4 file system"""
         self._test_ext_resize(mkfs_function=BlockDev.fs_ext4_mkfs,
                               info_function=BlockDev.fs_ext4_get_info,
-                              resize_function=BlockDev.fs_ext4_resize)
+                              resize_function=BlockDev.fs_ext4_resize,
+                              minsize_function=BlockDev.fs_ext4_get_min_size)
 
 
 class ExtSetUUID(ExtTestCase):

--- a/tests/fs_tests/ntfs_test.py
+++ b/tests/fs_tests/ntfs_test.py
@@ -173,6 +173,16 @@ class NTFSResize(NTFSTestCase):
         succ = BlockDev.fs_ntfs_resize(self.loop_dev, 0)
         self.assertTrue(succ)
 
+        succ = BlockDev.fs_ntfs_repair(self.loop_dev)
+        self.assertTrue(succ)
+
+        # get min size and resize to it
+        size = BlockDev.fs_ntfs_get_min_size(self.loop_dev)
+        self.assertNotEqual(size, 0)
+
+        succ = BlockDev.fs_ntfs_resize(self.loop_dev, size)
+        self.assertTrue(succ)
+
 
 class NTFSSetLabel(NTFSTestCase):
     def test_ntfs_set_label(self):


### PR DESCRIPTION
For NTFS and Ext we can get a filesystem minimum size estimate using the resize tools. Blivet is currently using this to get filesystem min size for resize and the resize tools return slightly different number than what we get from the dump/info tools.