### PR TITLE
Sync rhel10-branch CI configuration to master

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,6 +25,7 @@ jobs:
     - fedora-latest-stable-ppc64le
     - fedora-latest-stable-x86_64
   trigger: pull_request
+  branch: master
 
 - job: copr_build
   trigger: commit
@@ -89,6 +90,7 @@ jobs:
   trigger: pull_request
   targets:
     - fedora-latest-stable
+  branch: master
 
 # run tests for libblockdev consumers, see plans/ with `revdeps_blivet == yes`
 - job: tests
@@ -99,6 +101,7 @@ jobs:
       message: "Blivet tests failed for commit {commit_sha}. @vojtechtrefny please check."
   targets:
     - fedora-latest-stable
+  branch: master
   tf_extra_params:
     environments:
       - artifacts:
@@ -116,6 +119,7 @@ jobs:
       message: "udisks tests failed for commit {commit_sha}. @vojtechtrefny @tbzatek please check."
   targets:
     - fedora-latest-stable
+  branch: master
   tf_extra_params:
     environments:
       - artifacts:

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -100,6 +100,12 @@ jobs:
     - fedora-latest-stable
   branch: master
 
+- job: tests
+  trigger: pull_request
+  targets:
+    - centos-stream-10-x86_64
+  branch: rhel10-branch
+
 # run tests for libblockdev consumers, see plans/ with `revdeps_blivet == yes`
 - job: tests
   identifier: revdeps_blivet

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,6 +28,14 @@ jobs:
   branch: master
 
 - job: copr_build
+  targets:
+    - centos-stream-10-aarch64
+    - centos-stream-10-ppc64le
+    - centos-stream-10-x86_64
+  trigger: pull_request
+  branch: rhel10-branch
+
+- job: copr_build
   trigger: commit
   owner: "@storage"
   project: blivet-daily

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -13,17 +13,16 @@ actions:
 
 jobs:
 - job: copr_build
-  metadata:
-    targets:
-    - fedora-rawhide-aarch64
-    - fedora-rawhide-ppc64le
-    - fedora-rawhide-x86_64
-    - fedora-latest-aarch64
-    - fedora-latest-ppc64le
-    - fedora-latest-x86_64
-    - fedora-latest-stable-aarch64
-    - fedora-latest-stable-ppc64le
-    - fedora-latest-stable-x86_64
+  targets:
+  - fedora-rawhide-aarch64
+  - fedora-rawhide-ppc64le
+  - fedora-rawhide-x86_64
+  - fedora-latest-aarch64
+  - fedora-latest-ppc64le
+  - fedora-latest-x86_64
+  - fedora-latest-stable-aarch64
+  - fedora-latest-stable-ppc64le
+  - fedora-latest-stable-x86_64
   trigger: pull_request
   branch: master
 

--- a/plans/tests-rhel.fmf
+++ b/plans/tests-rhel.fmf
@@ -3,7 +3,7 @@ summary: Run tests
 adjust+:
   - when: revdeps_blivet == yes or revdeps_udisks == yes
     enabled: false
-  - when: distro == centos
+  - when: distro == fedora
     enabled: false
 
 prepare:
@@ -11,7 +11,7 @@ prepare:
     how: shell
     script:
       - sudo dnf install -y python3-libdnf5 'dnf-command(copr)'
-      - sudo dnf copr enable -y @storage/udisks-daily
+      - sudo dnf copr enable -y @storage/udisks-daily centos-stream-10-x86_64
       # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
       - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done
       - sudo dnf -y update


### PR DESCRIPTION
The idea is to have the same configuration both here and on the rhel10-branch (with only the appropriate tests for the branch running) so we can do rebases on the rhel10-branch without losing the RHEL-specific configuration.

See https://github.com/storaged-project/libblockdev/pull/1114 for more details.