### PR TITLE
Move UNUSED definition to common header utils.h

### DIFF
--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -154,7 +154,6 @@ void bd_btrfs_close (void) {
 }
 
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_btrfs_is_tech_avail:
@@ -165,7 +164,7 @@ void bd_btrfs_close (void) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_btrfs_is_tech_avail (BDBtrfsTech tech UNUSED, guint64 mode UNUSED, GError **error) {
+gboolean bd_btrfs_is_tech_avail (BDBtrfsTech tech G_GNUC_UNUSED, guint64 mode G_GNUC_UNUSED, GError **error) {
     /* all tech-mode combinations are supported by this implementation of the plugin */
     return check_deps (&avail_deps, DEPS_BTRFS_MASK, deps, DEPS_LAST, &deps_check_lock, error) &&
            check_module_deps (&avail_module_deps, MODULE_DEPS_BTRFS_MASK, module_deps, MODULE_DEPS_LAST, &deps_check_lock, error);

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -60,7 +60,6 @@
 #define DEFAULT_LUKS2_SECTOR_SIZE 512
 #endif
 
-#define UNUSED __attribute__((unused))
 
 /**
  * SECTION: crypto
@@ -304,7 +303,7 @@ BDCryptoLUKSTokenInfo* bd_crypto_luks_token_info_copy (BDCryptoLUKSTokenInfo *in
 /* "C" locale to get the locale-agnostic error messages */
 static locale_t c_locale = (locale_t) 0;
 
-static void crypto_log_redirect (gint level, const gchar *msg, void *usrptr UNUSED) {
+static void crypto_log_redirect (gint level, const gchar *msg, void *usrptr G_GNUC_UNUSED) {
     gchar *message = NULL;
 
     switch (level) {
@@ -465,7 +464,7 @@ GQuark bd_crypto_error_quark (void)
  *
  * Tech category: always available
  */
-gchar* bd_crypto_generate_backup_passphrase (GError **error UNUSED) {
+gchar* bd_crypto_generate_backup_passphrase (GError **error G_GNUC_UNUSED) {
     guint8 i = 0;
     guint8 offset = 0;
     guint8 charset_length = strlen (BD_CRYPTO_BACKUP_PASSPHRASE_CHARSET);
@@ -833,7 +832,7 @@ BDCryptoKeyslotContext* bd_crypto_keyslot_context_new_passphrase (const guint8 *
  *
  * Tech category: always available
  */
-BDCryptoKeyslotContext* bd_crypto_keyslot_context_new_keyfile (const gchar *keyfile, guint64 keyfile_offset, gsize key_size, GError **error UNUSED) {
+BDCryptoKeyslotContext* bd_crypto_keyslot_context_new_keyfile (const gchar *keyfile, guint64 keyfile_offset, gsize key_size, GError **error G_GNUC_UNUSED) {
     BDCryptoKeyslotContext *context = NULL;
 
     context = g_new0 (BDCryptoKeyslotContext, 1);
@@ -860,7 +859,7 @@ BDCryptoKeyslotContext* bd_crypto_keyslot_context_new_keyfile (const gchar *keyf
  *
  * Tech category: always available
  */
-BDCryptoKeyslotContext* bd_crypto_keyslot_context_new_keyring (const gchar *key_desc, GError **error UNUSED) {
+BDCryptoKeyslotContext* bd_crypto_keyslot_context_new_keyring (const gchar *key_desc, GError **error G_GNUC_UNUSED) {
     BDCryptoKeyslotContext *context = NULL;
 
     context = g_new0 (BDCryptoKeyslotContext, 1);
@@ -2392,7 +2391,7 @@ BDCryptoIntegrityInfo* bd_crypto_integrity_info (const gchar *device, GError **e
 
 /* added in cryptsetup 2.4.0 */
 #ifndef LIBCRYPTSETUP_24
-static int crypt_token_max (const char *type UNUSED) {
+static int crypt_token_max (const char *type G_GNUC_UNUSED) {
     return 32;
 }
 #endif
@@ -2941,11 +2940,11 @@ gboolean bd_crypto_tc_close (const gchar *tc_device, GError **error) {
 }
 
 #ifdef WITH_BD_ESCROW
-static gchar *always_fail_cb (gpointer data UNUSED, const gchar *prompt UNUSED, int echo UNUSED) {
+static gchar *always_fail_cb (gpointer data G_GNUC_UNUSED, const gchar *prompt G_GNUC_UNUSED, int echo G_GNUC_UNUSED) {
     return NULL;
 }
 
-static gchar *give_passphrase_cb (gpointer data, const gchar *prompt UNUSED, unsigned failed_attempts) {
+static gchar *give_passphrase_cb (gpointer data, const gchar *prompt G_GNUC_UNUSED, unsigned failed_attempts) {
     if (failed_attempts == 0)
         /* Return a copy of the passphrase that will be freed by volume_key */
         return g_strdup (data);
@@ -3046,7 +3045,8 @@ static gboolean write_escrow_data_file (struct libvk_volume *volume, struct libv
  * Tech category: %BD_CRYPTO_TECH_ESCROW-%BD_CRYPTO_TECH_MODE_CREATE
  */
 #ifndef WITH_BD_ESCROW
-gboolean bd_crypto_escrow_device (const gchar *device UNUSED, const gchar *passphrase UNUSED, const gchar *cert_data UNUSED, const gchar *directory UNUSED, const gchar *backup_passphrase UNUSED, GError **error) {
+gboolean bd_crypto_escrow_device (const gchar *device G_GNUC_UNUSED, const gchar *passphrase G_GNUC_UNUSED,const gchar *cert_data G_GNUC_UNUSED,
+                                  const gchar *directory G_GNUC_UNUSED, const gchar *backup_passphrase G_GNUC_UNUSED, GError **error) {
     /* this will return FALSE and set error, because escrow technology is not available */
     return bd_crypto_is_tech_avail (BD_CRYPTO_TECH_ESCROW, BD_CRYPTO_TECH_MODE_CREATE, error);
 }
@@ -3307,7 +3307,8 @@ gboolean bd_crypto_bitlk_close (const gchar *bitlk_device, GError **error) {
  * Tech category: %BD_CRYPTO_TECH_FVAULT2-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
  */
 #ifndef LIBCRYPTSETUP_26
-gboolean bd_crypto_fvault2_open (const gchar *device UNUSED, const gchar *name UNUSED, BDCryptoKeyslotContext *context UNUSED, gboolean read_only UNUSED, GError **error) {
+gboolean bd_crypto_fvault2_open (const gchar *device G_GNUC_UNUSED, const gchar *name G_GNUC_UNUSED, BDCryptoKeyslotContext *context G_GNUC_UNUSED,
+                                 gboolean read_only G_GNUC_UNUSED, GError **error) {
     /* this will return FALSE and set error, because FVAULT2 technology is not available */
     return bd_crypto_is_tech_avail (BD_CRYPTO_TECH_FVAULT2, BD_CRYPTO_TECH_MODE_OPEN_CLOSE, error);
 #else
@@ -3401,7 +3402,7 @@ gboolean bd_crypto_fvault2_open (const gchar *device, const gchar *name, BDCrypt
  * Tech category: %BD_CRYPTO_TECH_FVAULT2-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
  */
 #ifndef LIBCRYPTSETUP_26
-gboolean bd_crypto_fvault2_close (const gchar *fvault2_device UNUSED, GError **error) {
+gboolean bd_crypto_fvault2_close (const gchar *fvault2_device G_GNUC_UNUSED, GError **error) {
     /* this will return FALSE and set error, because FVAULT2 technology is not available */
     return bd_crypto_is_tech_avail (BD_CRYPTO_TECH_FVAULT2, BD_CRYPTO_TECH_MODE_OPEN_CLOSE, error);
 }

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -30,7 +30,6 @@
 
 #define DM_MIN_VERSION "1.02.93"
 
-#define UNUSED __attribute__((unused))
 
 /**
  * SECTION: dm
@@ -100,7 +99,7 @@ void bd_dm_close (void) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_dm_is_tech_avail (BDDMTech tech, guint64 mode UNUSED, GError **error) {
+gboolean bd_dm_is_tech_avail (BDDMTech tech, guint64 mode G_GNUC_UNUSED, GError **error) {
     /* all combinations are supported by this implementation of the plugin, but
        BD_DM_TECH_MAP requires the 'dmsetup' utility */
     switch (tech) {

--- a/src/plugins/fs/btrfs.c
+++ b/src/plugins/fs/btrfs.c
@@ -57,7 +57,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_BTRFSTUNE_MASK,    /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_fs_btrfs_is_tech_avail:
@@ -69,7 +68,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_btrfs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_btrfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/exfat.c
+++ b/src/plugins/fs/exfat.c
@@ -63,7 +63,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
 #define CLUSTERS_PREFIX_LEN 25
 
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_fs_exfat_is_tech_avail:
@@ -75,7 +74,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_exfat_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_exfat_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -63,7 +63,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_TUNE2FS_MASK       /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 static gint8 compute_percents (guint8 pass_cur, guint8 pass_total, gint val_cur, gint val_total) {
     gint perc;
@@ -157,7 +156,7 @@ static gboolean extract_e2fsck_progress (const gchar *line, guint8 *completion) 
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_ext_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_ext_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
     for (i = 0; i <= BD_FS_MODE_LAST; i++)

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -70,7 +70,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     0                       /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 /* option to get version was added in 1.11.0 so we need to cover situation
    where the version is too old to check the version */
@@ -110,7 +109,7 @@ static gboolean can_check_f2fs_version (UtilDep dep, GError **error) {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_f2fs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_f2fs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/generic.c
+++ b/src/plugins/fs/generic.c
@@ -40,7 +40,6 @@
 #include "ntfs.h"
 #include "f2fs.h"
 
-#define UNUSED __attribute__((unused))
 
 
 typedef enum {
@@ -305,7 +304,7 @@ const BDFSInfo fs_info[BD_FS_LAST_FS] = {
  *
  * Tech category: always available
  */
-const gchar** bd_fs_supported_filesystems (GError **error UNUSED) {
+const gchar** bd_fs_supported_filesystems (GError **error G_GNUC_UNUSED) {
     const gchar **filesystems = g_new0 (const gchar *, BD_FS_LAST_FS - BD_FS_OFFSET + 1);
     gint i = 0;
 

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -54,7 +54,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_NILFSTUNE_MASK,        /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 #ifdef __clang__
 #define ZERO_INIT {}
@@ -72,7 +71,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_nilfs2_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_nilfs2_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -61,7 +61,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_NTFSLABEL_MASK     /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_fs_ntfs_is_tech_avail:
@@ -73,7 +72,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_ntfs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_ntfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
     for (i = 0; i <= BD_FS_MODE_LAST; i++)

--- a/src/plugins/fs/udf.c
+++ b/src/plugins/fs/udf.c
@@ -60,7 +60,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_UDFLABEL_MASK,     /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_fs_udf_is_tech_avail:
@@ -72,7 +71,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_udf_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_udf_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -63,7 +63,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_FATLABELUUID_MASK, /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 #ifdef __clang__
 #define ZERO_INIT {}
@@ -81,7 +80,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_vfat_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_vfat_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
 

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -61,7 +61,6 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
     DEPS_XFS_ADMIN_MASK     /* set-uuid */
 };
 
-#define UNUSED __attribute__((unused))
 
 #ifdef __clang__
 #define ZERO_INIT {}
@@ -79,7 +78,7 @@ static guint32 fs_mode_util[BD_FS_MODE_LAST+1] = {
  *          plugin implementation and having all the runtime dependencies available
  */
 gboolean __attribute__ ((visibility ("hidden")))
-bd_fs_xfs_is_tech_avail (BDFSTech tech UNUSED, guint64 mode, GError **error) {
+bd_fs_xfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 required = 0;
     guint i = 0;
     for (i = 0; i <= BD_FS_MODE_LAST; i++)

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -75,7 +75,6 @@ void bd_loop_close (void) {
     /* nothing to do here */
 }
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_loop_is_tech_avail:
@@ -86,7 +85,7 @@ void bd_loop_close (void) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_loop_is_tech_avail (BDLoopTech tech UNUSED, guint64 mode UNUSED, GError **error UNUSED) {
+gboolean bd_loop_is_tech_avail (BDLoopTech tech G_GNUC_UNUSED, guint64 mode G_GNUC_UNUSED, GError **error G_GNUC_UNUSED) {
     /* all combinations are supported by this implementation of the plugin */
     return TRUE;
 }
@@ -206,7 +205,7 @@ BDLoopInfo* bd_loop_info (const gchar *loop, GError **error) {
  *
  * Tech category: %BD_LOOP_TECH_LOOP-%BD_LOOP_TECH_MODE_QUERY
  */
-gchar* bd_loop_get_loop_name (const gchar *file, GError **error UNUSED) {
+gchar* bd_loop_get_loop_name (const gchar *file, GError **error G_GNUC_UNUSED) {
     glob_t globbuf;
     gchar **path_p;
     gboolean success = FALSE;

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -97,7 +97,6 @@ static gchar *global_devices_str = NULL;
 #define METHOD_CALL_TIMEOUT 5000
 #define PROGRESS_WAIT 500 * 1000 /* microseconds */
 
-#define UNUSED __attribute__((unused))
 
 static GDBusConnection *bus = NULL;
 
@@ -1025,7 +1024,7 @@ static GVariant* get_vdo_properties (const gchar *vg_name, const gchar *pool_nam
     return ret;
 }
 
-static BDLVMPVdata* get_pv_data_from_props (GVariant *props, GError **error UNUSED) {
+static BDLVMPVdata* get_pv_data_from_props (GVariant *props, GError **error G_GNUC_UNUSED) {
     BDLVMPVdata *data = g_new0 (BDLVMPVdata, 1);
     GVariantDict dict;
     gchar *path = NULL;
@@ -1091,7 +1090,7 @@ static BDLVMPVdata* get_pv_data_from_props (GVariant *props, GError **error UNUS
     return data;
 }
 
-static BDLVMVGdata* get_vg_data_from_props (GVariant *props, GError **error UNUSED) {
+static BDLVMVGdata* get_vg_data_from_props (GVariant *props, GError **error G_GNUC_UNUSED) {
     BDLVMVGdata *data = g_new0 (BDLVMVGdata, 1);
     GVariantDict dict;
     GVariant *value = NULL;
@@ -1334,7 +1333,7 @@ static void _lvm_data_and_metadata_lvs (const gchar *vg_name, const gchar *lv_na
   return;
 }
 
-static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error UNUSED) {
+static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error G_GNUC_UNUSED) {
     BDLVMLVdata *data = g_new0 (BDLVMLVdata, 1);
     GVariantDict dict;
     GVariant *value = NULL;
@@ -1429,7 +1428,7 @@ static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error UNUS
     return data;
 }
 
-static BDLVMVDOPooldata* get_vdo_data_from_props (GVariant *props, GError **error UNUSED) {
+static BDLVMVDOPooldata* get_vdo_data_from_props (GVariant *props, GError **error G_GNUC_UNUSED) {
     BDLVMVDOPooldata *data = g_new0 (BDLVMVDOPooldata, 1);
     GVariantDict dict;
     gchar *value = NULL;
@@ -1539,7 +1538,7 @@ static GVariant* create_size_str_param (guint64 size, const gchar *unit) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error UNUSED) {
+gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error G_GNUC_UNUSED) {
     return (((size % 2) == 0) && (size >= (MIN_PE_SIZE)) && (size <= (MAX_PE_SIZE)));
 }
 
@@ -1551,7 +1550,7 @@ gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-guint64 *bd_lvm_get_supported_pe_sizes (GError **error UNUSED) {
+guint64 *bd_lvm_get_supported_pe_sizes (GError **error G_GNUC_UNUSED) {
     guint8 i;
     guint64 val = MIN_PE_SIZE;
     guint8 num_items = ((guint8) round (log2 ((double) MAX_PE_SIZE))) - ((guint8) round (log2 ((double) MIN_PE_SIZE))) + 2;
@@ -1573,7 +1572,7 @@ guint64 *bd_lvm_get_supported_pe_sizes (GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_get_max_lv_size (GError **error UNUSED) {
+guint64 bd_lvm_get_max_lv_size (GError **error G_GNUC_UNUSED) {
     return MAX_LV_SIZE;
 }
 
@@ -1593,7 +1592,7 @@ guint64 bd_lvm_get_max_lv_size (GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error UNUSED) {
+guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error G_GNUC_UNUSED) {
     pe_size = RESOLVE_PE_SIZE (pe_size);
     guint64 delta = size % pe_size;
     if (delta == 0)
@@ -1637,7 +1636,7 @@ guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size, GError **
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included, GError **error UNUSED) {
+guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included, GError **error G_GNUC_UNUSED) {
     guint64 raw_md_size;
     pe_size = RESOLVE_PE_SIZE (pe_size);
 
@@ -1664,7 +1663,7 @@ guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean inclu
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots UNUSED, GError **error UNUSED) {
+guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots G_GNUC_UNUSED, GError **error G_GNUC_UNUSED) {
     guint64 md_size = 0;
 
     /* based on lvcreate metadata size calculation */
@@ -1687,7 +1686,7 @@ guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error UNUSED) {
+gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error G_GNUC_UNUSED) {
     return ((MIN_THPOOL_MD_SIZE <= size) && (size <= MAX_THPOOL_MD_SIZE));
 }
 
@@ -1701,7 +1700,7 @@ gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error UNUSED) {
+gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error G_GNUC_UNUSED) {
     gdouble size_log2 = 0.0;
 
     if ((size < MIN_THPOOL_CHUNK_SIZE) || (size > MAX_THPOOL_CHUNK_SIZE))
@@ -2700,7 +2699,8 @@ gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 si
  *
  * Tech category: %BD_LVM_TECH_BASIC-%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_lvrepair (const gchar *vg_name UNUSED, const gchar *lv_name UNUSED, const gchar **pv_list UNUSED, const BDExtraArg **extra UNUSED, GError **error) {
+gboolean bd_lvm_lvrepair (const gchar *vg_name G_GNUC_UNUSED, const gchar *lv_name G_GNUC_UNUSED, const gchar **pv_list G_GNUC_UNUSED,
+                          const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
   g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_TECH_UNAVAIL,
                "lvrepair is not supported by this plugin implementation.");
   return FALSE;
@@ -3420,7 +3420,7 @@ gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name
  *
  * Tech category: %BD_LVM_TECH_GLOB_CONF no mode (it is ignored)
  */
-gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error UNUSED) {
+gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error G_GNUC_UNUSED) {
     /* XXX: the error attribute will likely be used in the future when
        some validation comes into the game */
 
@@ -3448,7 +3448,7 @@ gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error UNUSE
  *
  * Tech category: %BD_LVM_TECH_GLOB_CONF no mode (it is ignored)
  */
-gchar* bd_lvm_get_global_config (GError **error UNUSED) {
+gchar* bd_lvm_get_global_config (GError **error G_GNUC_UNUSED) {
     gchar *ret = NULL;
 
     g_mutex_lock (&global_config_lock);
@@ -3495,7 +3495,7 @@ gboolean bd_lvm_set_devices_filter (const gchar **devices, GError **error) {
  *
  * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
  */
-gchar** bd_lvm_get_devices_filter (GError **error UNUSED) {
+gchar** bd_lvm_get_devices_filter (GError **error G_GNUC_UNUSED) {
     gchar **ret = NULL;
 
     g_mutex_lock (&global_config_lock);
@@ -3519,7 +3519,7 @@ gchar** bd_lvm_get_devices_filter (GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CACHE_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error UNUSED) {
+guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error G_GNUC_UNUSED) {
     return MAX ((guint64) cache_size / 1000, MIN_CACHE_MD_SIZE);
 }
 
@@ -3529,7 +3529,7 @@ guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error UNU
  *
  * Get LV type string from flags.
  */
-static const gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error UNUSED) {
+static const gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error G_GNUC_UNUSED) {
     if (!meta) {
         if (flags & BD_LVM_CACHE_POOL_STRIPED)
             return "striped";
@@ -4509,7 +4509,10 @@ gboolean bd_lvm_vdo_pool_resize (const gchar *vg_name, const gchar *pool_name, g
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_CREATE&%BD_LVM_TECH_MODE_MODIFY
  */
-gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name UNUSED, const gchar *pool_lv UNUSED, const gchar *name UNUSED, guint64 virtual_size UNUSED, guint64 index_memory UNUSED, gboolean compression UNUSED, gboolean deduplication UNUSED, BDLVMVDOWritePolicy write_policy UNUSED, const BDExtraArg **extra UNUSED, GError **error) {
+gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name G_GNUC_UNUSED, const gchar *pool_lv G_GNUC_UNUSED, const gchar *name G_GNUC_UNUSED,
+                                  guint64 virtual_size G_GNUC_UNUSED, guint64 index_memory G_GNUC_UNUSED, gboolean compression G_GNUC_UNUSED,
+                                  gboolean deduplication G_GNUC_UNUSED, BDLVMVDOWritePolicy write_policy G_GNUC_UNUSED,
+                                  const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
     return bd_lvm_is_tech_avail (BD_LVM_TECH_VDO, BD_LVM_TECH_MODE_CREATE | BD_LVM_TECH_MODE_MODIFY, error);
 }
 

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -331,7 +331,6 @@ static const UtilFeatureDep features[FEATURES_LAST] = {
 
 static const gchar*const module_deps[MODULE_DEPS_LAST] = { "kvdo" };
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_lvm_init:
@@ -916,7 +915,7 @@ static BDLVMVDOPooldata* get_vdo_data_from_table (GHashTable *table, gboolean fr
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error UNUSED) {
+gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error G_GNUC_UNUSED) {
     return (((size % 2) == 0) && (size >= (MIN_PE_SIZE)) && (size <= (MAX_PE_SIZE)));
 }
 
@@ -928,7 +927,7 @@ gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-guint64 *bd_lvm_get_supported_pe_sizes (GError **error UNUSED) {
+guint64 *bd_lvm_get_supported_pe_sizes (GError **error G_GNUC_UNUSED) {
     guint8 i;
     guint64 val = MIN_PE_SIZE;
     guint8 num_items = ((guint8) round (log2 ((double) MAX_PE_SIZE))) - ((guint8) round (log2 ((double) MIN_PE_SIZE))) + 2;
@@ -950,7 +949,7 @@ guint64 *bd_lvm_get_supported_pe_sizes (GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_get_max_lv_size (GError **error UNUSED) {
+guint64 bd_lvm_get_max_lv_size (GError **error G_GNUC_UNUSED) {
     return MAX_LV_SIZE;
 }
 
@@ -970,7 +969,7 @@ guint64 bd_lvm_get_max_lv_size (GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error UNUSED) {
+guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error G_GNUC_UNUSED) {
     pe_size = RESOLVE_PE_SIZE (pe_size);
     guint64 delta = size % pe_size;
     if (delta == 0)
@@ -1041,7 +1040,7 @@ guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean inclu
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots UNUSED, GError **error UNUSED) {
+guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots G_GNUC_UNUSED, GError **error G_GNUC_UNUSED) {
     guint64 md_size = 0;
 
     /* based on lvcreate metadata size calculation */
@@ -1064,7 +1063,7 @@ guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error UNUSED) {
+gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error G_GNUC_UNUSED) {
     return ((MIN_THPOOL_MD_SIZE <= size) && (size <= MAX_THPOOL_MD_SIZE));
 }
 
@@ -1078,7 +1077,7 @@ gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_THIN_CALCS no mode (it is ignored)
  */
-gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error UNUSED) {
+gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error G_GNUC_UNUSED) {
     gdouble size_log2 = 0.0;
 
     if ((size < MIN_THPOOL_CHUNK_SIZE) || (size > MAX_THPOOL_CHUNK_SIZE))
@@ -2546,7 +2545,7 @@ gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name
  *
  * Tech category: %BD_LVM_TECH_GLOB_CONF no mode (it is ignored)
  */
-gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error UNUSED) {
+gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error G_GNUC_UNUSED) {
     /* XXX: the error attribute will likely be used in the future when
        some validation comes into the game */
 
@@ -2574,7 +2573,7 @@ gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error UNUSE
  *
  * Tech category: %BD_LVM_TECH_GLOB_CONF no mode (it is ignored)
  */
-gchar* bd_lvm_get_global_config (GError **error UNUSED) {
+gchar* bd_lvm_get_global_config (GError **error G_GNUC_UNUSED) {
     gchar *ret = NULL;
 
     g_mutex_lock (&global_config_lock);
@@ -2621,7 +2620,7 @@ gboolean bd_lvm_set_devices_filter (const gchar **devices, GError **error) {
  *
  * Tech category: %BD_LVM_TECH_DEVICES no mode (it is ignored)
  */
-gchar** bd_lvm_get_devices_filter (GError **error UNUSED) {
+gchar** bd_lvm_get_devices_filter (GError **error G_GNUC_UNUSED) {
     gchar **ret = NULL;
 
     g_mutex_lock (&global_config_lock);
@@ -2645,7 +2644,7 @@ gchar** bd_lvm_get_devices_filter (GError **error UNUSED) {
  *
  * Tech category: %BD_LVM_TECH_CACHE_CALCS no mode (it is ignored)
  */
-guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error UNUSED) {
+guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error G_GNUC_UNUSED) {
     return MAX ((guint64) cache_size / 1000, MIN_CACHE_MD_SIZE);
 }
 
@@ -2655,7 +2654,7 @@ guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error UNU
  *
  * Get LV type string from flags.
  */
-static const gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error UNUSED) {
+static const gchar* get_lv_type_from_flags (BDLVMCachePoolFlags flags, gboolean meta, GError **error G_GNUC_UNUSED) {
     if (!meta) {
         if (flags & BD_LVM_CACHE_POOL_STRIPED)
             return "striped";

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -179,7 +179,6 @@ void bd_md_close (void) {
     /* nothing to do here */
 }
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_md_is_tech_avail:
@@ -190,7 +189,7 @@ void bd_md_close (void) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_md_is_tech_avail (BDMDTech tech UNUSED, guint64 mode UNUSED, GError **error) {
+gboolean bd_md_is_tech_avail (BDMDTech tech G_GNUC_UNUSED, guint64 mode G_GNUC_UNUSED, GError **error) {
     /* all tech-mode combinations are supported by this implementation of the
        plugin, but it requires the 'mdadm' utility */
     return check_deps (&avail_deps, DEPS_MDADM_MASK, deps, DEPS_LAST, &deps_check_lock, error);
@@ -511,7 +510,7 @@ static gchar* get_mdadm_spec_from_input (const gchar *input, GError **error) {
  *
  * Tech category: always available
  */
-guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error UNUSED) {
+guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error G_GNUC_UNUSED) {
     guint64 headroom = BD_MD_SUPERBLOCK_SIZE;
     guint64 min_headroom = (1 MiB);
 

--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -109,7 +109,6 @@ void bd_nvdimm_close (void) {
     return;
 }
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_nvdimm_is_tech_avail:
@@ -285,7 +284,7 @@ gchar* bd_nvdimm_namespace_get_devname (const gchar *device, GError **error) {
  *
  * Deprecated: 3.1: NVDIMM plugin will be removed in the next major release
  */
-gboolean bd_nvdimm_namespace_enable (const gchar *namespace, const BDExtraArg **extra UNUSED, GError **error) {
+gboolean bd_nvdimm_namespace_enable (const gchar *namespace, const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
     struct ndctl_ctx *ctx = NULL;
     struct ndctl_namespace *ndns = NULL;
     gint ret = 0;
@@ -328,7 +327,7 @@ gboolean bd_nvdimm_namespace_enable (const gchar *namespace, const BDExtraArg **
  *
  * Deprecated: 3.1: NVDIMM plugin will be removed in the next major release
  */
-gboolean bd_nvdimm_namespace_disable (const gchar *namespace, const BDExtraArg **extra UNUSED, GError **error) {
+gboolean bd_nvdimm_namespace_disable (const gchar *namespace, const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
     struct ndctl_ctx *ctx = NULL;
     struct ndctl_namespace *ndns = NULL;
     gint ret = 0;
@@ -492,7 +491,7 @@ static BDNVDIMMNamespaceInfo* get_nvdimm_namespace_info (struct ndctl_namespace 
  *
  * Deprecated: 3.1: NVDIMM plugin will be removed in the next major release
  */
-BDNVDIMMNamespaceInfo* bd_nvdimm_namespace_info (const gchar *namespace, const BDExtraArg **extra UNUSED, GError **error) {
+BDNVDIMMNamespaceInfo* bd_nvdimm_namespace_info (const gchar *namespace, const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
     struct ndctl_ctx *ctx = NULL;
     struct ndctl_namespace *ndns = NULL;
     BDNVDIMMNamespaceInfo *info = NULL;
@@ -533,7 +532,8 @@ BDNVDIMMNamespaceInfo* bd_nvdimm_namespace_info (const gchar *namespace, const B
  *
  * Deprecated: 3.1: NVDIMM plugin will be removed in the next major release
  */
-BDNVDIMMNamespaceInfo** bd_nvdimm_list_namespaces (const gchar *bus_name, const gchar *region_name, gboolean idle, const BDExtraArg **extra UNUSED, GError **error) {
+BDNVDIMMNamespaceInfo** bd_nvdimm_list_namespaces (const gchar *bus_name, const gchar *region_name, gboolean idle,
+                                                   const BDExtraArg **extra G_GNUC_UNUSED, GError **error) {
     struct ndctl_ctx *ctx = NULL;
     struct ndctl_namespace *ndns = NULL;
     struct ndctl_region *region = NULL;

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -122,7 +122,6 @@ static gint log2i (guint x) {
     return ret;
 }
 
-#define UNUSED __attribute__((unused))
 
 /**
  * get_part_num: (skip)
@@ -161,7 +160,7 @@ static gint get_part_num (const gchar *part, GError **error) {
     return part_num;
 }
 
-static int fdisk_ask_callback (struct fdisk_context *cxt UNUSED, struct fdisk_ask *ask, void *data UNUSED) {
+static int fdisk_ask_callback (struct fdisk_context *cxt G_GNUC_UNUSED, struct fdisk_ask *ask, void *data G_GNUC_UNUSED) {
     gint type = 0;
     const gchar *fdisk_msg = NULL;
     gchar *message = NULL;
@@ -319,7 +318,7 @@ void bd_part_close (void) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_part_is_tech_avail (BDPartTech tech, guint64 mode UNUSED, GError **error) {
+gboolean bd_part_is_tech_avail (BDPartTech tech, guint64 mode G_GNUC_UNUSED, GError **error) {
     switch (tech) {
     case BD_PART_TECH_MBR:
     case BD_PART_TECH_GPT:

--- a/src/plugins/swap.c
+++ b/src/plugins/swap.c
@@ -87,7 +87,6 @@ void bd_swap_close (void) {
     /* nothing to do here */
 }
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_swap_is_tech_avail:
@@ -98,7 +97,7 @@ void bd_swap_close (void) {
  * Returns: whether the @tech-@mode combination is available -- supported by the
  *          plugin implementation and having all the runtime dependencies available
  */
-gboolean bd_swap_is_tech_avail (BDSwapTech tech UNUSED, guint64 mode, GError **error) {
+gboolean bd_swap_is_tech_avail (BDSwapTech tech G_GNUC_UNUSED, guint64 mode, GError **error) {
     guint32 requires = 0;
     if (mode & BD_SWAP_TECH_MODE_CREATE)
         requires |= DEPS_MKSWAP_MASK;

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -35,7 +35,6 @@
 #define ZERO_INIT {0}
 #endif
 
-#define UNUSED __attribute__((unused))
 
 extern char **environ;
 
@@ -825,7 +824,7 @@ gboolean bd_utils_check_util_version (const gchar *util, const gchar *version, c
  *
  * Returns: whether progress reporting was successfully initialized or not
  */
-gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **error UNUSED) {
+gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **error G_GNUC_UNUSED) {
     /* XXX: the error attribute will likely be used in the future when this
        function gets more complicated */
 
@@ -843,7 +842,7 @@ gboolean bd_utils_init_prog_reporting (BDUtilsProgFunc new_prog_func, GError **e
  *
  * Returns: whether progress reporting was successfully initialized or not
  */
-gboolean bd_utils_init_prog_reporting_thread (BDUtilsProgFunc new_prog_func, GError **error UNUSED) {
+gboolean bd_utils_init_prog_reporting_thread (BDUtilsProgFunc new_prog_func, GError **error G_GNUC_UNUSED) {
     /* XXX: the error attribute will likely be used in the future when this
        function gets more complicated */
 
@@ -852,7 +851,8 @@ gboolean bd_utils_init_prog_reporting_thread (BDUtilsProgFunc new_prog_func, GEr
     return TRUE;
 }
 
-static void thread_progress_muted (guint64 task_id UNUSED, BDUtilsProgStatus status UNUSED, guint8 completion UNUSED, gchar *msg UNUSED) {
+static void thread_progress_muted (guint64 task_id G_GNUC_UNUSED, BDUtilsProgStatus status G_GNUC_UNUSED,
+                                   guint8 completion G_GNUC_UNUSED, gchar *msg G_GNUC_UNUSED) {
     /* This function serves as a special value for the progress reporting
      * function to detect that nothing is done here. If clients use their own
      * empty function then bd_utils_prog_reporting_initialized will return TRUE
@@ -867,7 +867,7 @@ static void thread_progress_muted (guint64 task_id UNUSED, BDUtilsProgStatus sta
  * Returns: whether progress reporting for the current thread was successfully
  * muted (deinitialized even in presence of a global reporting function) or not
  */
-gboolean bd_utils_mute_prog_reporting_thread (GError **error UNUSED) {
+gboolean bd_utils_mute_prog_reporting_thread (GError **error G_GNUC_UNUSED) {
     /* XXX: the error attribute will likely be used in the future when this
        function gets more complicated */
 

--- a/src/utils/module.c
+++ b/src/utils/module.c
@@ -29,7 +29,6 @@
 #include "exec.h"
 #include "logging.h"
 
-#define UNUSED __attribute__((unused))
 
 /**
  * bd_utils_module_error_quark: (skip)
@@ -39,9 +38,9 @@ GQuark bd_utils_module_error_quark (void)
     return g_quark_from_static_string ("g-bd-utils-module-error-quark");
 }
 
-static void utils_kmod_log_redirect (void *log_data UNUSED, int priority,
-                                     const char *file UNUSED, int line UNUSED,
-                                     const char *fn UNUSED, const char *format,
+static void utils_kmod_log_redirect (void *log_data G_GNUC_UNUSED, int priority,
+                                     const char *file G_GNUC_UNUSED, int line G_GNUC_UNUSED,
+                                     const char *fn G_GNUC_UNUSED, const char *format,
                                      va_list args) {
     gchar *kmod_msg = NULL;
     gchar *message = NULL;


### PR DESCRIPTION
Let's move UNUSED defition to avoid redundancy.