### PR TITLE
docs: Add missing functions to docs/libblockdev-sections.txt

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -94,6 +94,8 @@ bd_crypto_luks_header_restore
 bd_crypto_luks_set_label
 bd_crypto_luks_set_uuid
 bd_crypto_luks_convert
+BDCryptoLUKSPersistentFlags
+bd_crypto_luks_set_persistent_flags
 BDCryptoLUKSInfo
 bd_crypto_luks_info_free
 bd_crypto_luks_info_copy


### PR DESCRIPTION
Forgot to add these in #1095