### PR TITLE
build: Fix linking with LLD

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -9,5 +9,5 @@ lvm_cache_stats_LDADD    = ${builddir}/../src/lib/libblockdev.la $(GLIB_LIBS) $(
 vfat_resize_CFLAGS   = $(GLIB_CFLAGS) $(BYTESIZE_CFLAGS) $(PARTED_CFLAGS) $(PARTED_FS_CFLAGS) -Wall -Wextra -Werror
 vfat_resize_CPPFLAGS = -I${builddir}/../include/
 vfat_resize_LDFLAGS  = -Wl,--no-undefined
-vfat_resize_LDADD    = ${builddir}/../src/lib/libblockdev.la $(GLIB_LIBS) $(BYTESIZE_LIBS) $(PARTED_LIBS) $(PARTED_FS_LIBS)
+vfat_resize_LDADD    = ${builddir}/../src/lib/libblockdev.la $(GLIB_LIBS) $(BYTESIZE_LIBS) $(PARTED_LIBS) $(PARTED_FS_LIBS) $(UUID_LIBS)
 endif


### PR DESCRIPTION
LLD is strict about specifying link dependencies and it complains about libuuid not being provided in LDFLAGS when linking tool binaries.

See https://bugs.gentoo.org/910487

Fixes: #1020