### PR TITLE
misc: Do not use "with_items" when installing packages

### DIFF
--- a/misc/libblockdev-tasks.yml
+++ b/misc/libblockdev-tasks.yml
@@ -4,13 +4,14 @@
 ---
 ####### Fedora
 - name: Install basic build tools (Fedora)
-  package: name={{item}} state=present
-  with_items:
-    - gcc
-    - make
-    - libtool
-    - autoconf
-    - automake
+  package:
+    state: present
+    name:
+      - gcc
+      - make
+      - libtool
+      - autoconf
+      - automake
   when: ansible_distribution == 'Fedora'
 
 - name: Install dnf-plugins-core for dnf builddep (Fedora)
@@ -22,59 +23,62 @@
   when: ansible_distribution == 'Fedora'
 
 - name: Install build dependencies not covered by dnf builddep (Fedora)
-  package: name={{item}} state=present
-  with_items:
-    - libfdisk-devel
-    - keyutils-libs-devel
-    - libnvme-devel
-    - e2fsprogs-devel
-    - json-glib-devel
-    - libatasmart-devel
-    - libyaml-devel
+  package:
+    state: present
+    name:
+      - libfdisk-devel
+      - keyutils-libs-devel
+      - libnvme-devel
+      - e2fsprogs-devel
+      - json-glib-devel
+      - libatasmart-devel
+      - libyaml-devel
   when: ansible_distribution == 'Fedora'
 
 - name: Install test dependencies (Fedora)
-  package: name={{item}} state=present
-  with_items:
-    - btrfs-progs
-    - cryptsetup
-    - device-mapper-multipath
-    - dosfstools
-    - e2fsprogs
-    - exfatprogs
-    - f2fs-tools
-    - glibc-all-langpacks
-    - kernel-modules-extra
-    - lvm2-dbusd
-    - mdadm
-    - ndctl
-    - nilfs-utils
-    - nss-tools
-    - ntfsprogs
-    - nvme-cli
-    - nvmetcli
-    - python3-bytesize
-    - python3-dbus
-    - python3-packaging
-    - python3-pylint
-    - python3-yaml
-    - smartmontools
-    - targetcli
-    - udftools
-    - vdo
-    - volume_key
-    - xfsprogs
+  package:
+    state: present
+    name:
+      - btrfs-progs
+      - cryptsetup
+      - device-mapper-multipath
+      - dosfstools
+      - e2fsprogs
+      - exfatprogs
+      - f2fs-tools
+      - glibc-all-langpacks
+      - kernel-modules-extra
+      - lvm2-dbusd
+      - mdadm
+      - ndctl
+      - nilfs-utils
+      - nss-tools
+      - ntfsprogs
+      - nvme-cli
+      - nvmetcli
+      - python3-bytesize
+      - python3-dbus
+      - python3-packaging
+      - python3-pylint
+      - python3-yaml
+      - smartmontools
+      - targetcli
+      - udftools
+      - vdo
+      - volume_key
+      - xfsprogs
   when: ansible_distribution == 'Fedora' and test_dependencies|bool
 
 ####### CentOS
 - name: Install basic build tools (CentOS)
-  package: name={{item}} state=present
-  with_items:
-    - gcc
-    - make
-    - libtool
-    - autoconf
-    - automake
+  package:
+    state: present
+    name:
+      - gcc
+      - make
+      - libtool
+      - autoconf
+      - automake
   when: ansible_distribution == 'CentOS'
 
 - name: Install dnf-plugins-core for dnf builddep (CentOS)
@@ -86,40 +90,42 @@
   when: ansible_distribution == 'CentOS'
 
 - name: Install build dependencies not covered by dnf builddep (CentOS)
-  package: name={{item}} state=present
-  with_items:
-    - libfdisk-devel
-    - keyutils-libs-devel
-    - libnvme-devel
-    - e2fsprogs-devel
-    - json-glib-devel
-    - libatasmart-devel
-    - libyaml-devel
+  package:
+    state: present
+    name:
+      - libfdisk-devel
+      - keyutils-libs-devel
+      - libnvme-devel
+      - e2fsprogs-devel
+      - json-glib-devel
+      - libatasmart-devel
+      - libyaml-devel
   when: ansible_distribution == 'CentOS'
 
 - name: Install test dependencies (CentOS)
