### PR TITLE
tests: Use BDPluginSpec constructor in LVM DBus plugin tests

### DIFF
--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -36,9 +36,7 @@ class LVMTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        ps = BlockDev.PluginSpec()
-        ps.name = BlockDev.Plugin.LVM
-        ps.so_name = "libbd_lvm.so.3"
+        ps = BlockDev.PluginSpec(name=BlockDev.Plugin.LVM, so_name="libbd_lvm.so.3")
         cls.requested_plugins = [ps]
 
         if not BlockDev.is_initialized():


### PR DESCRIPTION
Follow up for #973, I forgot to fix the BDPluginSpec construction for LVM DBus test cases.