### PR TITLE
tests: Skip LVM VDO tests if 'vdoformat' is not available

### DIFF
--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -2116,6 +2116,9 @@ class LVMVDOTest(LVMTestCase):
         if lvm_version < Version("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")
 
+        if not shutil.which("vdoformat"):
+            raise unittest.SkipTest("vdoformat executable not found in $PATH, skipping.")
+
         super().setUpClass()
 
     def setUp(self):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -1986,6 +1986,9 @@ class LVMVDOTest(LVMTestCase):
         if lvm_version < Version("2.3.07"):
             raise unittest.SkipTest("LVM version 2.3.07 or newer needed for LVM VDO.")
 
+        if not shutil.which("vdoformat"):
+            raise unittest.SkipTest("vdoformat executable not found in $PATH, skipping.")
+
         super().setUpClass()
 
     def setUp(self):


### PR DESCRIPTION
LVM VDO still uses the vdoformat binary which might not be available everywhere.

Related: https://github.com/storaged-project/udisks/issues/1353