### PR TITLE
infra: Add dependabot to automatically update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+
+  # Set update schedule for GitHub actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "infra"


### PR DESCRIPTION
Dependabot should automatically bump the required versions of GH actions so we don't need to do that manually. I tested this in libbytesize and it seems to be working fine, see https://github.com/storaged-project/libbytesize/pull/146