### PR TITLE
tests: Skip MDTestNominateDenominate in RHEL/CentOS 10

### DIFF
--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -76,3 +76,9 @@
     - distro: "fedora"
       version: "43"
       reason: "Bug in cryptsetup aborting when activating LUKSv1 with keyring"
+
+- test: mdraid_test.MDTestNominateDenominate.test_nominate_denominate
+  skip_on:
+    - distro: "centos"
+      version: "10"
+      reason: "Race condition in denominate with latest mdadm v4.4"


### PR DESCRIPTION
Race condition when trying to remove the disk, reported against C10S as RHEL-100004.