### PR TITLE
btrfs: make btrfs subvolume listing consistent

### DIFF
--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -643,7 +643,7 @@ BDBtrfsDeviceInfo** bd_btrfs_list_devices (const gchar *device, GError **error) 
  * Tech category: %BD_BTRFS_TECH_SUBVOL-%BD_BTRFS_TECH_MODE_QUERY
  */
 BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboolean snapshots_only, GError **error) {
-    const gchar *argv[7] = {"btrfs", "subvol", "list", "-p", NULL, NULL, NULL};
+    const gchar *argv[8] = {"btrfs", "subvol", "list", "-a", "-p", NULL, NULL, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
     gchar **lines = NULL;
@@ -651,7 +651,7 @@ BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboole
     gchar const * const pattern = "ID\\s+(?P<id>\\d+)\\s+gen\\s+\\d+\\s+(cgen\\s+\\d+\\s+)?" \
                                   "parent\\s+(?P<parent_id>\\d+)\\s+top\\s+level\\s+\\d+\\s+" \
                                   "(otime\\s+(\\d{4}-\\d{2}-\\d{2}\\s+\\d\\d:\\d\\d:\\d\\d|-)\\s+)?"\
-                                  "path\\s+(?P<path>\\S+)";
+                                  "path\\s+(<FS_TREE>/)?(?P<path>\\S+)";
     GRegex *regex = NULL;
     GMatchInfo *match_info = NULL;
     guint64 i = 0;
@@ -668,10 +668,10 @@ BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboole
         return NULL;
 
     if (snapshots_only) {
-        argv[4] = "-s";
-        argv[5] = mountpoint;
+        argv[5] = "-s";
+        argv[6] = mountpoint;
     } else
-        argv[4] = mountpoint;
+        argv[5] = mountpoint;
 
     regex = g_regex_new (pattern, G_REGEX_EXTENDED, 0, error);
     if (!regex) {


### PR DESCRIPTION
Depending on the given mountpoint listing subvolumes returns different pathnames. The pathnames are returned sort of relative to the provided mountpoint. For example listing with `/` as mountpoint can return:

['root', 'home', 'home/foo', 'foo']

While giving `/home` it returns:

['root', 'home', 'root/foo', 'foo']

This gives issues for Cockpit as we want to give users a consistent listing of their subvolumes and UDisks always uses the first MountPoint to look up the subvolumes so Cockpit would either have to figure out how that is relative to the given MountPoint or show inconsistent subvolumes.

---

Some notes for a future situation with `libbtrfsutil` as I don't want to break the API again, independent of mountpoint this returns the same subvolumes:

```
In [12]: [path for (path,info) in btrfsutil.SubvolumeIterator('/', 5)]
Out[12]:
['root',
 'root/var/lib/portables',
 'root/var/lib/machines',
 'root/foo',
 'root/bar',
 'home',
 'home/foo']

In [13]: [path for (path,info) in btrfsutil.SubvolumeIterator('/home', 5)]
Out[13]:
['root',
 'root/var/lib/portables',
 'root/var/lib/machines',
 'root/foo',
 'root/bar',
 'home',
 'home/foo']
```

With this patch libblockdev does that too:

```
In [6]: [x.path for x in BlockDev.btrfs_list_subvolumes('/home', False)]
Out[6]:
['root',
 'home',
 'root/bar',
 'root/var/lib/portables',
 'root/var/lib/machines',
 'root/foo',
 'home/foo']

In [7]: [x.path for x in BlockDev.btrfs_list_subvolumes('/', False)]
Out[7]:
['root',
 'home',
 'root/bar',
 'root/var/lib/portables',
 'root/var/lib/machines',
 'root/foo',
 'home/foo']
```

Old behaviour:

```
In [12]: [x.path for x in BlockDev.btrfs_list_subvolumes('/', False)]
Out[12]:
['root',
 'home',
 'bar',
 'var/lib/portables',
 'var/lib/machines',
 'foo',
 'home/foo']

In [13]: [x.path for x in BlockDev.btrfs_list_subvolumes('/home', False)]
Out[13]:
['root',
 'home',
 'root/bar',
 'root/var/lib/portables',
 'root/var/lib/machines',
 'root/foo',
 'foo']
```

Some research notes from @mvollmer  https://gist.githubusercontent.com/mvollmer/1cf111cfdb4f7ec55248ecd23ea4284d/raw/1711bc17482c8ec777081d14f316816e087ff330/gistfile1.txt