### PR TITLE
Bump version to 3.1.1

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -8,6 +8,8 @@ actions:
     - 'make'
     - 'make local'
     - 'bash -c "ls *.tar*"'
+  get-current-version:
+    - 'bash -c "grep Version: dist/libblockdev.spec.in | cut -f2 -d\":\" | tr -d \" \""'
 
 jobs:
 - job: copr_build
@@ -42,6 +44,8 @@ jobs:
       - 'make'
       - 'make local'
       - 'bash -c "ls *.tar*"'
+    get-current-version:
+      - 'bash -c "grep Version: dist/libblockdev.spec.in | cut -f2 -d\":\" | tr -d \" \""'
 
 - job: copr_build
   trigger: commit
@@ -61,6 +65,8 @@ jobs:
       - 'make'
       - 'make local'
       - 'bash -c "ls *.tar*"'
+    get-current-version:
+      - 'bash -c "grep Version: dist/libblockdev.spec.in | cut -f2 -d\":\" | tr -d \" \""'
 
 - job: propose_downstream
   trigger: release

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,6 +30,18 @@ jobs:
   project: blivet-daily
   branch: master
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
+      - 'sed -i -E "s/@WITH_.+@/1/g" dist/libblockdev.spec'
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec"'
+    create-archive:
+      - './autogen.sh'
+      - './configure'
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: copr_build
   trigger: commit
@@ -37,6 +49,18 @@ jobs:
   project: udisks-daily
   branch: master
   preserve_project: true
+  actions:
+    post-upstream-clone:
+      - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
+      - 'sed -i -E "s/@WITH_.+@/1/g" dist/libblockdev.spec'
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec"'
+    create-archive:
+      - './autogen.sh'
+      - './configure'
+      - 'make'
+      - 'make local'
+      - 'bash -c "ls *.tar*"'
 
 - job: propose_downstream
   trigger: release

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,3 +1,32 @@
+Libblockdev 3.1.1
+------------------
+
+New bugfix release of the libblockdev library with multiple fixes. See below
+for details.
+
+**Full list of changes**
+
+Giulio Benetti (1):
+
+- Use glib2 G_GNUC_UNUSED in place of UNUSED locally defined
+
+Tomas Bzatek (5):
+
+- Port to G_GNUC_INTERNAL for controlling symbols visibility
+- Fix some more occurrences of missing port to G_GNUC_UNUSED
+- dm_logging: Annotate redirect_dm_log() printf format
+- tests: Add NVMe persistent discovery controller tests
+- tests: Add NVMe controller type checks
+
+Vojtech Trefny (6):
+
+- Makefile: Fix bumpver to work with micro versions
+- tests: Manually remove removed PVs from LVM devices file
+- tests: Ignore LVM devices file for non-LVM tests
+- tests: Fix removing custom LVM devices file
+- nvme: Add bd_nvme_is_tech_avail to the API file
+- lvm-dbus: Fix passing size for pvresize over DBus
+
 Libblockdev 3.1.0
 ------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac for libblockdev
 
-AC_INIT([libblockdev], [3.1.0], [], [], [https://github.com/storaged-project/libblockdev])
+AC_INIT([libblockdev], [3.1.1], [], [], [https://github.com/storaged-project/libblockdev])
 
 # Disable building static libraries.
 # This needs to be set before initializing automake

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -77,7 +77,7 @@
 %define configure_opts %{?python3_copts} %{?lvm_dbus_copts} %{?btrfs_copts} %{?crypto_copts} %{?dm_copts} %{?loop_copts} %{?lvm_copts} %{?lvm_dbus_copts} %{?mdraid_copts} %{?mpath_copts} %{?swap_copts} %{?part_copts} %{?fs_copts} %{?nvdimm_copts} %{?tools_copts} %{?gi_copts} %{?nvme_copts}
 
 Name:        libblockdev
-Version:     3.1.0
+Version:     3.1.1
 Release:     1%{?dist}
 Summary:     A library for low-level manipulation with block devices
 License:     LGPL-2.1-or-later
@@ -851,6 +851,20 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %files plugins-all
 
 %changelog
+* Tue Mar 26 2024 Vojtech Trefny <vtrefny@redhat.com> - 3.1.1-1
+- lvm-dbus: Fix passing size for pvresize over DBus (vtrefny)
+- nvme: Add bd_nvme_is_tech_avail to the API file (vtrefny)
+- tests: Add NVMe controller type checks (tbzatek)
+- tests: Add NVMe persistent discovery controller tests (tbzatek)
+- tests: Fix removing custom LVM devices file (vtrefny)
+- tests: Ignore LVM devices file for non-LVM tests (vtrefny)
+- tests: Manually remove removed PVs from LVM devices file (vtrefny)
+- dm_logging: Annotate redirect_dm_log() printf format (tbzatek)
+- Fix some more occurrences of missing port to G_GNUC_UNUSED (tbzatek)
+- Port to G_GNUC_INTERNAL for controlling symbols visibility (tbzatek)
+- Use glib2 G_GNUC_UNUSED in place of UNUSED locally defined (giulio.benetti)
+- Makefile: Fix bumpver to work with micro versions (vtrefny)
+
 * Fri Jan 19 2024 Vojtech Trefny <vtrefny@redhat.com> - 3.1.0-1
 - tests: Skip some checks for btrfs errors with btrfs-progs 6.6.3 (vtrefny)
 - Fix missing progress initialization in bd_crypto_luks_add_key (vtrefny)


### PR DESCRIPTION
We did a new release from the 3.1.x branch so we need to bump the version here as well to make sure the daily builds are ahead of Fedora.