### PR TITLE
Skip tests for plugins disabled during compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ dist/libblockdev.spec
 tools/lvm-cache-stats
 tools/vfat-resize
 misc/.vagrant
+tests/config_h.py

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,7 +65,7 @@ DISTCHECK_CONFIGURE_FLAGS += --without-s390
 endif
 
 
-SUBDIRS = include src dist scripts data tools
+SUBDIRS = include src dist scripts data tools tests
 if WITH_GTK_DOC
 SUBDIRS += docs
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -41,7 +41,8 @@ AC_CONFIG_FILES([Makefile src/Makefile \
                           scripts/Makefile \
                           tools/Makefile \
                           data/Makefile \
-                          data/conf.d/Makefile])
+                          data/conf.d/Makefile \
+                          tests/Makefile])
 
 m4_ifdef([GOBJECT_INTROSPECTION_CHECK],
 [GOBJECT_INTROSPECTION_CHECK([1.3.0])],

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,82 @@
+# Generate config.h.py with translated defines for easy use within Python
+
+CONFIG_H_PY = config_h.py
+PLUGINS =
+
+if WITH_BTRFS
+PLUGINS += btrfs
+endif
+
+if WITH_CRYPTO
+PLUGINS += crypto
+endif
+
+if WITH_DM
+PLUGINS += dm
+endif
+
+if WITH_LOOP
+PLUGINS += loop
+endif
+
+if WITH_LVM
+PLUGINS += lvm
+endif
+
+if WITH_LVM_DBUS
+PLUGINS += lvm-dbus
+endif
+
+if WITH_MDRAID
+PLUGINS += mdraid
+endif
+
+if WITH_MPATH
+PLUGINS += mpath
+endif
+
+if WITH_SWAP
+PLUGINS += swap
+endif
+
+if WITH_PART
+PLUGINS += part
+endif
+
+if WITH_FS
+PLUGINS += fs
+endif
+
+if WITH_NVDIMM
+PLUGINS += nvdimm
+endif
+
+if WITH_NVME
+PLUGINS += nvme
+endif
+
+if WITH_SMART
+PLUGINS += smart
+endif
+
+if WITH_SMARTMONTOOLS
+PLUGINS += smartmontools
+endif
+
+if WITH_TOOLS
+PLUGINS += tools
+endif
+
+$(CONFIG_H_PY):
+	echo -n 'ENABLED_PLUGINS = [ ' > $(CONFIG_H_PY)
+	for i in $(PLUGINS); do \
+		echo -n "'$$i', " >> $(CONFIG_H_PY); \
+	done
+	echo ']' >> $(CONFIG_H_PY)
+
+all: $(CONFIG_H_PY)
+
+EXTRA_DIST =
+
+clean-local:
+	rm -f *~ $(CONFIG_H_PY)

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -9,7 +9,7 @@ import time
 from packaging.version import Version
 
 import overrides_hack
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, mount, umount, run_command, TestTags, tag_test
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, mount, umount, run_command, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -21,6 +21,8 @@ TEST_MNT = "/tmp/libblockdev_test_mnt"
 def wipefs(device):
     os.system("wipefs -a %s > /dev/null" % device)
 
+
+@required_plugins(("btrfs",))
 class BtrfsTest(unittest.TestCase):
     requested_plugins = BlockDev.plugin_specs_from_names(("btrfs",))
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -9,7 +9,7 @@ import locale
 import re
 import tarfile
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, get_avail_locales, requires_locales, run_command, read_file, TestTags, tag_test
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, get_avail_locales, requires_locales, run_command, read_file, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -35,6 +35,7 @@ HAVE_FVAULT2 = check_cryptsetup_version("2.6.0")
 HAVE_OPAL = check_cryptsetup_version("2.7.0")
 
 
+@required_plugins(("crypto", "loop"))
 class CryptoTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("crypto", "loop"))

--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import overrides_hack
 
-from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test
+from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -10,6 +10,7 @@ gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
 
+@required_plugins(("dm",))
 class DevMapperTest(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("dm",))

--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -33,7 +33,7 @@ def check_output(args, ignore_retcode=True):
         else:
             raise
 
-
+@utils.required_plugins(("fs", "loop"))
 class FSNoDevTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("fs", "loop"))

