### PR TITLE
part: Add human readable partition type to BDPartSpec

### DIFF
--- a/src/lib/plugin_apis/part.api
+++ b/src/lib/plugin_apis/part.api
@@ -72,6 +72,7 @@ typedef struct BDPartSpec {
     guint64 size;
     gboolean bootable;
     guint64 attrs;
+    gchar *type_name;
 } BDPartSpec;
 
 BDPartSpec* bd_part_spec_copy (BDPartSpec *data) {
@@ -85,6 +86,7 @@ BDPartSpec* bd_part_spec_copy (BDPartSpec *data) {
     ret->uuid = g_strdup (data->uuid);
     ret->id = g_strdup (data->id);
     ret->type_guid = g_strdup (data->type_guid);
+    ret->type_name = g_strdup (data->type_name);
     ret->type = data->type;
     ret->start = data->start;
     ret->size = data->size;
@@ -103,6 +105,7 @@ void bd_part_spec_free (BDPartSpec *data) {
     g_free (data->uuid);
     g_free (data->id);
     g_free (data->type_guid);
+    g_free (data->type_name);
     g_free (data);
 }
 

--- a/src/plugins/part.h
+++ b/src/plugins/part.h
@@ -51,6 +51,7 @@ typedef struct BDPartSpec {
     guint64 size;
     gboolean bootable;
     guint64 attrs;
+    gchar *type_name;
 } BDPartSpec;
 
 BDPartSpec* bd_part_spec_copy (BDPartSpec *data);

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1227,11 +1227,13 @@ class PartSetTypeCase(PartTestCase):
         self.assertTrue(succ)
         ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
         self.assertEqual(ps.type_guid, "E6D6D379-F507-44C2-A23C-238F2A3DF928")
+        self.assertEqual(ps.type_name, "Linux LVM")
 
         succ = BlockDev.part_set_part_type (self.loop_dev, ps.path, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
         self.assertTrue(succ)
         ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
         self.assertEqual(ps.type_guid, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
+        self.assertEqual(ps.type_name, "Linux filesystem")
 
         # let's now test an MSDOS partition table (doesn't support type GUIDs)
         succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
@@ -1322,6 +1324,7 @@ class PartSetGptFlagsCase(PartTestCase):
         self.assertTrue(succ)
         ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
         self.assertEqual(ps.type_guid, esp_guid)
+        self.assertEqual(ps.type_name, "EFI System")
 
 
 class PartSetGptAttrsCase(PartTestCase):


### PR DESCRIPTION
Unfortunately fdisk doesn't provide API to translate between the GUID and the "name" directly, we can only get it for existing partitions.

Related: https://github.com/storaged-project/blivet/issues/1258