### PR TITLE
LVM devices file fixes

### DIFF
--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -52,8 +52,8 @@ class DevMapperTestCase(DevMapperTest):
 
 class DevMapperGetSubsystemFromName(DevMapperTestCase):
     def _destroy_lvm(self):
-        run("vgremove --yes libbd_dm_tests >/dev/null 2>&1")
-        run("pvremove --yes %s >/dev/null 2>&1" % self.loop_dev)
+        run("vgremove --yes libbd_dm_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
+        run("pvremove --yes %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
 
     def _destroy_crypt(self):
         run("cryptsetup close libbd_dm_tests-subsystem_crypt >/dev/null 2>&1")
@@ -61,8 +61,8 @@ class DevMapperGetSubsystemFromName(DevMapperTestCase):
     def test_get_subsystem_from_name_lvm(self):
         """Verify that it is possible to get lvm device subsystem from its name"""
         self.addCleanup(self._destroy_lvm)
-        run("vgcreate libbd_dm_tests %s >/dev/null 2>&1" % self.loop_dev)
-        run("lvcreate -n subsystem_lvm -L50M libbd_dm_tests >/dev/null 2>&1")
+        run("vgcreate libbd_dm_tests %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
+        run("lvcreate -n subsystem_lvm -L50M libbd_dm_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
 
         subsystem = BlockDev.dm_get_subsystem_from_name("libbd_dm_tests-subsystem_lvm")
         self.assertEqual(subsystem, "LVM")

--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -151,26 +151,27 @@ class FSTestCase(FSNoDevTestCase):
         return Version(m.groups()[0])
 
     def _destroy_lvm(self, vgname):
-        utils.run("vgremove --yes %s >/dev/null 2>&1" % vgname)
-        utils.run("pvremove --yes %s >/dev/null 2>&1" % self.loop_dev)
+        utils.run("vgremove --yes %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % vgname)
+        utils.run("pvremove --yes %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
 
     def _setup_lvm(self, vgname, lvname, lvsize="50M"):
-        ret, _out, err = utils.run_command("pvcreate -ff -y %s" % self.loop_dev)
+        ret, _out, err = utils.run_command("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
         if ret != 0:
             raise RuntimeError("Failed to create PV for fs tests: %s" % err)
 
-        ret, _out, err = utils.run_command("vgcreate -s10M %s %s" % (vgname, self.loop_dev))
+        ret, _out, err = utils.run_command("vgcreate -s10M %s %s --config \"devices {use_devicesfile = 0}\"" % (vgname, self.loop_dev))
         if ret != 0:
             raise RuntimeError("Failed to create VG for fs tests: %s" % err)
         self.addCleanup(self._destroy_lvm, vgname)
 
-        ret, _out, err = utils.run_command("lvcreate -n %s -L%s %s" % (lvname, lvsize, vgname))
+        ret, _out, err = utils.run_command("lvcreate -n %s -L%s %s --config \"devices {use_devicesfile = 0}\"" % (lvname, lvsize, vgname))
         if ret != 0:
+            import pdb; pdb.set_trace()
             raise RuntimeError("Failed to create LV for fs tests: %s" % err)
 
         return "/dev/%s/%s" % (vgname, lvname)
 
     def _lvresize(self, vgname, lvname, size):
-        ret, _out, err = utils.run_command("lvresize -L%s %s/%s" % (size, vgname, lvname))
+        ret, _out, err = utils.run_command("lvresize -L%s %s/%s --config \"devices {use_devicesfile = 0}\"" % (size, vgname, lvname))
         if ret != 0:
             raise RuntimeError("Failed to resize LV for fs tests: %s" % err)

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -47,7 +47,7 @@ class TestGenericWipe(GenericTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_wipe("/non/existing/device", True)
 
-        ret = utils.run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
+        ret = utils.run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
         self.assertEqual(ret, 0)
 
         succ = BlockDev.fs_wipe(self.loop_dev, True)
@@ -55,7 +55,7 @@ class TestGenericWipe(GenericTestCase):
 
         # now test the same multiple times in a row
         for i in range(10):
-            ret = utils.run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
+            ret = utils.run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
             self.assertEqual(ret, 0)
 
             succ = BlockDev.fs_wipe(self.loop_dev, True)
@@ -133,7 +133,7 @@ class TestClean(GenericTestCase):
         succ = BlockDev.fs_clean(self.loop_dev)
         self.assertTrue(succ)
 
-        ret = utils.run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
+        ret = utils.run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
         self.assertEqual(ret, 0)
 
         succ = BlockDev.fs_clean(self.loop_dev)

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -360,15 +360,16 @@ class LvmPVonlyTestCase(LVMTestCase):
             raise RuntimeError("Failed to setup loop device for testing: %s" % e)
 
     def _clean_up(self):
-        try:
-            BlockDev.lvm_pvremove(self.loop_dev, None)
-        except:
-            pass
+        for dev in (self.loop_dev, self.loop_dev2):
+            try:
+                BlockDev.lvm_pvremove(dev)
+            except:
+                pass
 
-        try:
-            BlockDev.lvm_pvremove(self.loop_dev2, None)
-        except:
-            pass
+            try:
+                BlockDev.lvm_devices_delete(dev)
+            except:
+                pass
 
         try:
             delete_lio_device(self.loop_dev)

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -2254,7 +2254,10 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree("/etc/lvm/devices/" + cls.devicefile, ignore_errors=True)
+        try:
+            os.remove("/etc/lvm/devices/" + cls.devicefile)
+        except FileNotFoundError:
+            pass
 
         super(LvmTestDevicesFile, cls).tearDownClass()
 

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -358,20 +358,16 @@ class LvmPVonlyTestCase(LVMTestCase):
             raise RuntimeError("Failed to setup loop device for testing: %s" % e)
 
     def _clean_up(self):
-        try:
-            BlockDev.lvm_pvremove(self.loop_dev, None)
-        except:
-            pass
+        for dev in (self.loop_dev, self.loop_dev2, self.loop_dev3):
+            try:
+                BlockDev.lvm_pvremove(dev)
+            except:
+                pass
 
-        try:
-            BlockDev.lvm_pvremove(self.loop_dev2, None)
-        except:
-            pass
-
-        try:
-            BlockDev.lvm_pvremove(self.loop_dev3, None)
-        except:
-            pass
+            try:
+                BlockDev.lvm_devices_delete(dev)
+            except:
+                pass
 
         try:
             delete_lio_device(self.loop_dev)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -2166,7 +2166,10 @@ class LvmTestDevicesFile(LvmPVonlyTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree("/etc/lvm/devices/" + cls.devicefile, ignore_errors=True)
+        try:
+            os.remove("/etc/lvm/devices/" + cls.devicefile)
+        except FileNotFoundError:
+            pass
 
         super(LvmTestDevicesFile, cls).tearDownClass()
 

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -446,17 +446,17 @@ class UtilsDevUtilsSymlinksTestCase(UtilsTestCase):
         self.assertGreaterEqual(len(symlinks), 2)
 
         # create an LV to get a device with more symlinks
-        ret, _out, _err = run_command ("pvcreate %s" % self.loop_dev)
+        ret, _out, _err = run_command ("pvcreate %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
         self.assertEqual(ret, 0)
-        self.addCleanup(run_command, "pvremove %s" % self.loop_dev)
+        self.addCleanup(run_command, "pvremove %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
 
-        ret, _out, _err = run_command ("vgcreate utilsTestVG %s" % self.loop_dev)
+        ret, _out, _err = run_command ("vgcreate utilsTestVG %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
         self.assertEqual(ret, 0)
-        self.addCleanup(run_command, "vgremove -y utilsTestVG")
+        self.addCleanup(run_command, "vgremove -y utilsTestVG --config \"devices {use_devicesfile = 0}\"")
 
-        ret, _out, _err = run_command ("lvcreate -n utilsTestLV -L 12M utilsTestVG")
+        ret, _out, _err = run_command ("lvcreate -n utilsTestLV -L 12M utilsTestVG --config \"devices {use_devicesfile = 0}\"")
         self.assertEqual(ret, 0)
-        self.addCleanup(run_command, "lvremove -y utilsTestVG/utilsTestLV")
+        self.addCleanup(run_command, "lvremove -y utilsTestVG/utilsTestLV --config \"devices {use_devicesfile = 0}\"")
 
         symlinks = BlockDev.utils_get_device_symlinks("utilsTestVG/utilsTestLV")
         # there should be at least 4 symlinks for an LV


### PR DESCRIPTION
`pvremove` doesn't remove the devices file entry so we need to do that manually in the tests.