### PR TITLE
ci: Remove priority from Testing farm repositories

### DIFF
--- a/plans/blivet.fmf
+++ b/plans/blivet.fmf
@@ -6,6 +6,16 @@ adjust+:
   enabled: true
 
 prepare:
+  - name: copr
+    how: shell
+    script:
+      - sudo dnf install -y 'dnf-command(copr)'
+      - sudo dnf copr enable -y @storage/udisks-daily
+      # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
+      - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
+      - sudo dnf -y update
+
+  - name: ansible
     how: ansible
     playbook:
         - https://raw.githubusercontent.com/storaged-project/blivet/master/misc/install-test-dependencies.yml

--- a/plans/tests.fmf
+++ b/plans/tests.fmf
@@ -10,6 +10,9 @@ prepare:
     script:
       - sudo dnf install -y 'dnf-command(copr)'
       - sudo dnf copr enable -y @storage/udisks-daily
+      # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
+      - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
+      - sudo dnf -y update
 
   - name: ansible
     how: ansible

--- a/plans/udisks.fmf
+++ b/plans/udisks.fmf
@@ -6,6 +6,16 @@ adjust+:
   enabled: true
 
 prepare:
+  - name: copr
+    how: shell
+    script:
+      - sudo dnf install -y 'dnf-command(copr)'
+      - sudo dnf copr enable -y @storage/udisks-daily
+      # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
+      - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
+      - sudo dnf -y update
+
+  - name: ansible
     how: ansible
     playbook:
         - https://raw.githubusercontent.com/storaged-project/udisks/master/misc/install-test-dependencies.yml


### PR DESCRIPTION
Testing farm sets priority of their repositories to 9 which means the repo is prioritized over all other repositories including our Copr repo with daily builds preventing the latest libblockdev from being installed in the reverse dependency test.