### PR TITLE
tests: Fix NVMe sanitize log return codes

### DIFF
--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -283,7 +283,7 @@ class NVMeTestCase(NVMeTest):
         with self.assertRaisesRegex(GLib.GError, r".*Failed to open device .*': No such file or directory"):
             BlockDev.nvme_get_sanitize_log("/dev/nonexistent")
 
-        message = r"NVMe Get Log Page - Sanitize Status Log command error: Invalid Field in Command: A reserved coded value or an unsupported value in a defined field|NVMe Get Log Page - Sanitize Status Log command error: unrecognized"
+        message = r"NVMe Get Log Page - Sanitize Status Log command error: (Invalid Field in Command: A reserved coded value or an unsupported value in a defined field|unrecognized|No such file or directory)"
         with self.assertRaisesRegex(GLib.GError, message):
             # Cannot retrieve sanitize log on a nvme target loop devices
             BlockDev.nvme_get_sanitize_log(self.nvme_dev)


### PR DESCRIPTION
When calling nvme_get_log_sanitize() on a namespace device through io_uring codepath, return codes may differ slightly. This is perfectly fine, subject to the kernel implementation. In this case the errno 22 comes directly from io_uring_wait_cqe().

Fixes #1101