### PR TITLE
tests: Remove ext fs_check tests on mounted filesystem

### DIFF
--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -372,11 +372,6 @@ class ExtTestCheck(FSTestCase):
         succ = check_function(self.loop_dev, None)
         self.assertTrue(succ)
 
-        # mounted, but can be checked
-        with mounted(self.loop_dev, self.mount_dir):
-            succ = check_function(self.loop_dev, None)
-            self.assertTrue(succ)
-
         succ = check_function(self.loop_dev, None)
         self.assertTrue(succ)
 
@@ -406,10 +401,6 @@ class ExtTestRepair(FSTestCase):
         # unsafe operations should work here too
         succ = repair_function(self.loop_dev, True, None)
         self.assertTrue(succ)
-
-        with mounted(self.loop_dev, self.mount_dir):
-            with self.assertRaises(GLib.GError):
-                repair_function(self.loop_dev, False, None)
 
         succ = repair_function(self.loop_dev, False, None)
         self.assertTrue(succ)

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -117,9 +117,3 @@
    - distro: "centos"
      version: "9"
      reason: "LVM >= 2.03.19 is not yet available breaking our check for LVM resize on CentOS 9 Stream"
-
-- test: fs_test.ExtTestCheck.test_ext4_check
-  skip_on:
-  - distro: "fedora"
-    version: "39"
-    reason: "Ext4 cannot be checked when mounted with latest with e2fsprogs 1.47"


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=2211420

Backport of #907 to 2.x branch