### PR TITLE
lvm-dbus: Fix passing size for pvresize over DBus

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1406,7 +1406,7 @@ gboolean bd_lvm_pvresize (const gchar *device, guint64 size, const BDExtraArg **
     if (!obj_path)
         return FALSE;
 
-    params = g_variant_new ("(u)", size);
+    params = g_variant_new ("(t)", size);
     call_lvm_method_sync (obj_path, PV_INTF, "ReSize", params, NULL, extra, TRUE, error);
 
     return (*error == NULL);

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -387,8 +387,14 @@ class LvmTestPVresize(LvmPVonlyTestCase):
         succ = BlockDev.lvm_pvresize(self.loop_dev, 200 * 1024**2, None)
         self.assertTrue(succ)
 
+        info = BlockDev.lvm_pvinfo(self.loop_dev)
+        self.assertEqual(info.pv_size, 200 * 1024**2)
+
         succ = BlockDev.lvm_pvresize(self.loop_dev, 200 * 1024**3, None)
         self.assertTrue(succ)
+
+        info = BlockDev.lvm_pvinfo(self.loop_dev)
+        self.assertEqual(info.pv_size, 200 * 1024**3)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestPVscan(LvmPVonlyTestCase):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -372,8 +372,14 @@ class LvmTestPVresize(LvmPVonlyTestCase):
         succ = BlockDev.lvm_pvresize(self.loop_dev, 200 * 1024**2, None)
         self.assertTrue(succ)
 
+        info = BlockDev.lvm_pvinfo(self.loop_dev)
+        self.assertEqual(info.pv_size, 200 * 1024**2)
+
         succ = BlockDev.lvm_pvresize(self.loop_dev, 200 * 1024**3, None)
         self.assertTrue(succ)
+
+        info = BlockDev.lvm_pvinfo(self.loop_dev)
+        self.assertEqual(info.pv_size, 200 * 1024**3)
 
 class LvmTestPVscan(LvmPVonlyTestCase):
     def test_pvscan(self):


### PR DESCRIPTION
"u" is UINT32, we need to use "t" for UINT64