--- a/tests/fs_tests/generic_test.py
+++ b/tests/fs_tests/generic_test.py
@@ -980,6 +980,7 @@ class GenericResize(GenericTestCase):
         self.assertEqual(new_size, size)
 
     @tag_test(TestTags.UNSTABLE)
+    @utils.required_plugins(("tools",))
     def test_vfat_generic_resize(self):
         """Test generic resize function with a vfat file system"""
         def mkfs_vfat(device, options=None):

--- a/tests/fs_tests/vfat_test.py
+++ b/tests/fs_tests/vfat_test.py
@@ -42,6 +42,7 @@ class VfatTestCase(FSTestCase):
 
 class VfatTestAvailability(VfatNoDevTestCase):
 
+    @utils.required_plugins(("tools",))
     def test_vfat_available(self):
         """Verify that it is possible to check vfat tech availability"""
         available = BlockDev.fs_is_tech_avail(BlockDev.FSTech.VFAT,
@@ -281,6 +282,7 @@ class VfatSetUUID(VfatTestCase):
             BlockDev.fs_vfat_check_uuid(10 * "f")
 
 
+@utils.required_plugins(("tools",))
 class VfatResize(VfatTestCase):
     def test_vfat_resize(self):
         """Verify that it is possible to resize an vfat file system"""

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import re
 import overrides_hack
-from utils import fake_path, TestTags, tag_test
+from utils import fake_path, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -10,6 +10,7 @@ gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
 
+@required_plugins(("crypto","dm", "loop", "mdraid", "part", "swap"))
 class LibraryOpsTestCase(unittest.TestCase):
     log = ""
 

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -3,13 +3,15 @@ import unittest
 import time
 import overrides_hack
 
-from utils import create_sparse_tempfile, TestTags, tag_test
+from utils import create_sparse_tempfile, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
 gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
+
+@required_plugins(("loop",))
 class LoopTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("loop",))

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -11,7 +11,7 @@ from packaging.version import Version
 from itertools import chain
 import sys
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, run_command, TestTags, tag_test, read_file
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, run_command, TestTags, tag_test, read_file, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -38,6 +38,7 @@ def wait_for_sync(vg_name, lv_name):
             time.sleep(1)
 
 
+@required_plugins(("lvm-dbus",))
 class LVMTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -9,7 +9,7 @@ import time
 from contextlib import contextmanager
 from packaging.version import Version
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command, read_file
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command, read_file, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -32,6 +32,7 @@ def wait_for_sync(vg_name, lv_name):
             time.sleep(1)
 
 
+@required_plugins(("lvm",))
 class LVMTestCase(unittest.TestCase):
 
     @classmethod

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -5,7 +5,7 @@ import time
 from contextlib import contextmanager
 import overrides_hack
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, run_command, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -27,6 +27,8 @@ def wait_for_action(action_name):
                 print("Sleeping")
                 time.sleep(1)
 
+
+@required_plugins(("mdraid",))
 class MDTest(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("mdraid",))

--- a/tests/mpath_test.py
+++ b/tests/mpath_test.py
@@ -3,13 +3,15 @@ import os
 import overrides_hack
 import shutil
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, get_version, TestTags, tag_test
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, get_version, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
 gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
+
+@required_plugins(("mpath",))
 class MpathTest(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("mpath",))

--- a/tests/nvdimm_test.py
+++ b/tests/nvdimm_test.py
@@ -6,7 +6,7 @@ import overrides_hack
 
 from packaging.version import Version
 
-from utils import run_command, read_file, fake_path, TestTags, tag_test
+from utils import run_command, read_file, fake_path, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -14,6 +14,7 @@ gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
 
+@required_plugins(("nvdimm",))
 class NVDIMMTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("nvdimm",))

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -4,13 +4,15 @@ import re
 import shutil
 import overrides_hack
 
-from utils import create_sparse_tempfile, create_nvmet_device, delete_nvmet_device, setup_nvme_target, teardown_nvme_target, find_nvme_ctrl_devs_for_subnqn, find_nvme_ns_devs_for_subnqn, get_nvme_hostnqn, run_command, TestTags, tag_test, read_file, write_file
+from utils import create_sparse_tempfile, create_nvmet_device, delete_nvmet_device, setup_nvme_target, teardown_nvme_target, find_nvme_ctrl_devs_for_subnqn, find_nvme_ns_devs_for_subnqn, get_nvme_hostnqn, run_command, TestTags, tag_test, read_file, write_file, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
 gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
