### PR TITLE
packit: Fix replacement of placeholders in post-upstream-clone

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,7 +1,7 @@
 actions:
   post-upstream-clone:
     - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
-    - 'sed -i -e "s/@WITH_.+@/1/g" -e "s/@MAJOR_VER@/3/g" dist/libblockdev.spec'
+    - 'sed -i -e "s/@WITH_..*@/1/g" -e "s/@MAJOR_VER@/3/g" dist/libblockdev.spec'
   create-archive:
     - './autogen.sh'
     - './configure'
@@ -37,7 +37,7 @@ jobs:
       # bump release to 99 to always be ahead of Fedora builds
       - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec.in"'
       - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
-      - 'sed -i -e "s/@WITH_.+@/1/g" -e "s/@MAJOR_VER@/3/g" dist/libblockdev.spec'
+      - 'sed -i -e "s/@WITH_..*@/1/g" -e "s/@MAJOR_VER@/3/g" dist/libblockdev.spec'
     create-archive:
       - './autogen.sh'
       - './configure'
@@ -58,7 +58,7 @@ jobs:
       # bump release to 99 to always be ahead of Fedora builds
       - 'bash -c "sed -i -r \"s/Release:(\s*)\S+/Release:     99%{?dist}/\" dist/libblockdev.spec.in"'
       - 'cp dist/libblockdev.spec.in dist/libblockdev.spec'
-      - 'sed -i -e "s/@WITH_.+@/1/g" -e "s/@MAJOR_VER@/3/g" dist/libblockdev.spec'
+      - 'sed -i -e "s/@WITH_..*@/1/g" -e "s/@MAJOR_VER@/3/g" dist/libblockdev.spec'
     create-archive:
       - './autogen.sh'
       - './configure'


### PR DESCRIPTION
I'm not exactly sure why, but while the sed expression does work in Copr, it doesn't work in Packit sandbox environment when running propose-downstream, hence the failures: https://github.com/storaged-project/libblockdev/runs/32657399598

This should hopefully fix it.