### PR TITLE
tests: Enable LVM VDO tests on Debian

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt -y install ansible
-        ansible-playbook -b -i "localhost," -c local misc/install-test-dependencies.yml
+        ansible-playbook -b -i "localhost," -c local misc/install-test-dependencies.yml -e "test_dependencies=false"
 
     - name: Build
       run: |

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -145,7 +145,7 @@
       - vdo
       - volume-key
       - xfsprogs
-    when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu' and test_dependencies|bool
+    when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu') and test_dependencies|bool
 
 ####### Common actions
 

--- a/misc/install-test-dependencies.yml
+++ b/misc/install-test-dependencies.yml
@@ -142,6 +142,7 @@
       - smartmontools
       - targetcli-fb
       - udftools
+      - vdo
       - volume-key
       - xfsprogs
     when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu' and test_dependencies|bool

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -53,4 +53,5 @@
 - test: (lvm_test|lvm_dbus_tests).LVMVDOTest
   skip_on:
     - distro: "debian"
-      reason: "vdo userspace tools are not available on Debian"
+      arch: "i686"
+      reason: "vdo userspace tools are not available on 32bit Debian"


### PR DESCRIPTION
The VDO userspace tools are now available on 64bit Debian.