### PR TITLE
fs: Report reason for open() and ioctl() failures

### DIFF
--- a/src/plugins/fs/common.c
+++ b/src/plugins/fs/common.c
@@ -24,6 +24,7 @@
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>
+#include <errno.h>
 #include <uuid.h>
 
 #include <blockdev/utils.h>
@@ -58,7 +59,8 @@ get_uuid_label (const gchar *device, gchar **uuid, gchar **label, GError **error
     fd = open (device, O_RDONLY|O_CLOEXEC);
     if (fd == -1) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                     "Failed to create a probe for the device '%s'", device);
+                     "Failed to create a probe for the device '%s': %s",
+                     device, strerror_l (errno, _C_LOCALE));
         blkid_free_probe (probe);
         return FALSE;
     }

--- a/src/plugins/fs/common.h
+++ b/src/plugins/fs/common.h
@@ -4,6 +4,9 @@
 #ifndef BD_FS_COMMON
 #define BD_FS_COMMON
 
+/* "C" locale to get the locale-agnostic error messages */
+#define _C_LOCALE (locale_t) 0
+
 gint synced_close (gint fd);
 gboolean get_uuid_label (const gchar *device, gchar **uuid, gchar **label, GError **error);
 gboolean check_uuid (const gchar *uuid, GError **error);

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -26,6 +26,7 @@
 #include <sys/ioctl.h>
 #include <linux/fs.h>
 #include <fcntl.h>
+#include <errno.h>
 
 #include <blockdev/utils.h>
 
@@ -390,7 +391,8 @@ gboolean bd_fs_wipe (const gchar *device, gboolean all, gboolean force, GError *
     fd = open (device, mode);
     if (fd == -1) {
         g_set_error (&l_error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                     "Failed to open the device '%s'", device);
+                     "Failed to open the device '%s': %s",
+                     device, strerror_l (errno, _C_LOCALE));
         blkid_free_probe (probe);
         bd_utils_report_finished (progress_id, l_error->message);
         g_propagate_error (error, l_error);
@@ -548,7 +550,8 @@ gchar* bd_fs_get_fstype (const gchar *device,  GError **error) {
     fd = open (device, O_RDONLY|O_CLOEXEC);
     if (fd == -1) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                     "Failed to open the device '%s'", device);
+                     "Failed to open the device '%s': %s",
+                     device, strerror_l (errno, _C_LOCALE));
         blkid_free_probe (probe);
         return NULL;
     }
@@ -1829,7 +1832,8 @@ static gboolean fs_freeze (const char *mountpoint, gboolean freeze, GError **err
     fd = open (mountpoint, O_RDONLY);
     if (fd == -1) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                     "Failed to open the mountpoint '%s'", mountpoint);
+                     "Failed to open the mountpoint '%s': %s",
+                     mountpoint, strerror_l (errno, _C_LOCALE));
         return FALSE;
     }
 
@@ -1840,7 +1844,9 @@ static gboolean fs_freeze (const char *mountpoint, gboolean freeze, GError **err
 
     if (status != 0) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                     "Failed to %s '%s': %m.", freeze ? "freeze" : "unfreeze", mountpoint);
+                     "Failed to %s '%s': %s.",
+                     freeze ? "freeze" : "unfreeze", mountpoint,
+                     strerror_l (errno, _C_LOCALE));
         close (fd);
         return FALSE;
     }

--- a/src/plugins/fs/udf.c
+++ b/src/plugins/fs/udf.c
@@ -22,6 +22,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <string.h>
+#include <errno.h>
 #include <sys/ioctl.h>
 #include <linux/fs.h>
 
@@ -206,13 +208,15 @@ static gint get_blocksize (const gchar *device, GError **error) {
     fd = open (device, O_RDONLY);
     if (fd < 0) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                    "Failed to open the device '%s' to get its block size", device);
+                    "Failed to open the device '%s' to get its block size: %s",
+                    device, strerror_l (errno, _C_LOCALE));
         return -1;
     }
 
     if (ioctl (fd, BLKSSZGET, &blksize) < 0) {
         g_set_error (error, BD_FS_ERROR, BD_FS_ERROR_FAIL,
-                     "Failed to get block size of the device '%s'", device);
+                     "Failed to get block size of the device '%s': %s",
+                     device, strerror_l (errno, _C_LOCALE));
         close (fd);
         return -1;
     }


### PR DESCRIPTION
Simply by including a verbose strerror() representation. I find it useful in some cases.