-  package: name={{item}} state=present
-  with_items:
-    - cryptsetup
-    - device-mapper-multipath
-    - dosfstools
-    - e2fsprogs
-    - glibc-all-langpacks
-    - lvm2-dbusd
-    - mdadm
-    - ndctl
-    - nss-tools
-    - nvme-cli
-    - nvmetcli
-    - python3-bytesize
-    - python3-dbus
-    - python3-packaging
-    - python3-yaml
-    - smartmontools
-    - targetcli
-    - vdo
-    - volume_key
-    - xfsprogs
+  package:
+    state: present
+    name:
+      - cryptsetup
+      - device-mapper-multipath
+      - dosfstools
+      - e2fsprogs
+      - glibc-all-langpacks
+      - lvm2-dbusd
+      - mdadm
+      - ndctl
+      - nss-tools
+      - nvme-cli
+      - nvmetcli
+      - python3-bytesize
+      - python3-dbus
+      - python3-packaging
+      - python3-yaml
+      - smartmontools
+      - targetcli
+      - vdo
+      - volume_key
+      - xfsprogs
   when: ansible_distribution == 'CentOS' and test_dependencies|bool
 
 - name: Install pylint using pip (CentOS)
@@ -135,10 +141,11 @@
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Install basic build tools (Debian/Ubuntu)
-  package: name={{item}} state=present
-  with_items:
-    - gcc
-    - make
+  package:
+    state: present
+    name:
+      - gcc
+      - make
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Add source repositories (Debian/Ubuntu)
@@ -161,43 +168,45 @@
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Install build dependencies not covered by apt build-dep (Debian/Ubuntu)
-  package: name={{item}} state=present
-  with_items:
-    - libfdisk-dev
-    - libkeyutils-dev
-    - libext2fs-dev
-    - libjson-glib-dev
-    - libatasmart-dev
-    - libyaml-dev
+  package:
+    state: present
+    name:
+      - libfdisk-dev
+      - libkeyutils-dev
+      - libext2fs-dev
+      - libjson-glib-dev
+      - libatasmart-dev
+      - libyaml-dev
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Install test dependencies (Debian/Ubuntu)
-  package: name={{item}} state=present
-  with_items:
-    - btrfs-progs
-    - cryptsetup
-    - dosfstools
-    - e2fsprogs
-    - exfatprogs
-    - f2fs-tools
-    - libnss3-tools
-    - locales-all
-    - lvm2-dbusd
-    - mdadm
-    - ndctl
-    - nilfs-tools
-    - ntfs-3g
-    - pylint
-    - python3-bytesize
-    - python3-packaging
-    - python3-pydbus
-    - python3-yaml
-    - smartmontools
-    - targetcli-fb
-    - udftools
-    - vdo
-    - volume-key
-    - xfsprogs
+  package:
+    state: present
+    name:
+      - btrfs-progs
+      - cryptsetup
+      - dosfstools
+      - e2fsprogs
+      - exfatprogs
+      - f2fs-tools
+      - libnss3-tools
+      - locales-all
+      - lvm2-dbusd
+      - mdadm
+      - ndctl
+      - nilfs-tools
+      - ntfs-3g
+      - pylint
+      - python3-bytesize
+      - python3-packaging
+      - python3-pydbus
+      - python3-yaml
+      - smartmontools
+      - targetcli-fb
+      - udftools
+      - vdo
+      - volume-key
+      - xfsprogs
   when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu') and test_dependencies|bool
 
 ####### Common actions


### PR DESCRIPTION
We can just pass a list of packages to the package module, when using "with_items" ansible installs the packages one by one which is significantly slower.

On a system with all dependencies already present.
Before:
real    0m57,237s
user    0m3,023s
sys     0m1,783s

After:
real    0m9,712s
user    0m1,170s
sys     0m0,512s