### PR TITLE
tests: Temporarily skip some nvme tests on latest Fedora

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -71,3 +71,9 @@
     - distro: "fedora"
       version: "43"
       reason: "The fake in-memory namespace doesn't support sector mode in kernel 6.15"
+
+- test: nvme_test.NVMeTestCase.(test_sanitize_log|test_self_test_log)
+  skip_on:
+    - distro: "fedora"
+      version: ["42", "43"]
+      reason: "latest libnvme returns some invalid/unexpected values for sanitize and self test log"


### PR DESCRIPTION
nvme_get_sanitize_log and nvme_get_self_test_log now return some invalid data for our test loop based NVMe devices. We'll skip the tests until this is resolved.

See also #1098 and https://github.com/linux-nvme/libnvme/issues/980