### PR TITLE
tests: No longer need to skip exfat UUID tests on Fedora

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -50,12 +50,6 @@
     - arch: "i686"
       reason: "Cache attach/detach fails with ENOMEM on 32bit systems"
 
-- test: fs_tests.(exfat_test.ExfatSetUUID.test_exfat_set_uuid|generic_test.GenericSetUUID.test_exfat_generic_set_uuid)
-  skip_on:
-    - distro: "fedora"
-      version: ["39", "40", "41"]
-      reason: Setting UUID with LC_ALL=C.UTF-8 is broken with recent exfatprogs
-
 - test: (lvm_test|lvm_dbus_tests).LVMVDOTest
   skip_on:
     - distro: "centos"


### PR DESCRIPTION
The fixed version of exfatprogs is now available on all supported Fedora releases.