+
+@required_plugins(("nvme", "loop"))
 class NVMeTest(unittest.TestCase):
     requested_plugins = BlockDev.plugin_specs_from_names(("nvme", "loop"))
 

--- a/tests/overrides_test.py
+++ b/tests/overrides_test.py
@@ -6,9 +6,10 @@ import gi
 gi.require_version('BlockDev', '3.0')
 from gi.repository import BlockDev
 
-from utils import TestTags, tag_test
+from utils import TestTags, tag_test, required_plugins
 
 
+@required_plugins(("crypto", "dm", "loop", "lvm", "mdraid", "part", "swap"))
 class OverridesTest(unittest.TestCase):
     # all plugins except for 'btrfs', 'fs' and 'mpath' -- these don't have all
     # the dependencies on CentOS/Debian and we don't need them for this test

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import re
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, TestTags, tag_test, run_command
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, TestTags, tag_test, run_command, required_plugins
 import overrides_hack
 
 from bytesize.bytesize import Size, ROUND_UP
@@ -12,6 +12,8 @@ gi.require_version('GLib', '2.0')
 gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
+
+@required_plugins(("part",))
 class PartTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("part",))

--- a/tests/s390_test.py
+++ b/tests/s390_test.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import overrides_hack
 
-from utils import fake_path, TestTags, tag_test
+from utils import fake_path, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -10,6 +10,7 @@ gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
 @unittest.skipUnless(os.uname()[4].startswith('s390'), "s390x architecture required")
+@required_plugins(("s390",))
 class S390TestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("s390",))

--- a/tests/smart_test.py
+++ b/tests/smart_test.py
@@ -6,7 +6,7 @@ import time
 import shutil
 import overrides_hack
 
-from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, write_file, run_command
+from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, write_file, run_command, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -14,6 +14,7 @@ gi.require_version('BlockDev', '3.0')
 from gi.repository import BlockDev, GLib
 
 
+@required_plugins(("smart",))
 class SMARTTest(unittest.TestCase):
 
     # dumps from real drives, both HDD and SSD

--- a/tests/smartmontools_test.py
+++ b/tests/smartmontools_test.py
@@ -6,7 +6,7 @@ import time
 import shutil
 import overrides_hack
 
-from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, write_file, run_command
+from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, write_file, run_command, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -14,6 +14,7 @@ gi.require_version('BlockDev', '3.0')
 from gi.repository import BlockDev, GLib
 
 
+@required_plugins(("smartmontools",))
 class SmartmontoolsTest(unittest.TestCase):
 
     # dumps from real drives, both HDD and SSD

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -3,13 +3,15 @@ import os
 import resource
 import overrides_hack
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, run_command, run, TestTags, tag_test
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, run_command, run, TestTags, tag_test, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
 gi.require_version('BlockDev', '3.0')
 from gi.repository import GLib, BlockDev
 
+
+@required_plugins(("swap",))
 class SwapTest(unittest.TestCase):
     requested_plugins = BlockDev.plugin_specs_from_names(("swap",))
     dev_size = 1024**3

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -559,6 +559,21 @@ def skip_on(skip_on_distros=None, skip_on_version="", skip_on_arch="", reason=""
 
     return decorator
 
+def required_plugins(plugins):
+    def decorator(func):
+        try:
+            from config_h import ENABLED_PLUGINS
+        except ImportError:
+            # config_h doesn't exist -> we're running tests against installed libblockdev
+            return func
+
+        unavail = [p for p in plugins if p not in ENABLED_PLUGINS]
+        if unavail:
+            msg = "Skipping, libblockdev was compiled without plugins required for this test case: %s" % ", ".join(unavail)
+            return unittest.skip(msg)(func)
+        return func
+    return decorator
+
 # taken from libbytesize's tests/locale_utils.py
 def get_avail_locales():
     return {loc.decode(errors="replace").strip() for loc in subprocess.check_output(["locale", "-a"]).split()}


### PR DESCRIPTION
Fixes: #943

The `config_h.py` file functionality is basically copy-pasted from udisks.