### PR TITLE
crypto: Fix GType macro for crypto context

### DIFF
--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -755,7 +755,7 @@ struct _BDCryptoKeyslotContext {
 };
 typedef struct _BDCryptoKeyslotContext BDCryptoKeyslotContext;
 
-#define BD_CRYPTO_KEYSLOT_CONTEXT (bd_crypto_keyslot_context_get_type ())
+#define BD_CRYPTO_TYPE_KEYSLOT_CONTEXT (bd_crypto_keyslot_context_get_type ())
 GType bd_crypto_keyslot_context_get_type();
 
 /**


### PR DESCRIPTION
The convention is to name the macros PREFIX_TYPE_ and we adhere to it with other types so we should do that here as well.