### PR TITLE
ci: Switch branch for Blivet revdeps tests to 'main'

### DIFF
--- a/plans/blivet.fmf
+++ b/plans/blivet.fmf
@@ -26,7 +26,7 @@ prepare:
 discover:
     how: shell
     url: https://github.com/storaged-project/blivet
-    ref: master
+    ref: main
     tests:
       - name: all
         test: make test


### PR DESCRIPTION
Blivet recently renamed the master branch to main.