### PR TITLE
LUKS OPAL support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -206,6 +206,8 @@ AS_IF([test "x$with_crypto" != "xno"],
             [AC_DEFINE([LIBCRYPTSETUP_26])], [])
       AS_IF([$PKG_CONFIG --atleast-version=2.7.0 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_27])], [])
+      AC_CHECK_HEADER([linux/sed-opal.h],
+                      [AC_DEFINE([HAVE_LINUX_OPAL])], [])
       AS_IF([test "x$with_escrow" != "xno"],
             [LIBBLOCKDEV_PKG_CHECK_MODULES([NSS], [nss >= 3.18.0])
              LIBBLOCKDEV_CHECK_HEADER([volume_key/libvolume_key.h], [$GLIB_CFLAGS $NSS_CFLAGS], [libvolume_key.h not available])],

--- a/configure.ac
+++ b/configure.ac
@@ -204,6 +204,8 @@ AS_IF([test "x$with_crypto" != "xno"],
             [AC_DEFINE([LIBCRYPTSETUP_24])], [])
       AS_IF([$PKG_CONFIG --atleast-version=2.6.0 libcryptsetup],
             [AC_DEFINE([LIBCRYPTSETUP_26])], [])
+      AS_IF([$PKG_CONFIG --atleast-version=2.7.0 libcryptsetup],
+            [AC_DEFINE([LIBCRYPTSETUP_27])], [])
       AS_IF([test "x$with_escrow" != "xno"],
             [LIBBLOCKDEV_PKG_CHECK_MODULES([NSS], [nss >= 3.18.0])
              LIBBLOCKDEV_CHECK_HEADER([volume_key/libvolume_key.h], [$GLIB_CFLAGS $NSS_CFLAGS], [libvolume_key.h not available])],

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -126,6 +126,7 @@ bd_crypto_bitlk_open
 bd_crypto_bitlk_close
 bd_crypto_fvault2_open
 bd_crypto_fvault2_close
+bd_crypto_opal_is_supported
 BDCryptoTech
 BDCryptoTechMode
 bd_crypto_is_tech_avail

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -127,6 +127,7 @@ bd_crypto_bitlk_close
 bd_crypto_fvault2_open
 bd_crypto_fvault2_close
 bd_crypto_opal_is_supported
+bd_crypto_opal_wipe
 BDCryptoTech
 BDCryptoTechMode
 bd_crypto_is_tech_avail

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -128,6 +128,7 @@ bd_crypto_fvault2_open
 bd_crypto_fvault2_close
 bd_crypto_opal_is_supported
 bd_crypto_opal_wipe
+bd_crypto_opal_format
 BDCryptoTech
 BDCryptoTechMode
 bd_crypto_is_tech_avail

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -38,6 +38,7 @@ typedef enum {
     BD_CRYPTO_TECH_BITLK,
     BD_CRYPTO_TECH_KEYRING,
     BD_CRYPTO_TECH_FVAULT2,
+    BD_CRYPTO_TECH_SED_OPAL,
 } BDCryptoTech;
 
 typedef enum {
@@ -1322,5 +1323,18 @@ gboolean bd_crypto_fvault2_open (const gchar *device, const gchar *name, BDCrypt
  * Tech category: %BD_CRYPTO_TECH_FVAULT2-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
  */
 gboolean bd_crypto_fvault2_close (const gchar *fvault2_device, GError **error);
+
+/**
+ * bd_crypto_opal_is_supported:
+ * @device: device to check for OPAL support
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: %TRUE if the given @device supports OPAL or %FALSE if not or
+ * failed to determine (the @error is populated with the error in such
+ * cases).
+ *
+ * Tech category: %BD_CRYPTO_TECH_SED_OPAL-%BD_CRYPTO_TECH_MODE_QUERY
+ */
+gboolean bd_crypto_opal_is_supported (const gchar *device, GError **error);
 
 #endif  /* BD_CRYPTO_API */

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -1370,4 +1370,31 @@ gboolean bd_crypto_opal_is_supported (const gchar *device, GError **error);
  */
 gboolean bd_crypto_opal_wipe_device (const gchar *device, BDCryptoKeyslotContext *context, GError **error);
 
+/**
+ * bd_crypto_opal_format:
+ * @device: a device to format as LUKS HW-OPAL
+ * @cipher: (nullable): cipher specification (type-mode, e.g. "aes-xts-plain64") or %NULL to use the default
+ * @key_size: size of the volume key in bits or 0 to use the default
+ * @context: key slot context (passphrase/keyfile/token...) for this LUKS device
+ * @min_entropy: minimum random data entropy (in bits) required to format @device as LUKS
+ * @hw_encryption: type of hardware encryption (SW+HW or HW only)
+ * @opal_context: OPAL admin passphrase
+ * @extra: (nullable): extra arguments for LUKS format creation
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Formats the given @device as LUKS HW-OPAL according to the other parameters given. If
+ * @min_entropy is specified (greater than 0), the function waits for enough
+ * entropy to be available in the random data pool (WHICH MAY POTENTIALLY TAKE
+ * FOREVER).
+ *
+ * Supported @context types for this function: passphrase, key file
+ * Supported @opal_context types for this function: passphrase
+ *
+ * Returns: whether the given @device was successfully formatted as LUKS HW-OPAL or not
+ * (the @error contains the error in such cases)
+ *
+ * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_CREATE
+ */
+gboolean bd_crypto_opal_format (const gchar *device, const gchar *cipher, guint64 key_size, BDCryptoKeyslotContext *context, guint64 min_entropy, BDCryptoLUKSHWEncryptionType hw_encryption, BDCryptoKeyslotContext *opal_context, BDCryptoLUKSExtra *extra, GError **error);
+
 #endif  /* BD_CRYPTO_API */

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -365,6 +365,22 @@ typedef enum {
 GType bd_crypto_luks_info_get_type();
 
 /**
+ * BDCryptoLUKSHWEncryptionType:
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_UNKNOWN: used for unknown/unsupported hardware encryption or when
+ *                                        error was detected when getting the information
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_SW_ONLY: hardware encryption is not configured on this device
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_ONLY: only OPAL hardware encryption is configured on this device
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_AND_SW: both OPAL hardware encryption and software encryption
+ *                                               (using LUKS/dm-crypt) is configured on this device
+ */
+typedef enum {
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_UNKNOWN = 0,
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_SW_ONLY,
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_ONLY,
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_AND_SW,
+} BDCryptoLUKSHWEncryptionType;
+
+/**
  * BDCryptoLUKSInfo:
  * @version: LUKS version
  * @cipher: used cipher (e.g. "aes")
@@ -376,6 +392,7 @@ GType bd_crypto_luks_info_get_type();
  * @metadata_size: LUKS metadata size
  * @label: label of the LUKS device (valid only for LUKS 2)
  * @subsystem: subsystem of the LUKS device (valid only for LUKS 2)
+ * @hw_encryption: hardware encryption type
  */
 typedef struct BDCryptoLUKSInfo {
     BDCryptoLUKSVersion version;
@@ -387,6 +404,7 @@ typedef struct BDCryptoLUKSInfo {
     guint64 metadata_size;
     gchar *label;
     gchar *subsystem;
+    BDCryptoLUKSHWEncryptionType hw_encryption;
 } BDCryptoLUKSInfo;
 
 /**
@@ -429,6 +447,7 @@ BDCryptoLUKSInfo* bd_crypto_luks_info_copy (BDCryptoLUKSInfo *info) {
     new_info->metadata_size = info->metadata_size;
     new_info->label = g_strdup (info->label);
     new_info->subsystem = g_strdup (info->subsystem);
+    new_info->hw_encryption = info->hw_encryption;
 
     return new_info;
 }

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -1337,4 +1337,18 @@ gboolean bd_crypto_fvault2_close (const gchar *fvault2_device, GError **error);
  */
 gboolean bd_crypto_opal_is_supported (const gchar *device, GError **error);
 
+/**
+ * bd_crypto_opal_wipe_device:
+ * @device: LUKS HW-OPAL device to wipe
+ * @context: OPAL admin passphrase context
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Returns: whether @device was successfully wiped or not.
+ *
+ * Supported @context types for this function: passphrase
+ *
+ * Tech category: %BD_CRYPTO_TECH_SED_OPAL-%BD_CRYPTO_TECH_MODE_MODIFY
+ */
+gboolean bd_crypto_opal_wipe_device (const gchar *device, BDCryptoKeyslotContext *context, GError **error);
+
 #endif  /* BD_CRYPTO_API */

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -319,5 +319,6 @@ gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, 
 
 gboolean bd_crypto_opal_is_supported (const gchar *device, GError **error);
 gboolean bd_crypto_opal_wipe (const gchar *device, BDCryptoKeyslotContext *context, GError **error);
-
+gboolean bd_crypto_opal_format (const gchar *device, const gchar *cipher, guint64 key_size, BDCryptoKeyslotContext *context, guint64 min_entropy, BDCryptoLUKSHWEncryptionType hw_encryption,
+                                BDCryptoKeyslotContext *opal_context, BDCryptoLUKSExtra *extra, GError **error);
 #endif  /* BD_CRYPTO */

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -147,20 +147,20 @@ typedef enum {
 } BDCryptoIntegrityOpenFlags;
 
 /**
- * BDCryptoLUKSSEDOPALType:
- * @BD_CRYPTO_LUKS_SED_OPAL_UNKNOWN: used for unknown/unsupported hardware encryption or when
- *                                   error was raised when getting the information
- * @BD_CRYPTO_LUKS_SED_OPAL_SW_ONLY: OPAL hardware encryption is not configured on this device
- * @BD_CRYPTO_LUKS_SED_OPAL_HW_ONLY: only OPAL hardware encryption is configured on this device
- * @BD_CRYPTO_LUKS_SED_OPAL_HW_AND_SW: both OPAL hardware encryption and software encryption
- *                                     (using LUKS/dm-crypt) is configured on this device
+ * BDCryptoLUKSHWEncryptionType:
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_UNKNOWN: used for unknown/unsupported hardware encryption or when
+ *                                        error was detected when getting the information
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_SW_ONLY: hardware encryption is not configured on this device
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_ONLY: only OPAL hardware encryption is configured on this device
+ * @BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_AND_SW: both OPAL hardware encryption and software encryption
+ *                                               (using LUKS/dm-crypt) is configured on this device
  */
 typedef enum {
-    BD_CRYPTO_LUKS_SED_OPAL_UNKNOWN = 0,
-    BD_CRYPTO_LUKS_SED_OPAL_SW_ONLY,
-    BD_CRYPTO_LUKS_SED_OPAL_HW_ONLY,
-    BD_CRYPTO_LUKS_SED_OPAL_HW_AND_SW,
-} BDCryptoLUKSSEDOPALType;
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_UNKNOWN = 0,
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_SW_ONLY,
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_ONLY,
+    BD_CRYPTO_LUKS_HW_ENCRYPTION_OPAL_HW_AND_SW,
+} BDCryptoLUKSHWEncryptionType;
 
 /**
  * BDCryptoLUKSInfo:
@@ -186,7 +186,7 @@ typedef struct BDCryptoLUKSInfo {
     guint64 metadata_size;
     gchar *label;
     gchar *subsystem;
-    BDCryptoLUKSSEDOPALType hw_encryption;
+    BDCryptoLUKSHWEncryptionType hw_encryption;
 } BDCryptoLUKSInfo;
 
 void bd_crypto_luks_info_free (BDCryptoLUKSInfo *info);

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -42,6 +42,7 @@ typedef enum {
     BD_CRYPTO_TECH_BITLK,
     BD_CRYPTO_TECH_KEYRING,
     BD_CRYPTO_TECH_FVAULT2,
+    BD_CRYPTO_TECH_SED_OPAL,
 } BDCryptoTech;
 
 typedef enum {
@@ -146,6 +147,22 @@ typedef enum {
 } BDCryptoIntegrityOpenFlags;
 
 /**
+ * BDCryptoLUKSSEDOPALType:
+ * @BD_CRYPTO_LUKS_SED_OPAL_UNKNOWN: used for unknown/unsupported hardware encryption or when
+ *                                   error was raised when getting the information
+ * @BD_CRYPTO_LUKS_SED_OPAL_SW_ONLY: OPAL hardware encryption is not configured on this device
+ * @BD_CRYPTO_LUKS_SED_OPAL_HW_ONLY: only OPAL hardware encryption is configured on this device
+ * @BD_CRYPTO_LUKS_SED_OPAL_HW_AND_SW: both OPAL hardware encryption and software encryption
+ *                                     (using LUKS/dm-crypt) is configured on this device
+ */
+typedef enum {
+    BD_CRYPTO_LUKS_SED_OPAL_UNKNOWN = 0,
+    BD_CRYPTO_LUKS_SED_OPAL_SW_ONLY,
+    BD_CRYPTO_LUKS_SED_OPAL_HW_ONLY,
+    BD_CRYPTO_LUKS_SED_OPAL_HW_AND_SW,
+} BDCryptoLUKSSEDOPALType;
+
+/**
  * BDCryptoLUKSInfo:
  * @version: LUKS version
  * @cipher: used cipher (e.g. "aes")
@@ -157,6 +174,7 @@ typedef enum {
  * @metadata_size: LUKS metadata size
  * @label: label of the LUKS device (valid only for LUKS 2)
  * @subsystem: subsystem of the LUKS device (valid only for LUKS 2)
+ * @hw_encryption: hardware encryption type
  */
 typedef struct BDCryptoLUKSInfo {
     BDCryptoLUKSVersion version;
@@ -168,6 +186,7 @@ typedef struct BDCryptoLUKSInfo {
     guint64 metadata_size;
     gchar *label;
     gchar *subsystem;
+    BDCryptoLUKSSEDOPALType hw_encryption;
 } BDCryptoLUKSInfo;
 
 void bd_crypto_luks_info_free (BDCryptoLUKSInfo *info);
@@ -297,5 +316,7 @@ gboolean bd_crypto_fvault2_open (const gchar *device, const gchar *name, BDCrypt
 gboolean bd_crypto_fvault2_close (const gchar *fvault2_device, GError **error);
 
 gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, const gchar *cert_data, const gchar *directory, const gchar *backup_passphrase, GError **error);
+
+gboolean bd_crypto_opal_is_supported (const gchar *device, GError **error);
 
 #endif  /* BD_CRYPTO */

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -318,5 +318,6 @@ gboolean bd_crypto_fvault2_close (const gchar *fvault2_device, GError **error);
 gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, const gchar *cert_data, const gchar *directory, const gchar *backup_passphrase, GError **error);
 
 gboolean bd_crypto_opal_is_supported (const gchar *device, GError **error);
+gboolean bd_crypto_opal_wipe (const gchar *device, BDCryptoKeyslotContext *context, GError **error);
 
 #endif  /* BD_CRYPTO */

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -386,6 +386,13 @@ def crypto_integrity_open(device, name, algorithm, context=None, flags=0, extra=
 __all__.append("crypto_integrity_open")
 
 
+_crypto_opal_format = BlockDev.crypto_opal_format
+@override(BlockDev.crypto_opal_format)
+def crypto_opal_format(device, cipher=None, key_size=0, context=None, min_entropy=0, opal_context=None, hw_encryption=BlockDev.CryptoLUKSHWEncryptionType.OPAL_HW_AND_SW, extra=None):
+    return _crypto_opal_format(device, cipher, key_size, context, min_entropy, hw_encryption, opal_context, extra)
+__all__.append("crypto_opal_format")
+
+
 _dm_create_linear = BlockDev.dm_create_linear
 @override(BlockDev.dm_create_linear)
 def dm_create_linear(map_name, device, length, uuid=None):


### PR DESCRIPTION
Support for OPAL self-encrypting drives using the latest cryptsetup feature that allows combining LUKS and SED OPAL drives.

Marking as a draft for now, I don't plan to do much changes but I might change some smaller things based on the blivet and anaconda support.