### PR TITLE
Disable LVM devices config file when running tests

### DIFF
--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -45,8 +45,8 @@ class DevMapperTestCase(unittest.TestCase):
 
 class DevMapperGetSubsystemFromName(DevMapperTestCase):
     def _destroy_lvm(self):
-        run("vgremove --yes libbd_dm_tests >/dev/null 2>&1")
-        run("pvremove --yes %s >/dev/null 2>&1" % self.loop_dev)
+        run("vgremove --yes libbd_dm_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
+        run("pvremove --yes %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
 
     def _destroy_crypt(self):
         run("cryptsetup close libbd_dm_tests-subsystem_crypt >/dev/null 2>&1")
@@ -54,8 +54,8 @@ class DevMapperGetSubsystemFromName(DevMapperTestCase):
     def test_get_subsystem_from_name_lvm(self):
         """Verify that it is possible to get lvm device subsystem from its name"""
         self.addCleanup(self._destroy_lvm)
-        run("vgcreate libbd_dm_tests %s >/dev/null 2>&1" % self.loop_dev)
-        run("lvcreate -n subsystem_lvm -L50M libbd_dm_tests >/dev/null 2>&1")
+        run("vgcreate libbd_dm_tests %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
+        run("lvcreate -n subsystem_lvm -L50M libbd_dm_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
 
         subsystem = BlockDev.dm_get_subsystem_from_name("libbd_dm_tests-subsystem_lvm")
         self.assertEqual(subsystem, "LVM")

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -146,7 +146,7 @@ class TestGenericWipe(FSTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_wipe("/non/existing/device", True)
 
-        ret = run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
+        ret = run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
         self.assertEqual(ret, 0)
 
         succ = BlockDev.fs_wipe(self.loop_dev, True)
@@ -154,7 +154,7 @@ class TestGenericWipe(FSTestCase):
 
         # now test the same multiple times in a row
         for i in range(10):
-            ret = run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
+            ret = run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
             self.assertEqual(ret, 0)
 
             succ = BlockDev.fs_wipe(self.loop_dev, True)
@@ -232,7 +232,7 @@ class TestClean(FSTestCase):
         succ = BlockDev.fs_clean(self.loop_dev)
         self.assertTrue(succ)
 
-        ret = run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
+        ret = run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
         self.assertEqual(ret, 0)
 
         succ = BlockDev.fs_clean(self.loop_dev)
@@ -333,7 +333,7 @@ class ExtTestWipe(FSTestCase):
         with self.assertRaises(GLib.GError):
             wipe_function(self.loop_dev)
 
-        run("pvcreate -ff -y %s >/dev/null" % self.loop_dev)
+        run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null" % self.loop_dev)
 
         # LVM PV signature, not an ext4 file system
         with self.assertRaises(GLib.GError):
@@ -623,7 +623,7 @@ class XfsTestWipe(FSTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_xfs_wipe(self.loop_dev)
 
-        run("pvcreate -ff -y %s >/dev/null" % self.loop_dev)
+        run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null" % self.loop_dev)
 
         # LVM PV signature, not an xfs file system
         with self.assertRaises(GLib.GError):
@@ -735,15 +735,15 @@ class XfsResize(FSTestCase):
     _loop_size = 500 * 1024**2
 
     def _destroy_lvm(self):
-        run("vgremove --yes libbd_fs_tests >/dev/null 2>&1")
-        run("pvremove --yes %s >/dev/null 2>&1" % self.loop_dev)
+        run("vgremove --yes libbd_fs_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
+        run("pvremove --yes %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
 
     def test_xfs_resize(self):
         """Verify that it is possible to resize an xfs file system"""
 
-        run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
-        run("vgcreate -s10M libbd_fs_tests %s >/dev/null 2>&1" % self.loop_dev)
-        run("lvcreate -n xfs_test -L350M libbd_fs_tests >/dev/null 2>&1")
+        run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
+        run("vgcreate -s10M libbd_fs_tests %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
+        run("lvcreate -n xfs_test -L350M libbd_fs_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
         self.addCleanup(self._destroy_lvm)
         lv = "/dev/libbd_fs_tests/xfs_test"
 
@@ -772,7 +772,7 @@ class XfsResize(FSTestCase):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_resize(lv, 40 * 1024**2)
 
-        run("lvresize -L400M libbd_fs_tests/xfs_test >/dev/null 2>&1")
+        run("lvresize -L400M libbd_fs_tests/xfs_test --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
         # should grow
         with mounted(lv, self.mount_dir):
             succ = BlockDev.fs_xfs_resize(self.mount_dir, 0, None)
@@ -782,7 +782,7 @@ class XfsResize(FSTestCase):
         self.assertTrue(fi)
         self.assertEqual(fi.block_size * fi.block_count, 400 * 1024**2)
 
-        run("lvresize -L450M libbd_fs_tests/xfs_test >/dev/null 2>&1")
+        run("lvresize -L450M libbd_fs_tests/xfs_test --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
         # should grow just to 430 MiB
         with mounted(lv, self.mount_dir):
             succ = BlockDev.fs_xfs_resize(self.mount_dir, 430 * 1024**2 / fi.block_size, None)
@@ -850,7 +850,7 @@ class VfatTestWipe(FSTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_vfat_wipe(self.loop_dev)
 
-        run("pvcreate -ff -y %s >/dev/null" % self.loop_dev)
+        run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null" % self.loop_dev)
 
         # LVM PV signature, not an vfat file system
         with self.assertRaises(GLib.GError):
@@ -1009,7 +1009,7 @@ class ExfatTestWipe(ExfatTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_exfat_wipe(self.loop_dev)
 
-        run("pvcreate -ff -y %s >/dev/null" % self.loop_dev)
+        run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null" % self.loop_dev)
 
         # LVM PV signature, not an exfat file system
         with self.assertRaises(GLib.GError):
@@ -1636,15 +1636,15 @@ class GenericResize(FSTestCase):
         self._test_generic_resize(mkfs_function=mkfs_vfat)
 
     def _destroy_lvm(self):
-        run("vgremove --yes libbd_fs_tests >/dev/null 2>&1")
-        run("pvremove --yes %s >/dev/null 2>&1" % self.loop_dev)
+        run("vgremove --yes libbd_fs_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
+        run("pvremove --yes %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
 
     def test_xfs_generic_resize(self):
         """Test generic resize function with an xfs file system"""
 
-        run("pvcreate -ff -y %s >/dev/null 2>&1" % self.loop_dev)
-        run("vgcreate -s10M libbd_fs_tests %s >/dev/null 2>&1" % self.loop_dev)
-        run("lvcreate -n xfs_test -L350M libbd_fs_tests >/dev/null 2>&1")
+        run("pvcreate -ff -y %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
+        run("vgcreate -s10M libbd_fs_tests %s --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1" % self.loop_dev)
+        run("lvcreate -n xfs_test -L350M libbd_fs_tests --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
         self.addCleanup(self._destroy_lvm)
 
         lv = "/dev/libbd_fs_tests/xfs_test"
@@ -1677,7 +1677,7 @@ class GenericResize(FSTestCase):
                 with self.assertRaises(GLib.GError):
                     succ = BlockDev.fs_resize(lv, 40 * 1024**2)
 
-        run("lvresize -L400M libbd_fs_tests/xfs_test >/dev/null 2>&1")
+        run("lvresize -L400M libbd_fs_tests/xfs_test --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
         # should grow
         with mounted(lv, self.mount_dir):
             succ = BlockDev.fs_resize(lv, 0)
@@ -1687,7 +1687,7 @@ class GenericResize(FSTestCase):
         self.assertTrue(fi)
         self.assertEqual(fi.block_size * fi.block_count, 400 * 1024**2)
 
-        run("lvresize -L450M libbd_fs_tests/xfs_test >/dev/null 2>&1")
+        run("lvresize -L450M libbd_fs_tests/xfs_test --config \"devices {use_devicesfile = 0}\" >/dev/null 2>&1")
         # should grow just to 430 MiB
         with mounted(lv, self.mount_dir):
             succ = BlockDev.fs_resize(lv, 430 * 1024**2)

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -283,6 +283,22 @@ class LvmPVonlyTestCase(LVMTestCase):
 
     _sparse_size = 1024**3
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        if os.path.exists("/etc/lvm/devices/system.devices"):
+            raise unittest.SkipTest("LVM devices file exists, skipping LVM DBus tests")
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        try:
+            os.remove("/etc/lvm/devices/bd_lvm_dbus.devices")
+        except FileNotFoundError:
+            pass
+
     # :TODO:
     #     * test pvmove (must create two PVs, a VG, a VG and some data in it
     #       first)
@@ -1748,5 +1764,5 @@ class LvmConfigTestPvremove(LvmPVonlyTestCase):
         self.assertTrue(succ)
 
         BlockDev.lvm_set_global_config("")
-        succ = BlockDev.lvm_pvremove(self.loop_dev)
+        succ = BlockDev.lvm_pvremove(self.loop_dev, None)
         self.assertTrue(succ)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -268,6 +268,24 @@ class LvmPVonlyTestCase(LVMTestCase):
 
     _sparse_size = 1024**3
 
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        try:
+            BlockDev.lvm_set_global_config("devices {use_devicesfile = 0}")
+        except:
+            pass
+
+    @classmethod
+    def tearDownClass(cls):
+        super().tearDownClass()
+
+        try:
+            BlockDev.lvm_set_global_config("")
+        except:
+            pass
+
     # :TODO:
     #     * test pvmove (must create two PVs, a VG, a VG and some data in it
     #       first)
@@ -1721,5 +1739,7 @@ class LvmConfigTestPvremove(LvmPVonlyTestCase):
         self.assertTrue(succ)
 
         BlockDev.lvm_set_global_config("")
-        succ = BlockDev.lvm_pvremove(self.loop_dev)
+
+        ea = BlockDev.ExtraArg.new("--config", "devices {use_devicesfile = 0}")
+        succ = BlockDev.lvm_pvremove(self.loop_dev, extra=[ea])
         self.assertTrue(succ)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -398,17 +398,17 @@ class UtilsDevUtilsSymlinksTestCase(UtilsTestCase):
         self.assertGreaterEqual(len(symlinks), 2)
 
         # create an LV to get a device with more symlinks
-        ret, _out, _err = run_command ("pvcreate %s" % self.loop_dev)
+        ret, _out, _err = run_command ("pvcreate %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
         self.assertEqual(ret, 0)
-        self.addCleanup(run_command, "pvremove %s" % self.loop_dev)
+        self.addCleanup(run_command, "pvremove %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
 
-        ret, _out, _err = run_command ("vgcreate utilsTestVG %s" % self.loop_dev)
+        ret, _out, _err = run_command ("vgcreate utilsTestVG %s --config \"devices {use_devicesfile = 0}\"" % self.loop_dev)
         self.assertEqual(ret, 0)
-        self.addCleanup(run_command, "vgremove -y utilsTestVG")
+        self.addCleanup(run_command, "vgremove -y utilsTestVG --config \"devices {use_devicesfile = 0}\"")
 
-        ret, _out, _err = run_command ("lvcreate -n utilsTestLV -L 12M utilsTestVG")
+        ret, _out, _err = run_command ("lvcreate -n utilsTestLV -L 12M utilsTestVG --config \"devices {use_devicesfile = 0}\"")
         self.assertEqual(ret, 0)
-        self.addCleanup(run_command, "lvremove -y utilsTestVG/utilsTestLV")
+        self.addCleanup(run_command, "lvremove -y utilsTestVG/utilsTestLV --config \"devices {use_devicesfile = 0}\"")
 
         symlinks = BlockDev.utils_get_device_symlinks("utilsTestVG/utilsTestLV")
         # there should be at least 4 symlinks for an LV


### PR DESCRIPTION
We do not support LVM devices file on 2.x so we want to completely disable it when running tests. We unfortunately need to disable LVM DBus tests when the device exists because we cannot disable the device file usage in LVM DbusD.