### PR TITLE
tests: Fix skipping VDO tests on Debian and CentOS 10

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -52,6 +52,5 @@
 
 - test: (lvm_test|lvm_dbus_tests).LVMVDOTest
   skip_on:
-    - distro: "centos"
-      version: "10"
-      reason: "vdo userspace tools are not yet available on RHEL/CentOS 10"
+    - distro: "debian"
+      reason: "vdo userspace tools are not available on Debian"


### PR DESCRIPTION
VDO userspace tools are now available on C10S, but are not yet available on Debian where the kernel module is now available.