### PR TITLE
dist: Fix source URL in spec

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -90,7 +90,7 @@ Release:     1%{?dist}
 Summary:     A library for low-level manipulation with block devices
 License:     LGPL-2.1-or-later
 URL:         https://github.com/storaged-project/libblockdev
-Source0:     https://github.com/storaged-project/libblockdev/releases/download/%{version}-%{release}/%{name}-%{version}.tar.gz
+Source0:     https://github.com/storaged-project/libblockdev/releases/download/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: make
 BuildRequires: glib2-devel


### PR DESCRIPTION
We stopped using the release version in tags in 07352e9 so we need to update the path to the release tarball as well.