### PR TITLE
part: Fix potential double free when getting parttype

### DIFF
--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -462,7 +462,6 @@ static gchar* get_part_type_guid_and_gpt_flags (const gchar *device, int part_nu
     if (!ptype_string) {
         g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_FAIL,
                      "Failed to get partition type for partition %d on device '%s'", part_num, device);
-        fdisk_unref_parttype (ptype);
         fdisk_unref_partition (pa);
         close_context (cxt);
         return NULL;
@@ -470,7 +469,6 @@ static gchar* get_part_type_guid_and_gpt_flags (const gchar *device, int part_nu
 
     ret = g_strdup (ptype_string);
 
-    fdisk_unref_parttype (ptype);
     fdisk_unref_partition (pa);
     close_context (cxt);
     return ret;


### PR DESCRIPTION
fdisk_partition_get_type returns a pointer to a static table so we shouldn't free it. fdisk_unref_parttype should against this but we see some double free crashes that could be caused by this.

Related: https://github.com/storaged-project/udisks/issues/1208