### PR TITLE
tests: Skip exFAT UUID tests also on Fedora 39

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -53,5 +53,5 @@
 - test: fs_tests.(exfat_test.ExfatSetUUID.test_exfat_set_uuid|generic_test.GenericSetUUID.test_exfat_generic_set_uuid)
   skip_on:
     - distro: "fedora"
-      version: ["40", "41"]
+      version: ["39", "40", "41"]
       reason: Setting UUID with LC_ALL=C.UTF-8 is broken with recent exfatprogs


### PR DESCRIPTION
Latest exfatprogs was backported to 39 too.