### PR TITLE
ci: Fix bumping release for Packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -34,10 +34,10 @@ jobs:
   preserve_project: true
   actions:
     post-upstream-clone:
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec.in"'
       - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
       - 'sed -i -E "s/@WITH_.+@/1/g" dist/libblockdev.spec'
-      # bump release to 99 to always be ahead of Fedora builds
-      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec"'
     create-archive:
       - './autogen.sh'
       - './configure'
@@ -55,10 +55,10 @@ jobs:
   preserve_project: true
   actions:
     post-upstream-clone:
+      # bump release to 99 to always be ahead of Fedora builds
+      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec.in"'
       - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
       - 'sed -i -E "s/@WITH_.+@/1/g" dist/libblockdev.spec'
-      # bump release to 99 to always be ahead of Fedora builds
-      - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec"'
     create-archive:
       - './autogen.sh'
       - './configure'


### PR DESCRIPTION
We need to bump the release in the SPEC template so it's not overwritten by the autogen call later.