### PR TITLE
tests: Skip NVDIMM reconfigure tests on rawhide

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -65,3 +65,9 @@
     - distro: "debian"
       version: "12"
       reason: "LVM >= 2.03.17 needed for LVM config parsing with --valuesonly"
+
+- test: nvdimm_test.NVDIMMNamespaceTestCase.test_namespace_reconfigure
+  skip_on:
+    - distro: "fedora"
+      version: "43"
+      reason: "The fake in-memory namespace doesn't support sector mode in kernel 6.15"


### PR DESCRIPTION
Something changed in the latest 6.15 RC and the "fake" NVDIMM device we use for testing no longer supports sector mode.

The nvdimm plugin is deprecated so I don't really want to try to fix the tests. If this starts to fail on more distributions, I will just skip the entire test suite.