### PR TITLE
[crypto/nvme/smart] Align structs 8 byte for 64-bit platforms

### DIFF
--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -124,8 +124,8 @@ BDCryptoLUKSExtra* bd_crypto_luks_extra_new (guint64 data_alignment, const gchar
  * @buffer_sectors: number of sectors in one buffer
  */
 typedef struct BDCryptoIntegrityExtra {
-    guint32 sector_size;
     guint64 journal_size;
+    guint32 sector_size;
     guint journal_watermark;
     guint journal_commit_time;
     guint32 interleave_sectors;
@@ -187,11 +187,11 @@ typedef enum {
  * @hw_encryption: hardware encryption type
  */
 typedef struct BDCryptoLUKSInfo {
-    BDCryptoLUKSVersion version;
     gchar *cipher;
     gchar *mode;
     gchar *uuid;
     gchar *backing_device;
+    BDCryptoLUKSVersion version;
     guint32 sector_size;
     guint64 metadata_size;
     gchar *label;
@@ -253,8 +253,8 @@ BDCryptoIntegrityInfo* bd_crypto_integrity_info_copy (BDCryptoIntegrityInfo *inf
  * @keyslot: keyslot this token is assigned to or -1 for inactive/unassigned tokens
  */
 typedef struct BDCryptoLUKSTokenInfo {
-    guint id;
     gchar *type;
+    guint id;
     gint keyslot;
 } BDCryptoLUKSTokenInfo;
 

--- a/src/plugins/nvme/nvme.h
+++ b/src/plugins/nvme/nvme.h
@@ -365,11 +365,11 @@ typedef enum {
  * @transport_type: type of the transport associated with the error.
  */
 typedef struct BDNVMEErrorLogEntry {
-    guint64 error_count;
-    guint16 command_id;
-    guint64 command_specific;
-    guint16 command_status;
     GError *command_error;
+    guint64 error_count;
+    guint64 command_specific;
+    guint16 command_id;
+    guint16 command_status;
     guint64 lba;
     guint32 nsid;
     BDNVMETransportType transport_type;
@@ -432,8 +432,8 @@ typedef struct BDNVMESelfTestLogEntry {
     BDNVMESelfTestResult result;
     BDNVMESelfTestAction action;
     guint8 segment;
-    guint64 power_on_hours;
     guint32 nsid;
+    guint64 power_on_hours;
     guint64 failing_lba;
     GError *status_code_error;
 } BDNVMESelfTestLogEntry;

--- a/src/plugins/smart/smart.h
+++ b/src/plugins/smart/smart.h
@@ -179,8 +179,8 @@ typedef struct BDSmartATAAttribute {
     gint threshold;
     gboolean failed_past;
     gboolean failing_now;
-    guint64 value_raw;
     guint16 flags;
+    guint64 value_raw;
     gint64 pretty_value;
     BDSmartATAAttributeUnit pretty_value_unit;
     gchar *pretty_value_string;
@@ -220,10 +220,10 @@ typedef struct BDSmartATA {
     gint self_test_polling_extended;
     gint self_test_polling_conveyance;
     guint smart_capabilities;
-    BDSmartATAAttribute **attributes;
     guint power_on_time;
-    guint64 power_cycle_count;
     guint temperature;
+    BDSmartATAAttribute **attributes;
+    guint64 power_cycle_count;
 } BDSmartATA;
 
 
@@ -368,8 +368,8 @@ typedef struct BDSmartSCSI {
     BDSmartSCSIInformationalException scsi_ie;
     guint8 scsi_ie_asc;
     guint8 scsi_ie_ascq;
-    gchar *scsi_ie_string;
     BDSmartSCSIBackgroundScanStatus background_scan_status;
+    gchar *scsi_ie_string;
     gdouble background_scan_progress;
     guint background_scan_runs;
     guint background_medium_scan_runs;


### PR DESCRIPTION
@vojtechtrefny, hello.
I'm new contributor at you.
This PR change should be guaranteed to lead to more frequent structs entry into CPU cache, which can greatly affect performance if aligned structures are used frequently. I hope that you know advantage this optimization method at the architectural level codebase and its inconveniences as stylistic ABI breakdown.

More info about technique:
https://stackoverflow.com/a/20882083
https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/ https://en.wikipedia.org/wiki/Data_structure_alignment