### PR TITLE
Upstream kernel VDO support

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -149,6 +149,7 @@ srpm_build_deps:
  - libmount-devel
  - libnvme-devel
  - libuuid-devel
+ - libyaml-devel
  - ndctl-devel
  - nss-devel
  - parted-devel

--- a/configure.ac
+++ b/configure.ac
@@ -217,6 +217,10 @@ AS_IF([test "x$with_dm" != "xno" -o "x$with_lvm" != "xno" -o "x$with_lvm_dbus" !
       [LIBBLOCKDEV_PKG_CHECK_MODULES([DEVMAPPER], [devmapper >= 1.02.93])],
       [])
 
+AS_IF([test "x$with_lvm" != "xno" -o "x$with_lvm_dbus" != "xno"],
+      [LIBBLOCKDEV_PKG_CHECK_MODULES([YAML], [yaml-0.1])],
+      [])
+
 AS_IF([test "x$with_part" != "xno"],
       [LIBBLOCKDEV_PKG_CHECK_MODULES([FDISK], [fdisk >= 2.31.0])],
       [])

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -298,6 +298,7 @@ with the libblockdev-loop plugin/library.
 %if %{with_lvm}
 %package lvm
 BuildRequires: device-mapper-devel
+BuildRequires: libyaml-devel
 Summary:     The LVM plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: lvm2
@@ -320,6 +321,7 @@ with the libblockdev-lvm plugin/library.
 %if %{with_lvm_dbus}
 %package lvm-dbus
 BuildRequires: device-mapper-devel
+BuildRequires: libyaml-devel
 Summary:     The LVM plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} = %{version}-%{release}
 Requires: lvm2-dbusd >= 2.02.156

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -70,6 +70,7 @@
       - smartmontools
       - targetcli
       - udftools
+      - vdo
       - volume_key
       - xfsprogs
     when: ansible_distribution == 'Fedora' and test_dependencies|bool

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -39,6 +39,7 @@
       - e2fsprogs-devel
       - json-glib-devel
       - libatasmart-devel
+      - libyaml-devel
     when: ansible_distribution == 'Fedora'
 
   - name: Install test dependencies (Fedora)
@@ -113,6 +114,7 @@
       - libext2fs-dev
       - libjson-glib-dev
       - libatasmart-dev
+      - libyaml-dev
     when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
   - name: Install test dependencies (Debian/Ubuntu)

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -1965,10 +1965,10 @@ BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_st
  *                                                    statistics or %NULL in case of error
  *                                                    (@error gets populated in those cases)
  *
- * Statistics are collected from the values exposed by the kernel `kvdo` module
- * at the `/sys/kvdo/<VDO_NAME>/statistics/` path.
+ * Statistics are collected from the values exposed by the kernel `dm-vdo` module.
+ *
  * Some of the keys are computed to mimic the information produced by the vdo tools.
- * Please note the contents of the hashtable may vary depending on the actual kvdo module version.
+ * Please note the contents of the hashtable may vary depending on the actual dm-vdo module version.
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
  */

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -99,16 +99,16 @@ libbd_loop_la_SOURCES = loop.c loop.h
 endif
 
 if WITH_LVM
-libbd_lvm_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
-libbd_lvm_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS)
+libbd_lvm_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) $(YAML_CFLAGS) -Wall -Wextra -Werror
+libbd_lvm_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS) $(YAML_LIBS)
 libbd_lvm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 3:0:0 -Wl,--no-undefined -export-symbols-regex '^bd_.*'
 libbd_lvm_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_lvm_la_SOURCES = lvm.c lvm.h check_deps.c check_deps.h dm_logging.c dm_logging.h vdo_stats.c vdo_stats.h
 endif
 
 if WITH_LVM_DBUS
