### PR TITLE
ci: Use Ubuntu 24.04 in GitHub actions

### DIFF
--- a/.github/workflows/blivet-tests.yml
+++ b/.github/workflows/blivet-tests.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: blivet-tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI_CONTAINER: libblockdev-ci-blivet-tests
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
@@ -39,7 +39,7 @@ jobs:
 
     - name: Build
       run: |
-        ./autogen.sh && ./configure --without-nvme && make -j
+        ./autogen.sh && ./configure && make -j
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   build:
     name: compilation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
       matrix:
-        compiler: ['gcc-9', 'gcc-10', 'gcc-11', 'gcc-12', 'gcc-13',
-                   'clang-13', 'clang-14', 'clang-15', 'clang-16', 'clang-17']
+        compiler: ['gcc-10', 'gcc-11', 'gcc-12', 'gcc-13', 'gcc-14',
+                   'clang-14', 'clang-15', 'clang-16', 'clang-17', 'clang-18']
 
     steps:
     - uses: actions/checkout@v4
@@ -24,25 +24,13 @@ jobs:
         sudo apt -y install ansible
         ansible-playbook -b -i "localhost," -c local misc/install-test-dependencies.yml -e "test_dependencies=false"
 
-    - name: Enable additional repositories (gcc)
-      run: |
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-        sudo apt update
-
-    - name: Enable additional repositories (clang)
-      run: |
-        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-        echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" | sudo tee /etc/apt/sources.list.d/llvm.list
-        echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
-        sudo apt update
-
     - name: Install compiler
       run: |
         sudo apt -y install ${{ matrix.compiler }}
 
     - name: Configure
       run: |
-        ./autogen.sh && CC=${{ matrix.compiler }} ./configure --without-nvme
+        ./autogen.sh && CC=${{ matrix.compiler }} ./configure
 
     - name: Make
       run: |

--- a/.github/workflows/udisks-build.yml
+++ b/.github/workflows/udisks-build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: udisks-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       CI_CONTAINER: libblockdev-ci-udisks-build
     steps:

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -87,7 +87,11 @@
 
   - name: Add source repositories (Debian/Ubuntu)
     shell: "grep '^deb ' /etc/apt/sources.list | perl -pe 's/deb /deb-src /' >> /etc/apt/sources.list"
-    when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+    when: ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version < '24')
+
+  - name: Add source repositories (Debian/Ubuntu)
+    shell: "sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources"
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '24'
 
   - name: Update apt cache (Debian/Ubuntu)
     apt:


### PR DESCRIPTION
The latest LTS is now available and it has some new compilers available and also the latest libnvme we need to compile the NVMe plugin.