### PR TITLE
README: Update supported technologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ Following storage technologies are supported by libblockdev
  - encryption
    - LUKS, TrueCrypt/VeraCrypt, BitLocker, FileVault2
    - integrity
+   - SED OPAL
  - DM (device mapper)
  - loop devices
  - MD RAID
  - multipath
  - s390
    - DASD, zFCP
- - NVDIMM namespaces
+ - NVDIMM namespaces (deprecated)
  - NVMe
+ - SMART
 
 #### Architecture
 


### PR DESCRIPTION
SMART and SED OPAL were added in 3.2 and NVDIMM is deprecated since 3.1.