-libbd_lvm_dbus_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
-libbd_lvm_dbus_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS)
+libbd_lvm_dbus_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) $(YAML_CFLAGS) -Wall -Wextra -Werror
+libbd_lvm_dbus_la_LIBADD = ${builddir}/../utils/libbd_utils.la -lm $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS) $(YAML_LIBS)
 libbd_lvm_dbus_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 3:0:0 -Wl,--no-undefined -export-symbols-regex '^bd_.*'
 libbd_lvm_dbus_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_lvm_dbus_la_SOURCES = lvm-dbus.c lvm.h check_deps.c check_deps.h dm_logging.c dm_logging.h vdo_stats.c vdo_stats.h

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -326,7 +326,7 @@ static const UtilFeatureDep features[FEATURES_LAST] = {
 #define MODULE_DEPS_VDO_MASK (1 << MODULE_DEPS_VDO)
 #define MODULE_DEPS_LAST 1
 
-static const gchar*const module_deps[MODULE_DEPS_LAST] = { "kvdo" };
+static const gchar*const module_deps[MODULE_DEPS_LAST] = { "dm-vdo" };
 
 /**
  * bd_lvm_init:

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -4711,10 +4711,10 @@ BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_st
  *                                                    statistics or %NULL in case of error
  *                                                    (@error gets populated in those cases)
  *
- * Statistics are collected from the values exposed by the kernel `kvdo` module
- * at the `/sys/kvdo/<VDO_NAME>/statistics/` path.
+ * Statistics are collected from the values exposed by the kernel `dm-vdo` module.
+ *
  * Some of the keys are computed to mimic the information produced by the vdo tools.
- * Please note the contents of the hashtable may vary depending on the actual kvdo module version.
+ * Please note the contents of the hashtable may vary depending on the actual dm-vdo module version.
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
  */
@@ -4746,12 +4746,12 @@ BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_nam
         return NULL;
 
     stats = g_new0 (BDLVMVDOStats, 1);
-    get_stat_val64_default (full_stats, "block_size", &stats->block_size, -1);
-    get_stat_val64_default (full_stats, "logical_block_size", &stats->logical_block_size, -1);
-    get_stat_val64_default (full_stats, "physical_blocks", &stats->physical_blocks, -1);
-    get_stat_val64_default (full_stats, "data_blocks_used", &stats->data_blocks_used, -1);
-    get_stat_val64_default (full_stats, "overhead_blocks_used", &stats->overhead_blocks_used, -1);
-    get_stat_val64_default (full_stats, "logical_blocks_used", &stats->logical_blocks_used, -1);
+    get_stat_val64_default (full_stats, "blockSize", &stats->block_size, -1);
+    get_stat_val64_default (full_stats, "logicalBlockSize", &stats->logical_block_size, -1);
+    get_stat_val64_default (full_stats, "physicalBlocks", &stats->physical_blocks, -1);
+    get_stat_val64_default (full_stats, "dataBlocksUsed", &stats->data_blocks_used, -1);
+    get_stat_val64_default (full_stats, "overheadBlocksUsed", &stats->overhead_blocks_used, -1);
+    get_stat_val64_default (full_stats, "logicalBlocksUsed", &stats->logical_blocks_used, -1);
     get_stat_val64_default (full_stats, "usedPercent", &stats->used_percent, -1);
     get_stat_val64_default (full_stats, "savingPercent", &stats->saving_percent, -1);
     if (!get_stat_val_double (full_stats, "writeAmplificationRatio", &stats->write_amplification_ratio))

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -329,7 +329,7 @@ static const UtilFeatureDep features[FEATURES_LAST] = {
 #define MODULE_DEPS_VDO_MASK (1 << MODULE_DEPS_VDO)
 #define MODULE_DEPS_LAST 1
 
-static const gchar*const module_deps[MODULE_DEPS_LAST] = { "kvdo" };
+static const gchar*const module_deps[MODULE_DEPS_LAST] = { "dm-vdo" };
 
 
 /**

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -3798,10 +3798,10 @@ BDLVMVDOWritePolicy bd_lvm_get_vdo_write_policy_from_str (const gchar *policy_st
  *                                                    statistics or %NULL in case of error
  *                                                    (@error gets populated in those cases)
  *
- * Statistics are collected from the values exposed by the kernel `kvdo` module
- * at the `/sys/kvdo/<VDO_NAME>/statistics/` path.
+ * Statistics are collected from the values exposed by the kernel `dm-vdo` module.
+ *
  * Some of the keys are computed to mimic the information produced by the vdo tools.
- * Please note the contents of the hashtable may vary depending on the actual kvdo module version.
+ * Please note the contents of the hashtable may vary depending on the actual dm-vdo module version.
  *
  * Tech category: %BD_LVM_TECH_VDO-%BD_LVM_TECH_MODE_QUERY
  */
@@ -3833,12 +3833,12 @@ BDLVMVDOStats* bd_lvm_vdo_get_stats (const gchar *vg_name, const gchar *pool_nam
         return NULL;
 
     stats = g_new0 (BDLVMVDOStats, 1);
-    get_stat_val64_default (full_stats, "block_size", &stats->block_size, -1);
-    get_stat_val64_default (full_stats, "logical_block_size", &stats->logical_block_size, -1);
-    get_stat_val64_default (full_stats, "physical_blocks", &stats->physical_blocks, -1);
-    get_stat_val64_default (full_stats, "data_blocks_used", &stats->data_blocks_used, -1);
-    get_stat_val64_default (full_stats, "overhead_blocks_used", &stats->overhead_blocks_used, -1);
-    get_stat_val64_default (full_stats, "logical_blocks_used", &stats->logical_blocks_used, -1);
+    get_stat_val64_default (full_stats, "blockSize", &stats->block_size, -1);
+    get_stat_val64_default (full_stats, "logicalBlockSize", &stats->logical_block_size, -1);
+    get_stat_val64_default (full_stats, "physicalBlocks", &stats->physical_blocks, -1);
+    get_stat_val64_default (full_stats, "dataBlocksUsed", &stats->data_blocks_used, -1);
+    get_stat_val64_default (full_stats, "overheadBlocksUsed", &stats->overhead_blocks_used, -1);
+    get_stat_val64_default (full_stats, "logicalBlocksUsed", &stats->logical_blocks_used, -1);
     get_stat_val64_default (full_stats, "usedPercent", &stats->used_percent, -1);
     get_stat_val64_default (full_stats, "savingPercent", &stats->saving_percent, -1);
     if (!get_stat_val_double (full_stats, "writeAmplificationRatio", &stats->write_amplification_ratio))

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -2030,11 +2030,11 @@ class LVMVDOTest(LVMTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not BlockDev.utils_have_kernel_module("kvdo"):
+        if not BlockDev.utils_have_kernel_module("dm-vdo"):
             raise unittest.SkipTest("VDO kernel module not available, skipping.")
 
         try:
-            BlockDev.utils_load_kernel_module("kvdo")
+            BlockDev.utils_load_kernel_module("dm-vdo")
         except GLib.GError as e:
             if "File exists" not in e.message:
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -2091,7 +2091,9 @@ class LVMVDOTest(LVMTestCase):
         pool_info = BlockDev.lvm_lvinfo("testVDOVG", "vdoPool")
         self.assertEqual(pool_info.segtype, "vdo-pool")
         self.assertEqual(pool_info.data_lv, "vdoPool_vdata")
-        self.assertGreater(pool_info.data_percent, 0)
+        lvm_version = self._get_lvm_version()
+        if lvm_version >= Version("2.03.24"):
+            self.assertGreater(pool_info.data_percent, 0)
 
         pool = BlockDev.lvm_vdolvpoolname("testVDOVG", "vdoLV")
         self.assertEqual(pool, lv_info.pool_lv)

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1929,11 +1929,11 @@ class LVMVDOTest(LVMTestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not BlockDev.utils_have_kernel_module("kvdo"):
+        if not BlockDev.utils_have_kernel_module("dm-vdo"):
             raise unittest.SkipTest("VDO kernel module not available, skipping.")
 
         try:
-            BlockDev.utils_load_kernel_module("kvdo")
+            BlockDev.utils_load_kernel_module("dm-vdo")
         except GLib.GError as e:
             if "File exists" not in e.message:
                 raise unittest.SkipTest("cannot load VDO kernel module, skipping.")

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1990,7 +1990,9 @@ class LVMVDOTest(LVMTestCase):
         pool_info = BlockDev.lvm_lvinfo("testVDOVG", "vdoPool")
         self.assertEqual(pool_info.segtype, "vdo-pool")
         self.assertEqual(pool_info.data_lv, "vdoPool_vdata")
-        self.assertGreater(pool_info.data_percent, 0)
+        lvm_version = self._get_lvm_version()
+        if lvm_version >= Version("2.03.24"):
+            self.assertGreater(pool_info.data_percent, 0)
 
         pool = BlockDev.lvm_vdolvpoolname("testVDOVG", "vdoLV")
         self.assertEqual(pool, lv_info.pool_lv)
@@ -2151,7 +2153,11 @@ class LVMVDOTest(LVMTestCase):
         self.assertTrue(vdo_info.deduplication)
 
         vdo_stats = BlockDev.lvm_vdo_get_stats("testVDOVG", "vdoPool")
-        self.assertEqual(vdo_info.saving_percent, vdo_stats.saving_percent)
+
+        lvm_version = self._get_lvm_version()
+        if lvm_version >= Version("2.03.24"):
+            # saving_percent is incorrect with LVM < 2.03.24
+            self.assertEqual(vdo_info.saving_percent, vdo_stats.saving_percent)
 
         # just sanity check
         self.assertNotEqual(vdo_stats.used_percent, -1)

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -55,3 +55,9 @@
     - distro: "fedora"
       version: ["39", "40", "41"]
       reason: Setting UUID with LC_ALL=C.UTF-8 is broken with recent exfatprogs
+
+- test: (lvm_test|lvm_dbus_tests).LVMVDOTest
+  skip_on:
+    - distro: "centos"
+      version: "10"
+      reason: "vdo userspace tools are not yet available on RHEL/CentOS 10"


### PR DESCRIPTION
Few changes we need in order to support VDO with the latest upstream 6.9 kernel. The biggest change is renaming of the module (`kvdo` → `dm-vdo`) and deprecation of the `/sys/kvdo` API.