### PR TITLE
Tests speedup

### DIFF
--- a/tests/_lvm_cases.py
+++ b/tests/_lvm_cases.py
@@ -22,11 +22,11 @@ from gi.repository import GLib, BlockDev
 
 
 def _get_lvm_version():
-        _ret, out, _err = run_command("lvm version")
-        m = re.search(r"LVM version:\s+([\d\.]+)", out)
-        if not m or len(m.groups()) != 1:
-            raise RuntimeError("Failed to determine LVM version from: %s" % out)
-        return Version(m.groups()[0])
+    _ret, out, _err = run_command("lvm version")
+    m = re.search(r"LVM version:\s+([\d\.]+)", out)
+    if not m or len(m.groups()) != 1:
+        raise RuntimeError("Failed to determine LVM version from: %s" % out)
+    return Version(m.groups()[0])
 
 LVM_VERSION = _get_lvm_version()
 
@@ -1243,7 +1243,7 @@ class LvmTestLVs(LvmPVVGLVTestCase):
         self.assertEqual(BlockDev.lvm_cache_pool_name("testVG", "testLV"), cpool_name)
 
     @tag_test(TestTags.SLOW)
-    def test_create_cached_lv(self):
+    def test_create_writecached_lv(self):
         """Verify that it is possible to create a cached LV in a single step"""
 
         if LVM_VERSION < Version("2.03.10") and self.test_type == "dbus":
@@ -1299,7 +1299,7 @@ class LvmTestLVs(LvmPVVGLVTestCase):
         self.assertEqual(stats.mode, BlockDev.LVMCacheMode.WRITETHROUGH)
 
     @tag_test(TestTags.SLOW)
-    def test_cache_get_stats(self):
+    def test_thinpool_cache_get_stats(self):
         """Verify that it is possible to get stats for a cached thinpool"""
 
         succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -43,7 +43,7 @@ class BtrfsTest(unittest.TestCase):
 class BtrfsPluginVersionCase(BtrfsTest):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.BTRFS), "libbd_btrfs.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.BTRFS), "libbd_btrfs.so.3")
 
 class BtrfsTestCase(BtrfsTest):
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -124,7 +124,7 @@ class CryptoNoDevTestCase(CryptoTestCase):
 
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.CRYPTO), "libbd_crypto.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.CRYPTO), "libbd_crypto.so.3")
 
     @tag_test(TestTags.NOSTORAGE)
     def test_generate_backup_passhprase(self):
@@ -1166,7 +1166,7 @@ class CryptoTestSetPersistentFlags(CryptoTestCase):
                                                       BlockDev.CryptoLUKSPersistentFlags.ALLOW_DISCARDS)
 
     @tag_test(TestTags.SLOW, TestTags.CORE)
-    def test_luks_set_persistent_flags(self):
+    def test_luks2_set_persistent_flags(self):
         """Verify that we can set flags on a LUKS 2 device"""
 
         self._luks2_format(self.loop_devs[0], PASSWD, fast_pbkdf=True)

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -42,6 +42,9 @@ class CryptoTestCase(unittest.TestCase):
 
     _dm_name = "libblockdevTestLUKS"
     _sparse_size = 1024**3
+    _num_devices = 1
+    loop_devs = []
+    dev_files = []
 
     @classmethod
     def setUpClass(cls):
@@ -55,16 +58,16 @@ class CryptoTestCase(unittest.TestCase):
 
     def setUp(self):
         self.addCleanup(self._clean_up)
-        self.dev_file = create_sparse_tempfile("crypto_test", self._sparse_size)
-        self.dev_file2 = create_sparse_tempfile("crypto_test2", self._sparse_size)
-        try:
-            self.loop_dev = create_lio_device(self.dev_file)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
-        try:
-            self.loop_dev2 = create_lio_device(self.dev_file2)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
+
+        for i in range(self._num_devices):
+            dev_file = create_sparse_tempfile("crypto_test", self._sparse_size)
+            self.dev_files.append(dev_file)
+
+            try:
+                loop_dev = create_lio_device(self.dev_files[i])
+                self.loop_devs.append(loop_dev)
+            except RuntimeError as e:
+                raise RuntimeError("Failed to setup loop device for testing: %s" % e)
 
         # make a key file
         handle, self.keyfile = tempfile.mkstemp(prefix="libblockdev_test_keyfile", text=False)
@@ -77,21 +80,18 @@ class CryptoTestCase(unittest.TestCase):
         except:
             pass
 
-        try:
-            delete_lio_device(self.loop_dev)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file)
-
-        try:
-            delete_lio_device(self.loop_dev2)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file2)
+        for i in range(self._num_devices):
+            try:
+                delete_lio_device(self.loop_devs[i])
+            except RuntimeError:
+                # just move on, we can do no better here
+                pass
+            os.unlink(self.dev_files[i])
 
         os.unlink(self.keyfile)
+
+        self.dev_files.clear()
+        self.loop_devs.clear()
 
     def _luks_format(self, device, passphrase, keyfile=None, luks_version=BlockDev.CryptoLUKSVersion.LUKS1):
         ctx = BlockDev.CryptoKeyslotContext(passphrase=passphrase)
@@ -164,7 +164,7 @@ class CryptoTestFormat(CryptoTestCase):
 
         # the simple case with password
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(device=self.loop_dev, cipher="aes-xts-plain64",
+        succ = BlockDev.crypto_luks_format(device=self.loop_devs[0], cipher="aes-xts-plain64",
                                            key_size=0, context=ctx, min_entropy=0,
                                            luks_version=BlockDev.CryptoLUKSVersion.LUKS1,
                                            extra=None)
@@ -172,7 +172,7 @@ class CryptoTestFormat(CryptoTestCase):
 
         # create with a keyfile
         ctx = BlockDev.CryptoKeyslotContext(keyfile=self.keyfile, keyfile_offset=0, key_size=0)
-        succ = BlockDev.crypto_luks_format(device=self.loop_dev, cipher="aes-xts-plain64",
+        succ = BlockDev.crypto_luks_format(device=self.loop_devs[0], cipher="aes-xts-plain64",
                                            key_size=0, context=ctx, min_entropy=0,
                                            luks_version=BlockDev.CryptoLUKSVersion.LUKS1,
                                            extra=None)
@@ -184,27 +184,27 @@ class CryptoTestFormat(CryptoTestCase):
 
         # the simple case with password
         pw_ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, pw_ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, pw_ctx, 0)
         self.assertTrue(succ)
 
         # create with a keyfile
         kf_ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, kf_ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, kf_ctx, 0)
         self.assertTrue(succ)
 
         # the simple case with password blob
         bl_ctx = BlockDev.CryptoKeyslotContext(passphrase=[ord(c) for c in PASSWD])
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, bl_ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, bl_ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, None)
         self.assertTrue(succ)
 
         # simple case with extra options
         extra = BlockDev.CryptoLUKSExtra(label="blockdevLUKS")
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, pw_ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, pw_ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         m = re.search(r"Label:\s*(\S+)\s*", out)
         if not m or len(m.groups()) != 1:
             self.fail("Failed to get label information from:\n%s %s" % (out, err))
@@ -213,11 +213,11 @@ class CryptoTestFormat(CryptoTestCase):
         # different key derivation function
         pbkdf = BlockDev.CryptoLUKSPBKDF(type="pbkdf2")
         extra = BlockDev.CryptoLUKSExtra(pbkdf=pbkdf)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, pw_ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, pw_ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         m = re.search(r"PBKDF:\s*(\S+)\s*", out)
         if not m or len(m.groups()) != 1:
             self.fail("Failed to get pbkdf information from:\n%s %s" % (out, err))
@@ -235,11 +235,11 @@ class CryptoTestFormat(CryptoTestCase):
         extra = BlockDev.CryptoLUKSExtra(pbkdf=pbkdf)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         m = re.search(r"PBKDF:\s*(\S+)\s*", out)
         if not m or len(m.groups()) != 1:
             self.fail("Failed to get pbkdf information from:\n%s %s" % (out, err))
@@ -264,11 +264,11 @@ class CryptoTestFormat(CryptoTestCase):
         # different options for argon2 -- only memory set
         pbkdf = BlockDev.CryptoLUKSPBKDF(max_memory_kb=100*1024)
         extra = BlockDev.CryptoLUKSExtra(pbkdf=pbkdf)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         m = re.search(r"Memory:\s*(\d+)\s*", out)
         if not m or len(m.groups()) != 1:
             self.fail("Failed to get pbkdf information from:\n%s %s" % (out, err))
@@ -279,11 +279,11 @@ class CryptoTestFormat(CryptoTestCase):
         # different options for argon2 -- only miterations set
         pbkdf = BlockDev.CryptoLUKSPBKDF(iterations=5)
         extra = BlockDev.CryptoLUKSExtra(pbkdf=pbkdf)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         m = re.search(r"Time cost:\s*(\d+)\s*", out)
         if not m or len(m.groups()) != 1:
             self.fail("Failed to get pbkdf information from:\n%s %s" % (out, err))
@@ -305,24 +305,24 @@ class CryptoTestFormat(CryptoTestCase):
 
         # aes-xts: key size should default to 512
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 0, ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 0, ctx, 0)
         self.assertTrue(succ)
 
-        key_size = self._get_luks1_key_size(self.loop_dev)
+        key_size = self._get_luks1_key_size(self.loop_devs[0])
         self.assertEqual(key_size, 512)
 
         # aes-cbc: key size should default to 256
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-cbc-essiv:sha256", 0, ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-cbc-essiv:sha256", 0, ctx, 0)
         self.assertTrue(succ)
 
-        key_size = self._get_luks1_key_size(self.loop_dev)
+        key_size = self._get_luks1_key_size(self.loop_devs[0])
         self.assertEqual(key_size, 256)
 
         # try specifying key size for aes-xts
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-xts-plain64", 256, ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-xts-plain64", 256, ctx, 0)
         self.assertTrue(succ)
 
-        key_size = self._get_luks1_key_size(self.loop_dev)
+        key_size = self._get_luks1_key_size(self.loop_devs[0])
         self.assertEqual(key_size, 256)
 
 
@@ -341,10 +341,10 @@ class CryptoTestResize(CryptoTestCase):
         """Verify that resizing LUKS device works"""
 
         # the simple case with password
-        self._luks_format(self.loop_dev, PASSWD)
+        self._luks_format(self.loop_devs[0], PASSWD)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         # resize to 512 KiB (1024 * 512B sectors)
@@ -363,10 +363,10 @@ class CryptoTestResize(CryptoTestCase):
         """Verify that resizing LUKS 2 device works"""
 
         # the simple case with password
-        self._luks2_format(self.loop_dev, PASSWD, self.keyfile)
+        self._luks2_format(self.loop_devs[0], PASSWD, self.keyfile)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         # resize without passphrase should fail if key is saved in keyring
@@ -390,7 +390,7 @@ class CryptoTestOpenClose(CryptoTestCase):
     def _luks_open_close(self, create_fn):
         """Verify that opening/closing LUKS device works"""
 
-        create_fn(self.loop_dev, PASSWD, self.keyfile)
+        create_fn(self.loop_devs[0], PASSWD, self.keyfile)
 
         with self.assertRaises(GLib.GError):
             ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
@@ -398,23 +398,23 @@ class CryptoTestOpenClose(CryptoTestCase):
 
         with self.assertRaisesRegex(GLib.GError, r"Device name cannot contain '/' character"):
             ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-            BlockDev.crypto_luks_open(self.loop_dev, "libblockdev/TestLUKS", ctx, False)
+            BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdev/TestLUKS", ctx, False)
 
 
         with self.assertRaisesRegex(GLib.GError, r"Incorrect passphrase"):
             ctx = BlockDev.CryptoKeyslotContext(passphrase="wrong-passphrase")
-            BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+            BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
 
         with self.assertRaises(GLib.GError):
             ctx = BlockDev.CryptoKeyslotContext(keyfile="wrong-keyfile")
-            BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+            BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
 
         with self.assertRaisesRegex(GLib.GError, "Only .* context types are valid for LUKS open"):
             ctx = BlockDev.CryptoKeyslotContext(volume_key=list(secrets.token_bytes(64)))
-            BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+            BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         # use the full /dev/mapper/ path
@@ -422,7 +422,7 @@ class CryptoTestOpenClose(CryptoTestCase):
         self.assertTrue(succ)
 
         ctx = BlockDev.CryptoKeyslotContext(keyfile=self.keyfile)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         # use just the LUKS device name
@@ -430,7 +430,7 @@ class CryptoTestOpenClose(CryptoTestCase):
         self.assertTrue(succ)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=[ord(c) for c in PASSWD])
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_close("/dev/mapper/libblockdevTestLUKS")
@@ -441,7 +441,7 @@ class CryptoTestOpenClose(CryptoTestCase):
         self.assertTrue(succ)
 
         ctx = BlockDev.CryptoKeyslotContext(keyring="myshinylittlekey")
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx)
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
@@ -459,10 +459,10 @@ class CryptoTestOpenClose(CryptoTestCase):
     def test_luks2_open_close_non_ascii_passphrase(self):
         passphrase = "šššššššš"
 
-        self._luks2_format(self.loop_dev, passphrase)
+        self._luks2_format(self.loop_devs[0], passphrase)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=passphrase)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
@@ -474,7 +474,7 @@ class CryptoTestOpenClose(CryptoTestCase):
             f.flush()
 
             ctx = BlockDev.CryptoKeyslotContext(keyfile=f.name)
-            succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+            succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
             self.assertTrue(succ)
 
             succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
@@ -485,7 +485,7 @@ class CryptoTestOpenClose(CryptoTestCase):
         self.assertTrue(succ)
 
         ctx = BlockDev.CryptoKeyslotContext(keyring="myshinylittlekey")
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx)
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
@@ -496,16 +496,16 @@ class CryptoTestAddKey(CryptoTestCase):
     def _add_key(self, create_fn):
         """Verify that adding key to LUKS device works"""
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         with self.assertRaises(GLib.GError):
             ctx = BlockDev.CryptoKeyslotContext(passphrase="wrong-passphrase")
             nctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD2)
-            BlockDev.crypto_luks_add_key(self.loop_dev, ctx, nctx)
+            BlockDev.crypto_luks_add_key(self.loop_devs[0], ctx, nctx)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
         nctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD2)
-        succ = BlockDev.crypto_luks_add_key(self.loop_dev, ctx, nctx)
+        succ = BlockDev.crypto_luks_add_key(self.loop_devs[0], ctx, nctx)
         self.assertTrue(succ)
 
     @tag_test(TestTags.SLOW)
@@ -520,31 +520,31 @@ class CryptoTestRemoveKey(CryptoTestCase):
     def _remove_key(self, create_fn):
         """Verify that removing key from LUKS device works"""
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
         nctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD2)
-        succ = BlockDev.crypto_luks_add_key(self.loop_dev, ctx, nctx)
+        succ = BlockDev.crypto_luks_add_key(self.loop_devs[0], ctx, nctx)
         self.assertTrue(succ)
 
         nctx2 = BlockDev.CryptoKeyslotContext(passphrase=PASSWD3)
-        succ = BlockDev.crypto_luks_add_key(self.loop_dev, ctx, nctx2)
+        succ = BlockDev.crypto_luks_add_key(self.loop_devs[0], ctx, nctx2)
         self.assertTrue(succ)
 
         nctx3 = BlockDev.CryptoKeyslotContext(keyfile=self.keyfile)
-        succ = BlockDev.crypto_luks_add_key(self.loop_dev, ctx, nctx3)
+        succ = BlockDev.crypto_luks_add_key(self.loop_devs[0], ctx, nctx3)
 
         with self.assertRaises(GLib.GError):
             wctx = BlockDev.CryptoKeyslotContext(passphrase="wrong-passphrase")
-            BlockDev.crypto_luks_remove_key(self.loop_dev, wctx)
+            BlockDev.crypto_luks_remove_key(self.loop_devs[0], wctx)
 
-        succ = BlockDev.crypto_luks_remove_key(self.loop_dev, ctx)
+        succ = BlockDev.crypto_luks_remove_key(self.loop_devs[0], ctx)
         self.assertTrue(succ)
 
-        succ = BlockDev.crypto_luks_remove_key(self.loop_dev, nctx2)
+        succ = BlockDev.crypto_luks_remove_key(self.loop_devs[0], nctx2)
         self.assertTrue(succ)
 
-        succ = BlockDev.crypto_luks_remove_key(self.loop_dev, nctx3)
+        succ = BlockDev.crypto_luks_remove_key(self.loop_devs[0], nctx3)
         self.assertTrue(succ)
 
     @tag_test(TestTags.SLOW)
@@ -572,13 +572,13 @@ class CryptoTestErrorLocale(CryptoTestCase):
         """Verify that the error msg is locale agnostic"""
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, None, 0, ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], None, 0, ctx, 0)
         self.assertTrue(succ)
 
         locale.setlocale(locale.LC_ALL, "cs_CZ.UTF-8")
         try:
             ctx = BlockDev.CryptoKeyslotContext(passphrase="wrong-passphrase")
-            BlockDev.crypto_luks_remove_key(self.loop_dev, ctx)
+            BlockDev.crypto_luks_remove_key(self.loop_devs[0], ctx)
         except GLib.GError as e:
             self.assertIn("Operation not permitted", str(e))
 
@@ -586,16 +586,16 @@ class CryptoTestChangeKey(CryptoTestCase):
     def _change_key(self, create_fn):
         """Verify that changing key in LUKS device works"""
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         with self.assertRaisesRegex(GLib.GError, r"No keyslot with given passphrase found."):
             ctx = BlockDev.CryptoKeyslotContext(passphrase="wrong-passphrase")
             nctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD2)
-            BlockDev.crypto_luks_change_key(self.loop_dev, ctx, nctx)
+            BlockDev.crypto_luks_change_key(self.loop_devs[0], ctx, nctx)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
         nctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD2)
-        succ = BlockDev.crypto_luks_change_key(self.loop_dev, ctx, nctx)
+        succ = BlockDev.crypto_luks_change_key(self.loop_devs[0], ctx, nctx)
         self.assertTrue(succ)
 
     @tag_test(TestTags.SLOW)
@@ -607,18 +607,20 @@ class CryptoTestChangeKey(CryptoTestCase):
         self._change_key(self._luks2_format)
 
 class CryptoTestIsLuks(CryptoTestCase):
+    _num_devices = 2
+
     def _is_luks(self, create_fn):
         """Verify that LUKS device recognition works"""
 
         with self.assertRaises(GLib.GError):
             BlockDev.crypto_device_is_luks("/non/existing/device")
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
-        is_luks = BlockDev.crypto_device_is_luks(self.loop_dev)
+        is_luks = BlockDev.crypto_device_is_luks(self.loop_devs[0])
         self.assertTrue(is_luks)
 
-        is_luks = BlockDev.crypto_device_is_luks(self.loop_dev2)
+        is_luks = BlockDev.crypto_device_is_luks(self.loop_devs[1])
         self.assertFalse(is_luks)
 
     @tag_test(TestTags.SLOW)
@@ -636,10 +638,10 @@ class CryptoTestLuksStatus(CryptoTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.crypto_luks_status("/non/existing/device")
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         # use the full /dev/mapper path
@@ -668,10 +670,10 @@ class CryptoTestLuksOpenRW(CryptoTestCase):
     def _luks_open_rw(self, create_fn):
         """Verify that a LUKS device can be activated as RW as well as RO"""
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         # tests that we can write something to the raw LUKS device
@@ -682,7 +684,7 @@ class CryptoTestLuksOpenRW(CryptoTestCase):
         self.assertTrue(succ)
 
         # now try the same with LUKS device opened as RO
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, True)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, True)
         self.assertTrue(succ)
 
         # tests that we can write something to the raw LUKS device
@@ -739,17 +741,17 @@ class CryptoTestEscrow(CryptoTestCase):
     def test_escrow_packet(self):
         """Verify that an escrow packet can be created for a device"""
 
-        self._luks_format(self.loop_dev, PASSWD)
+        self._luks_format(self.loop_devs[0], PASSWD)
 
         escrow_dir = tempfile.mkdtemp(prefix='libblockdev_test_escrow')
         self.addCleanup(shutil.rmtree, escrow_dir)
         with open(self.public_cert, 'rb') as cert_file:
-            succ = BlockDev.crypto_escrow_device(self.loop_dev, PASSWD, cert_file.read(),
+            succ = BlockDev.crypto_escrow_device(self.loop_devs[0], PASSWD, cert_file.read(),
                     escrow_dir, None)
         self.assertTrue(succ)
 
         # Find the escrow packet
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         escrow_packet_file = '%s/%s-escrow' % (escrow_dir, info.uuid)
         self.assertTrue(os.path.isfile(escrow_packet_file))
 
@@ -768,7 +770,7 @@ class CryptoTestEscrow(CryptoTestCase):
 
         # Restore access to the volume
         # PASSWD3 is the new passphrase for the LUKS device
-        p = subprocess.Popen(['volume_key', '--restore', '-b', self.loop_dev,
+        p = subprocess.Popen(['volume_key', '--restore', '-b', self.loop_devs[0],
             '%s/escrow-out' % escrow_dir], stdin=subprocess.PIPE)
         p.communicate(input=('%s\0%s\0%s\0' % (PASSWD2, PASSWD3, PASSWD3)).encode('utf-8'))
         if p.returncode != 0:
@@ -776,24 +778,24 @@ class CryptoTestEscrow(CryptoTestCase):
 
         # Open the volume with the new passphrase
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD3)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, 'libblockdevTestLUKS', ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], 'libblockdevTestLUKS', ctx)
         self.assertTrue(succ)
 
     @tag_test(TestTags.SLOW)
     def test_backup_passphrase(self):
         """Verify that a backup passphrase can be created for a device"""
-        self._luks_format(self.loop_dev, PASSWD)
+        self._luks_format(self.loop_devs[0], PASSWD)
 
         escrow_dir = tempfile.mkdtemp(prefix='libblockdev_test_escrow')
         self.addCleanup(shutil.rmtree, escrow_dir)
         backup_passphrase = BlockDev.crypto_generate_backup_passphrase()
         with open(self.public_cert, 'rb') as cert_file:
-            succ = BlockDev.crypto_escrow_device(self.loop_dev, PASSWD, cert_file.read(),
+            succ = BlockDev.crypto_escrow_device(self.loop_devs[0], PASSWD, cert_file.read(),
                     escrow_dir, backup_passphrase)
         self.assertTrue(succ)
 
         # Find the backup passphrase
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         escrow_backup_passphrase = "%s/%s-escrow-backup-passphrase" % (escrow_dir, info.uuid)
         self.assertTrue(os.path.isfile(escrow_backup_passphrase))
 
@@ -808,16 +810,16 @@ class CryptoTestEscrow(CryptoTestCase):
 
         # Check that the backup passphrase works
         ctx = BlockDev.CryptoKeyslotContext(passphrase=backup_passphrase)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, 'libblockdevTestLUKS', ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], 'libblockdevTestLUKS', ctx)
         self.assertTrue(succ)
 
 class CryptoTestSuspendResume(CryptoTestCase):
     def _luks_suspend_resume(self, create_fn):
 
-        create_fn(self.loop_dev, PASSWD, self.keyfile)
+        create_fn(self.loop_devs[0], PASSWD, self.keyfile)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx)
         self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
@@ -882,11 +884,11 @@ class CryptoTestSuspendResume(CryptoTestCase):
 class CryptoTestKillSlot(CryptoTestCase):
     def _luks_kill_slot(self, create_fn):
 
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
         nctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD2)
-        succ = BlockDev.crypto_luks_add_key(self.loop_dev, ctx, nctx)
+        succ = BlockDev.crypto_luks_add_key(self.loop_devs[0], ctx, nctx)
         self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
@@ -894,22 +896,22 @@ class CryptoTestKillSlot(CryptoTestCase):
 
         # invalid slot
         with self.assertRaises(GLib.GError):
-            BlockDev.crypto_luks_kill_slot(self.loop_dev, -1)
+            BlockDev.crypto_luks_kill_slot(self.loop_devs[0], -1)
 
         # unused slot
         with self.assertRaises(GLib.GError):
-            BlockDev.crypto_luks_kill_slot(self.loop_dev, 2)
+            BlockDev.crypto_luks_kill_slot(self.loop_devs[0], 2)
 
         # destroy second keyslot
-        succ = BlockDev.crypto_luks_kill_slot(self.loop_dev, 1)
+        succ = BlockDev.crypto_luks_kill_slot(self.loop_devs[0], 1)
         self.assertTrue(succ)
 
         # opening with the second passphrase should fail
         with self.assertRaises(GLib.GError):
-            BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", nctx)
+            BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", nctx)
 
         # opening with passphrase should still work
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx)
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
@@ -934,37 +936,37 @@ class CryptoTestHeaderBackupRestore(CryptoTestCase):
         self.addCleanup(shutil.rmtree, self.backup_dir)
 
     def _luks_header_backup_restore(self, create_fn):
-        create_fn(self.loop_dev, PASSWD, None)
+        create_fn(self.loop_devs[0], PASSWD, None)
 
         backup_file = os.path.join(self.backup_dir, "luks-header.txt")
 
-        succ = BlockDev.crypto_luks_header_backup(self.loop_dev, backup_file)
+        succ = BlockDev.crypto_luks_header_backup(self.loop_devs[0], backup_file)
         self.assertTrue(succ)
         self.assertTrue(os.path.isfile(backup_file))
 
         # now completely destroy the luks header
-        ret, out, err = run_command("cryptsetup erase %s -q && wipefs -a %s" % (self.loop_dev, self.loop_dev))
+        ret, out, err = run_command("cryptsetup erase %s -q && wipefs -a %s" % (self.loop_devs[0], self.loop_devs[0]))
         if ret != 0:
-            self.fail("Failed to erase LUKS header from %s:\n%s %s" % (self.loop_dev, out, err))
+            self.fail("Failed to erase LUKS header from %s:\n%s %s" % (self.loop_devs[0], out, err))
 
-        _ret, fstype, _err = run_command("blkid -p -ovalue -sTYPE %s" % self.loop_dev)
+        _ret, fstype, _err = run_command("blkid -p -ovalue -sTYPE %s" % self.loop_devs[0])
         self.assertFalse(fstype)  # false == empty
 
         # header is destroyed, should not be possible to open
         with self.assertRaises(GLib.GError):
             ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-            BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx)
+            BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx)
 
         # and restore the header back
-        succ = BlockDev.crypto_luks_header_restore(self.loop_dev, backup_file)
+        succ = BlockDev.crypto_luks_header_restore(self.loop_devs[0], backup_file)
         self.assertTrue(succ)
 
-        _ret, fstype, _err = run_command("blkid -p -ovalue -sTYPE %s" % self.loop_dev)
+        _ret, fstype, _err = run_command("blkid -p -ovalue -sTYPE %s" % self.loop_devs[0])
         self.assertEqual(fstype, "crypto_LUKS")
 
         # opening should now work
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx)
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
@@ -987,24 +989,24 @@ class CryptoTestInfo(CryptoTestCase):
         self.assertEqual(info.version, version)
         self.assertEqual(info.cipher, "aes")
         self.assertEqual(info.mode, "cbc-essiv:sha256")
-        self.assertEqual(info.backing_device, self.loop_dev)
+        self.assertEqual(info.backing_device, self.loop_devs[0])
 
-        _ret, uuid, _err = run_command("blkid -p -ovalue -sUUID %s" % self.loop_dev)
+        _ret, uuid, _err = run_command("blkid -p -ovalue -sUUID %s" % self.loop_devs[0])
         self.assertEqual(info.uuid, uuid)
 
-        ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         if ret != 0:
-            self.fail("Failed to get LUKS header from %s:\n%s %s" % (self.loop_dev, out, err))
+            self.fail("Failed to get LUKS header from %s:\n%s %s" % (self.loop_devs[0], out, err))
 
         if version == BlockDev.CryptoLUKSVersion.LUKS1:
             m = re.search(r"Payload offset:\s*([0-9]+)", out)
             if m is None:
-                self.fail("Failed to get LUKS offset information from %s:\n%s %s" % (self.loop_dev, out, err))
+                self.fail("Failed to get LUKS offset information from %s:\n%s %s" % (self.loop_devs[0], out, err))
             offset = int(m.group(1)) * 512
         else:
             m = re.search(r"offset:\s*([0-9]+)\s*\[bytes\]", out)
             if m is None:
-                self.fail("Failed to get LUKS 2 offset information from %s:\n%s %s" % (self.loop_dev, out, err))
+                self.fail("Failed to get LUKS 2 offset information from %s:\n%s %s" % (self.loop_devs[0], out, err))
             offset = int(m.group(1))
 
         self.assertEqual(info.metadata_size, offset)
@@ -1014,13 +1016,13 @@ class CryptoTestInfo(CryptoTestCase):
         """Verify that we can get information about a LUKS device"""
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-cbc-essiv:sha256", 256, ctx, 0)
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-cbc-essiv:sha256", 256, ctx, 0)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self._verify_luks_info(info, BlockDev.CryptoLUKSVersion.LUKS1)
 
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         info = BlockDev.crypto_luks_info("libblockdevTestLUKS")
@@ -1040,14 +1042,14 @@ class CryptoTestInfo(CryptoTestCase):
         extra.sector_size = 4096
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-cbc-essiv:sha256", 256, ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-cbc-essiv:sha256", 256, ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self._verify_luks_info(info, BlockDev.CryptoLUKSVersion.LUKS2)
 
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         info = BlockDev.crypto_luks_info("libblockdevTestLUKS")
@@ -1069,12 +1071,12 @@ class CryptoTestSetLabel(CryptoTestCase):
     def test_luks_set_label(self):
         """Verify that we can set label on a LUKS device"""
 
-        self._luks_format(self.loop_dev, PASSWD)
+        self._luks_format(self.loop_devs[0], PASSWD)
 
         with self.assertRaisesRegex(GLib.GError, r"Label can be set only on LUKS 2"):
-            BlockDev.crypto_luks_set_label(self.loop_dev, self.label, self.subsystem)
+            BlockDev.crypto_luks_set_label(self.loop_devs[0], self.label, self.subsystem)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.label, "")
         self.assertEqual(info.subsystem, "")
@@ -1083,33 +1085,33 @@ class CryptoTestSetLabel(CryptoTestCase):
     def test_luks2_set_label(self):
         """Verify that we can set label on a LUKS 2 device"""
 
-        self._luks2_format(self.loop_dev, PASSWD)
+        self._luks2_format(self.loop_devs[0], PASSWD)
 
-        succ = BlockDev.crypto_luks_set_label(self.loop_dev, self.label, self.subsystem)
+        succ = BlockDev.crypto_luks_set_label(self.loop_devs[0], self.label, self.subsystem)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.label, self.label)
         self.assertEqual(info.subsystem, self.subsystem)
 
-        _ret, label, _err = run_command("blkid -p -ovalue -sLABEL %s" % self.loop_dev)
+        _ret, label, _err = run_command("blkid -p -ovalue -sLABEL %s" % self.loop_devs[0])
         self.assertEqual(label, self.label)
 
-        _ret, subsystem, _err = run_command("blkid -p -ovalue -sSUBSYSTEM %s" % self.loop_dev)
+        _ret, subsystem, _err = run_command("blkid -p -ovalue -sSUBSYSTEM %s" % self.loop_devs[0])
         self.assertEqual(subsystem, self.subsystem)
 
-        succ = BlockDev.crypto_luks_set_label(self.loop_dev, None, None)
+        succ = BlockDev.crypto_luks_set_label(self.loop_devs[0], None, None)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.label, "")
         self.assertEqual(info.subsystem, "")
 
-        _ret, label, _err = run_command("blkid -p -ovalue -sLABEL %s" % self.loop_dev)
+        _ret, label, _err = run_command("blkid -p -ovalue -sLABEL %s" % self.loop_devs[0])
         self.assertEqual(label, "")
-        _ret, subsystem, _err = run_command("blkid -p -ovalue -sSUBSYSTEM %s" % self.loop_dev)
+        _ret, subsystem, _err = run_command("blkid -p -ovalue -sSUBSYSTEM %s" % self.loop_devs[0])
         self.assertEqual(subsystem, "")
 
 
@@ -1121,19 +1123,19 @@ class CryptoTestSetUuid(CryptoTestCase):
     def test_luks_set_uuid(self):
         """Verify that we can set label on a LUKS device"""
 
-        self._luks_format(self.loop_dev, PASSWD)
+        self._luks_format(self.loop_devs[0], PASSWD)
 
-        succ = BlockDev.crypto_luks_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.crypto_luks_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.uuid, self.test_uuid)
 
-        succ = BlockDev.crypto_luks_set_uuid(self.loop_dev, None)
+        succ = BlockDev.crypto_luks_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertNotEqual(info.uuid, self.test_uuid)
 
@@ -1141,19 +1143,19 @@ class CryptoTestSetUuid(CryptoTestCase):
     def test_luks2_set_uuid(self):
         """Verify that we can set label on a LUKS 2 device"""
 
-        self._luks2_format(self.loop_dev, PASSWD)
+        self._luks2_format(self.loop_devs[0], PASSWD)
 
-        succ = BlockDev.crypto_luks_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.crypto_luks_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.uuid, self.test_uuid)
 
-        succ = BlockDev.crypto_luks_set_uuid(self.loop_dev, None)
+        succ = BlockDev.crypto_luks_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertNotEqual(info.uuid, self.test_uuid)
 
@@ -1164,23 +1166,23 @@ class CryptoTestSetPersistentFlags(CryptoTestCase):
     def test_luks_set_persistent_flags(self):
         """Verify that we can set flags on a LUKS device"""
 
-        self._luks_format(self.loop_dev, PASSWD)
+        self._luks_format(self.loop_devs[0], PASSWD)
 
         with self.assertRaisesRegex(GLib.GError, "Persistent flags can be set only on LUKS v2"):
-            BlockDev.crypto_luks_set_persistent_flags(self.loop_dev,
+            BlockDev.crypto_luks_set_persistent_flags(self.loop_devs[0],
                                                       BlockDev.CryptoLUKSPersistentFlags.ALLOW_DISCARDS)
 
     @tag_test(TestTags.SLOW, TestTags.CORE)
     def test_luks_set_persistent_flags(self):
         """Verify that we can set flags on a LUKS 2 device"""
 
-        self._luks2_format(self.loop_dev, PASSWD)
+        self._luks2_format(self.loop_devs[0], PASSWD)
 
-        succ = BlockDev.crypto_luks_set_persistent_flags(self.loop_dev,
+        succ = BlockDev.crypto_luks_set_persistent_flags(self.loop_devs[0],
                                                          BlockDev.CryptoLUKSPersistentFlags.ALLOW_DISCARDS)
         self.assertTrue(succ)
 
-        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_dev)
+        _ret, out, err = run_command("cryptsetup luksDump %s" % self.loop_devs[0])
         m = re.search(r"Flags:\s*(\S+)\s*", out)
         if not m or len(m.groups()) != 1:
             self.fail("Failed to get label information from:\n%s %s" % (out, err))
@@ -1193,12 +1195,12 @@ class CryptoTestConvert(CryptoTestCase):
     def test_convert_luks1_to_luks2(self):
         """Verify that we can convert a device from LUKS1 format to LUKS2"""
 
-        self._luks_format(self.loop_dev, PASSWD, luks_version=BlockDev.CryptoLUKSVersion.LUKS1)
+        self._luks_format(self.loop_devs[0], PASSWD, luks_version=BlockDev.CryptoLUKSVersion.LUKS1)
 
-        succ = BlockDev.crypto_luks_convert(self.loop_dev, BlockDev.CryptoLUKSVersion.LUKS2)
+        succ = BlockDev.crypto_luks_convert(self.loop_devs[0], BlockDev.CryptoLUKSVersion.LUKS2)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.version, BlockDev.CryptoLUKSVersion.LUKS2)
 
@@ -1206,21 +1208,21 @@ class CryptoTestConvert(CryptoTestCase):
     def test_convert_luks1_to_luks2_to_luks1(self):
         """Verify that we can convert a device from LUKS1 format to LUKS2 and back to LUKS1"""
 
-        self._luks_format(self.loop_dev, PASSWD, luks_version=BlockDev.CryptoLUKSVersion.LUKS1)
+        self._luks_format(self.loop_devs[0], PASSWD, luks_version=BlockDev.CryptoLUKSVersion.LUKS1)
 
         # LUKS1 -> LUKS2
-        succ = BlockDev.crypto_luks_convert(self.loop_dev, BlockDev.CryptoLUKSVersion.LUKS2)
+        succ = BlockDev.crypto_luks_convert(self.loop_devs[0], BlockDev.CryptoLUKSVersion.LUKS2)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.version, BlockDev.CryptoLUKSVersion.LUKS2)
 
         # LUKS2 -> LUKS1
-        succ = BlockDev.crypto_luks_convert(self.loop_dev, BlockDev.CryptoLUKSVersion.LUKS1)
+        succ = BlockDev.crypto_luks_convert(self.loop_devs[0], BlockDev.CryptoLUKSVersion.LUKS1)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.version, BlockDev.CryptoLUKSVersion.LUKS1)
 
@@ -1228,37 +1230,39 @@ class CryptoTestConvert(CryptoTestCase):
     def test_convert_luks2_to_luks2_fails(self):
         """Verify that conversion to the present format fails"""
 
-        self._luks_format(self.loop_dev, PASSWD, luks_version=BlockDev.CryptoLUKSVersion.LUKS2)
+        self._luks_format(self.loop_devs[0], PASSWD, luks_version=BlockDev.CryptoLUKSVersion.LUKS2)
 
         with self.assertRaisesRegex(GLib.GError, r"Conversion to the LUKS2 type was requested, but device .* is "
                                                  r"already of type: LUKS2"):
-            BlockDev.crypto_luks_convert(self.loop_dev, BlockDev.CryptoLUKSVersion.LUKS2)
+            BlockDev.crypto_luks_convert(self.loop_devs[0], BlockDev.CryptoLUKSVersion.LUKS2)
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.version, BlockDev.CryptoLUKSVersion.LUKS2)
 
 
 class CryptoTestLuksSectorSize(CryptoTestCase):
+    _num_devices = 2
+
     def setUp(self):
         if not check_cryptsetup_version("2.4.0"):
             self.skipTest("cryptsetup encryption sector size not available, skipping.")
 
-        # we need a loop devices for this test case
+        # we need special loop devices for this test case
         self.addCleanup(self._clean_up)
-        self.dev_file = create_sparse_tempfile("crypto_test", 1024**3)
-        self.dev_file2 = create_sparse_tempfile("crypto_test", 1024**3)
+        self.dev_files.append(create_sparse_tempfile("crypto_test", self._sparse_size))
+        self.dev_files.append(create_sparse_tempfile("crypto_test", self._sparse_size))
 
         # create a 4k sector loop device
-        succ, loop = BlockDev.loop_setup(self.dev_file, sector_size=4096)
+        succ, loop = BlockDev.loop_setup(self.dev_files[0], sector_size=4096)
         if not succ:
             raise RuntimeError("Failed to setup loop device for testing")
-        self.loop_dev = "/dev/%s" % loop
+        self.loop_devs.append("/dev/%s" % loop)
 
-        succ, loop = BlockDev.loop_setup(self.dev_file2)
+        succ, loop = BlockDev.loop_setup(self.dev_files[1])
         if not succ:
             raise RuntimeError("Failed to setup loop device for testing")
-        self.loop_dev2 = "/dev/%s" % loop
+        self.loop_devs.append("/dev/%s" % loop)
 
     def _clean_up(self):
         try:
@@ -1266,20 +1270,21 @@ class CryptoTestLuksSectorSize(CryptoTestCase):
         except:
             pass
 
-        BlockDev.loop_teardown(self.loop_dev)
-        os.unlink(self.dev_file)
+        for i in range(self._num_devices):
+            BlockDev.loop_teardown(self.loop_devs[i])
+            os.unlink(self.dev_files[i])
 
-        BlockDev.loop_teardown(self.loop_dev2)
-        os.unlink(self.dev_file2)
+        self.dev_files.clear()
+        self.loop_devs.clear()
 
     @tag_test(TestTags.SLOW)
     def test_luks2_sector_size_autodetect(self):
         """Verify that we can autodetect 4k drives and set 4k sector size for them"""
         # format the 4k loop device, encryption sector size should default to 4096
-        self._luks2_format(self.loop_dev, PASSWD)
+        self._luks2_format(self.loop_devs[0], PASSWD)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         info = BlockDev.crypto_luks_info("libblockdevTestLUKS")
@@ -1292,9 +1297,9 @@ class CryptoTestLuksSectorSize(CryptoTestCase):
         self.assertTrue(succ)
 
         # with the 512 loop device, we should still get 512
-        self._luks2_format(self.loop_dev2, PASSWD)
+        self._luks2_format(self.loop_devs[1], PASSWD)
 
-        succ = BlockDev.crypto_luks_open(self.loop_dev2, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[1], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         info = BlockDev.crypto_luks_info("libblockdevTestLUKS")
@@ -1319,15 +1324,15 @@ class CryptoTestLUKS2Integrity(CryptoTestCase):
         extra.integrity = "hmac(sha256)"
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-cbc-essiv:sha256", 512, ctx, 0,
+        succ = BlockDev.crypto_luks_format(self.loop_devs[0], "aes-cbc-essiv:sha256", 512, ctx, 0,
                                            BlockDev.CryptoLUKSVersion.LUKS2, extra)
         self.assertTrue(succ)
 
-        info = BlockDev.crypto_integrity_info(self.loop_dev)
+        info = BlockDev.crypto_integrity_info(self.loop_devs[0])
         self.assertIsNotNone(info)
         self.assertEqual(info.algorithm, "hmac(sha256)")
 
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         info = BlockDev.crypto_integrity_info("libblockdevTestLUKS")
@@ -1339,7 +1344,7 @@ class CryptoTestLUKS2Integrity(CryptoTestCase):
         self.assertEqual(info.algorithm, "hmac(sha256)")
 
         # get integrity device dm name
-        _ret, int_name, _err = run_command('ls /sys/block/%s/holders/' % self.loop_dev.split("/")[-1])
+        _ret, int_name, _err = run_command('ls /sys/block/%s/holders/' % self.loop_devs[0].split("/")[-1])
         self.assertTrue(int_name)  # true == not empty
 
         tag_size = read_file("/sys/block/%s/integrity/tag_size" % int_name)
@@ -1362,20 +1367,20 @@ class CryptoTestLUKSToken(CryptoTestCase):
         """Verify that we can get information about LUKS2 tokens"""
 
         # the simple case with password
-        self._luks2_format(self.loop_dev, PASSWD, None)
+        self._luks2_format(self.loop_devs[0], PASSWD, None)
 
-        info = BlockDev.crypto_luks_token_info(self.loop_dev)
+        info = BlockDev.crypto_luks_token_info(self.loop_devs[0])
         self.assertListEqual(info, [])
 
         # add kernel keyring token using cryptsetup
-        ret, _out, err = run_command("cryptsetup token add --key-description aaaa %s" % self.loop_dev)
-        self.assertEqual(ret, 0, msg="Failed to add token to %s: %s" % (self.loop_dev, err))
+        ret, _out, err = run_command("cryptsetup token add --key-description aaaa %s" % self.loop_devs[0])
+        self.assertEqual(ret, 0, msg="Failed to add token to %s: %s" % (self.loop_devs[0], err))
 
-        info = BlockDev.crypto_luks_token_info(self.loop_dev)
+        info = BlockDev.crypto_luks_token_info(self.loop_devs[0])
         self._verify_token_info(info)
 
         ctx = BlockDev.CryptoKeyslotContext(passphrase=PASSWD)
-        succ = BlockDev.crypto_luks_open(self.loop_dev, "libblockdevTestLUKS", ctx, False)
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", ctx, False)
         self.assertTrue(succ)
 
         info = BlockDev.crypto_luks_token_info("libblockdevTestLUKS")
@@ -1685,10 +1690,10 @@ class CryptoTestIntegrity(CryptoTestCase):
 
     def test_integrity(self):
         # basic format+open+close test
-        succ = BlockDev.crypto_integrity_format(self.loop_dev, "sha256", False)
+        succ = BlockDev.crypto_integrity_format(self.loop_devs[0], "sha256", False)
         self.assertTrue(succ)
 
-        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "sha256")
+        succ = BlockDev.crypto_integrity_open(self.loop_devs[0], self._dm_name, "sha256")
         self.assertTrue(succ)
         self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
 
@@ -1702,10 +1707,10 @@ class CryptoTestIntegrity(CryptoTestCase):
         # same now with a keyed algorithm
         ctx = BlockDev.CryptoKeyslotContext(volume_key=list(secrets.token_bytes(64)))
 
-        succ = BlockDev.crypto_integrity_format(self.loop_dev, "hmac(sha256)", False, ctx)
+        succ = BlockDev.crypto_integrity_format(self.loop_devs[0], "hmac(sha256)", False, ctx)
         self.assertTrue(succ)
 
-        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "hmac(sha256)", ctx)
+        succ = BlockDev.crypto_integrity_open(self.loop_devs[0], self._dm_name, "hmac(sha256)", ctx)
         self.assertTrue(succ)
         self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
 
@@ -1718,10 +1723,10 @@ class CryptoTestIntegrity(CryptoTestCase):
 
         # same with some custom parameters
         extra = BlockDev.CryptoIntegrityExtra(sector_size=4096, interleave_sectors=65536)
-        succ = BlockDev.crypto_integrity_format(self.loop_dev, "crc32c", wipe=False, extra=extra)
+        succ = BlockDev.crypto_integrity_format(self.loop_devs[0], "crc32c", wipe=False, extra=extra)
         self.assertTrue(succ)
 
-        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "crc32c")
+        succ = BlockDev.crypto_integrity_open(self.loop_devs[0], self._dm_name, "crc32c")
         self.assertTrue(succ)
         self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
 
@@ -1735,7 +1740,7 @@ class CryptoTestIntegrity(CryptoTestCase):
         self.assertFalse(os.path.exists("/dev/mapper/%s" % self._dm_name))
 
         # open with flags
-        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "crc32c",
+        succ = BlockDev.crypto_integrity_open(self.loop_devs[0], self._dm_name, "crc32c",
                                               flags=BlockDev.CryptoIntegrityOpenFlags.ALLOW_DISCARDS)
         self.assertTrue(succ)
         self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
@@ -1760,13 +1765,13 @@ class CryptoTestIntegrity(CryptoTestCase):
         self.assertTrue(succ)
         self.addCleanup(BlockDev.utils_init_prog_reporting, None)
 
-        succ = BlockDev.crypto_integrity_format(self.loop_dev, "sha256", True)
+        succ = BlockDev.crypto_integrity_format(self.loop_devs[0], "sha256", True)
         self.assertTrue(succ)
 
         # at least one message "Integrity device wipe in progress" should be logged
         self.assertTrue(any(prog[1] == "Integrity device wipe in progress" for prog in progress_log))
 
-        succ = BlockDev.crypto_integrity_open(self.loop_dev, self._dm_name, "sha256")
+        succ = BlockDev.crypto_integrity_open(self.loop_devs[0], self._dm_name, "sha256")
         self.assertTrue(succ)
         self.assertTrue(os.path.exists("/dev/mapper/%s" % self._dm_name))
 
@@ -1787,24 +1792,24 @@ class CryptoTestLUKSOpal(CryptoTestCase):
     def test_luks_opal_sanity(self):
         """Basic sanity check for LUKS HW-OPAL support"""
         with self.assertRaisesRegex(GLib.GError, r"Failed to get opal status for the device"):
-            BlockDev.crypto_opal_is_supported(self.loop_dev)
+            BlockDev.crypto_opal_is_supported(self.loop_devs[0])
 
         with self.assertRaisesRegex(GLib.GError, r"OPAL doesn't seem to be supported on"):
-            BlockDev.crypto_opal_format(self.loop_dev, context=BlockDev.CryptoKeyslotContext(passphrase="aaaaa"),
+            BlockDev.crypto_opal_format(self.loop_devs[0], context=BlockDev.CryptoKeyslotContext(passphrase="aaaaa"),
                                         opal_context=BlockDev.CryptoKeyslotContext(passphrase="aaaaa"))
 
         # "normal" LUKS device
-        self._luks_format(self.loop_dev, PASSWD, None)
+        self._luks_format(self.loop_devs[0], PASSWD, None)
 
         with self.assertRaisesRegex(GLib.GError, r"isn't a LUKS HW-OPAL device"):
-            BlockDev.crypto_opal_wipe_device(self.loop_dev,
+            BlockDev.crypto_opal_wipe_device(self.loop_devs[0],
                                              BlockDev.CryptoKeyslotContext(passphrase="aaaaa"))
 
-        info = BlockDev.crypto_luks_info(self.loop_dev)
+        info = BlockDev.crypto_luks_info(self.loop_devs[0])
         self.assertEqual(info.hw_encryption, BlockDev.CryptoLUKSHWEncryptionType.SW_ONLY)
 
         with self.assertRaisesRegex(GLib.GError, r"OPAL doesn't seem to be supported on"):
-            BlockDev.crypto_opal_reset_device(self.loop_dev,
+            BlockDev.crypto_opal_reset_device(self.loop_devs[0],
                                               BlockDev.CryptoKeyslotContext(passphrase="aaaaa"))
 
     @unittest.skip("requires special hardware")

--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -25,7 +25,7 @@ class DevMapperTest(unittest.TestCase):
 class DevMapperPluginVersionCase(DevMapperTest):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.DM), "libbd_dm.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.DM), "libbd_dm.so.3")
 
 class DevMapperTestCase(DevMapperTest):
 

--- a/tests/fs_tests/btrfs_test.py
+++ b/tests/fs_tests/btrfs_test.py
@@ -66,18 +66,18 @@ class BtrfsTestMkfs(BtrfsTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_btrfs_mkfs("/non/existing/device", None)
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "btrfs")
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
 
 class BtrfsMkfsWithLabel(BtrfsTestCase):
@@ -85,10 +85,10 @@ class BtrfsMkfsWithLabel(BtrfsTestCase):
         """Verify that it is possible to create a btrfs file system with label"""
 
         ea = BlockDev.ExtraArg.new("-L", "test_label")
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, [ea])
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0], [ea])
         self.assertTrue(succ)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
@@ -98,10 +98,10 @@ class BtrfsTestCheck(BtrfsTestCase):
     def test_btrfs_check(self):
         """Verify that it is possible to check an btrfs file system"""
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_btrfs_check(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_check(self.loop_devs[0], None)
         self.assertTrue(succ)
 
 
@@ -109,10 +109,10 @@ class BtrfsTestRepair(BtrfsTestCase):
     def test_btrfs_repair(self):
         """Verify that it is possible to repair a btrfs file system"""
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_btrfs_repair(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_repair(self.loop_devs[0], None)
         self.assertTrue(succ)
 
 
@@ -120,10 +120,10 @@ class BtrfsGetInfo(BtrfsTestCase):
     def test_btrfs_get_info(self):
         """Verify that it is possible to get info about a btrfs file system"""
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
 
         self.assertTrue(fi)
@@ -139,10 +139,10 @@ class BtrfsSetLabel(BtrfsTestCase):
     def test_btrfs_set_label(self):
         """Verify that it is possible to set label of a btrfs file system"""
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
             self.assertTrue(fi)
             self.assertEqual(fi.label, "")
@@ -182,20 +182,20 @@ class BtrfsSetUUID(BtrfsTestCase):
     def test_btrfs_set_uuid(self):
         """Verify that it is possible to set UUID of an btrfs file system"""
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_btrfs_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.fs_btrfs_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, self.test_uuid)
 
         # no uuid -> random
-        succ = BlockDev.fs_btrfs_set_uuid(self.loop_dev, None)
+        succ = BlockDev.fs_btrfs_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             fi = BlockDev.fs_btrfs_get_info(self.mount_dir)
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
@@ -212,10 +212,10 @@ class BtrfsResize(BtrfsTestCase):
     def test_btrfs_resize(self):
         """Verify that it is possible to resize a btrfs file system"""
 
-        succ = BlockDev.fs_btrfs_mkfs(self.loop_dev)
+        succ = BlockDev.fs_btrfs_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             succ = BlockDev.fs_btrfs_resize(self.mount_dir, 300 * 1024**2)
             self.assertTrue(succ)
 
@@ -245,23 +245,24 @@ class BtrfsResize(BtrfsTestCase):
 
 
 class BtrfsMultiDevice(BtrfsTestCase):
+    num_devices = 2
 
     def _clean_up(self):
         utils.umount(self.mount_dir)
-        BlockDev.fs_wipe(self.loop_dev2, True)
+        BlockDev.fs_wipe(self.loop_devs[1], True)
 
         super(BtrfsMultiDevice, self)._clean_up()
 
     def test_btrfs_multidevice(self):
         """Verify that filesystem plugin returns errors when used on multidevice volumes"""
 
-        ret, _out, _err = utils.run_command("mkfs.btrfs %s %s" % (self.loop_dev, self.loop_dev2))
+        ret, _out, _err = utils.run_command("mkfs.btrfs %s %s" % (self.loop_devs[0], self.loop_devs[1]))
         self.assertEqual(ret, 0)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             with self.assertRaisesRegex(GLib.GError, "Filesystem plugin is not suitable for multidevice Btrfs volumes"):
                     BlockDev.fs_btrfs_get_info(self.mount_dir)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             with self.assertRaisesRegex(GLib.GError, "Filesystem plugin is not suitable for multidevice Btrfs volumes"):
                 BlockDev.fs_btrfs_resize(self.mount_dir, 0)

--- a/tests/fs_tests/exfat_test.py
+++ b/tests/fs_tests/exfat_test.py
@@ -102,18 +102,18 @@ class ExfatTestMkfs(ExfatTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_exfat_mkfs("/non/existing/device", None)
 
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev)
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "exfat")
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
 
 class ExfatMkfsWithLabel(ExfatTestCase):
@@ -121,10 +121,10 @@ class ExfatMkfsWithLabel(ExfatTestCase):
         """Verify that it is possible to create an exfat file system with label"""
 
         ea = BlockDev.ExtraArg.new("-n", "test_label")
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, [ea])
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0], [ea])
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
 
@@ -133,10 +133,10 @@ class ExfatTestCheck(ExfatTestCase):
     def test_exfat_check(self):
         """Verify that it is possible to check an exfat file system"""
 
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev)
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_exfat_check(self.loop_dev)
+        succ = BlockDev.fs_exfat_check(self.loop_devs[0])
         self.assertTrue(succ)
 
 
@@ -144,10 +144,10 @@ class ExfatTestRepair(ExfatTestCase):
     def test_exfat_repair(self):
         """Verify that it is possible to repair an exfat file system"""
 
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev)
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_exfat_repair(self.loop_dev)
+        succ = BlockDev.fs_exfat_repair(self.loop_devs[0])
         self.assertTrue(succ)
 
 
@@ -155,10 +155,10 @@ class ExfatGetInfo(ExfatTestCase):
     def test_exfat_get_info(self):
         """Verify that it is possible to get info about an exfat file system"""
 
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
         # should be an non-empty string
@@ -172,28 +172,28 @@ class ExfatSetLabel(ExfatTestCase):
     def test_exfat_set_label(self):
         """Verify that it is possible to set label of an exfat file system"""
 
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
-        succ = BlockDev.fs_exfat_set_label(self.loop_dev, "test_label")
+        succ = BlockDev.fs_exfat_set_label(self.loop_devs[0], "test_label")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
 
-        succ = BlockDev.fs_exfat_set_label(self.loop_dev, "test_label2")
+        succ = BlockDev.fs_exfat_set_label(self.loop_devs[0], "test_label2")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label2")
 
-        succ = BlockDev.fs_exfat_set_label(self.loop_dev, "")
+        succ = BlockDev.fs_exfat_set_label(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
@@ -208,31 +208,31 @@ class ExfatSetUUID(ExfatTestCase):
     def test_exfat_set_uuid(self):
         """Verify that it is possible to set UUID/volume ID of an exfat file system"""
 
-        succ = BlockDev.fs_exfat_mkfs(self.loop_dev)
+        succ = BlockDev.fs_exfat_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_exfat_set_uuid(self.loop_dev, "0x2E24EC82")
+        succ = BlockDev.fs_exfat_set_uuid(self.loop_devs[0], "0x2E24EC82")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, "2E24-EC82")
 
-        succ = BlockDev.fs_exfat_set_uuid(self.loop_dev, "2E24EC82")
+        succ = BlockDev.fs_exfat_set_uuid(self.loop_devs[0], "2E24EC82")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, "2E24-EC82")
 
         # should be also support with the dash
-        succ = BlockDev.fs_exfat_set_uuid(self.loop_dev, "2E24-EC82")
+        succ = BlockDev.fs_exfat_set_uuid(self.loop_devs[0], "2E24-EC82")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, "2E24-EC82")
 
-        succ = BlockDev.fs_exfat_set_uuid(self.loop_dev, "")
+        succ = BlockDev.fs_exfat_set_uuid(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = BlockDev.fs_exfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_exfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertTrue(fi.uuid)  # new random, not empty
         self.assertNotEqual(fi.uuid, "2E24-EC82")

--- a/tests/fs_tests/ext_test.py
+++ b/tests/fs_tests/ext_test.py
@@ -121,18 +121,18 @@ class ExtTestMkfs(ExtTestCase):
         with self.assertRaises(GLib.GError):
             mkfs_function("/non/existing/device", None)
 
-        succ = mkfs_function(self.loop_dev, None)
+        succ = mkfs_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, ext_version)
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
     @tag_test(TestTags.CORE)
     def test_ext2_mkfs(self):
@@ -156,10 +156,10 @@ class ExtTestMkfs(ExtTestCase):
 class ExtMkfsWithLabel(ExtTestCase):
     def _test_ext_mkfs_with_label(self, mkfs_function, info_function):
         ea = BlockDev.ExtraArg.new("-L", "TEST_LABEL")
-        succ = mkfs_function(self.loop_dev, [ea])
+        succ = mkfs_function(self.loop_devs[0], [ea])
         self.assertTrue(succ)
 
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL")
 
@@ -181,10 +181,10 @@ class ExtMkfsWithLabel(ExtTestCase):
 
 class ExtTestCheck(ExtTestCase):
     def _test_ext_check(self, mkfs_function, check_function):
-        succ = mkfs_function(self.loop_dev, None)
+        succ = mkfs_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = check_function(self.loop_dev, None)
+        succ = check_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
     def test_ext2_check(self):
@@ -205,17 +205,17 @@ class ExtTestCheck(ExtTestCase):
 
 class ExtTestRepair(ExtTestCase):
     def _test_ext_repair(self, mkfs_function, repair_function):
-        succ = mkfs_function(self.loop_dev, None)
+        succ = mkfs_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = repair_function(self.loop_dev, False, None)
+        succ = repair_function(self.loop_devs[0], False, None)
         self.assertTrue(succ)
 
         # unsafe operations should work here too
-        succ = repair_function(self.loop_dev, True, None)
+        succ = repair_function(self.loop_devs[0], True, None)
         self.assertTrue(succ)
 
-        succ = repair_function(self.loop_dev, False, None)
+        succ = repair_function(self.loop_devs[0], False, None)
         self.assertTrue(succ)
 
     def test_ext2_repair(self):
@@ -236,10 +236,10 @@ class ExtTestRepair(ExtTestCase):
 
 class ExtGetInfo(ExtTestCase):
     def _test_ext_get_info(self, mkfs_function, info_function):
-        succ = BlockDev.fs_ext4_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_ext4_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_ext4_get_info(self.loop_dev)
+        fi = BlockDev.fs_ext4_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
         self.assertEqual(fi.block_count, self.loop_size / 1024)
@@ -250,8 +250,8 @@ class ExtGetInfo(ExtTestCase):
         self.assertTrue(fi.uuid)
         self.assertTrue(fi.state, "clean")
 
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_ext4_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_ext4_get_info(self.loop_devs[0])
             self.assertEqual(fi.block_size, 1024)
             self.assertEqual(fi.block_count, self.loop_size / 1024)
             # at least 90 % should be available, so it should be reported
@@ -282,28 +282,28 @@ class ExtGetInfo(ExtTestCase):
 
 class ExtSetLabel(ExtTestCase):
     def _test_ext_set_label(self, mkfs_function, info_function, label_function, check_function):
-        succ = mkfs_function(self.loop_dev, None)
+        succ = mkfs_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
-        succ = label_function(self.loop_dev, "TEST_LABEL")
+        succ = label_function(self.loop_devs[0], "TEST_LABEL")
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL")
 
-        succ = label_function(self.loop_dev, "TEST_LABEL2")
+        succ = label_function(self.loop_devs[0], "TEST_LABEL2")
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL2")
 
-        succ = label_function(self.loop_dev, "")
+        succ = label_function(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
@@ -337,27 +337,27 @@ class ExtSetLabel(ExtTestCase):
 
 class ExtResize(ExtTestCase):
     def _test_ext_resize(self, mkfs_function, info_function, resize_function, minsize_function):
-        succ = mkfs_function(self.loop_dev, None)
+        succ = mkfs_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
         self.assertEqual(fi.block_count, self.loop_size / 1024)
         # at least 90 % should be available, so it should be reported
         self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
-        succ = resize_function(self.loop_dev, 50 * 1024**2, None)
+        succ = resize_function(self.loop_devs[0], 50 * 1024**2, None)
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
         self.assertEqual(fi.block_count, 50 * 1024**2 / 1024)
 
         # resize back
-        succ = resize_function(self.loop_dev, self.loop_size, None)
+        succ = resize_function(self.loop_devs[0], self.loop_size, None)
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
         self.assertEqual(fi.block_count, self.loop_size / 1024)
@@ -365,17 +365,17 @@ class ExtResize(ExtTestCase):
         self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
         # resize again
-        succ = resize_function(self.loop_dev, 50 * 1024**2, None)
+        succ = resize_function(self.loop_devs[0], 50 * 1024**2, None)
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
         self.assertEqual(fi.block_count, 50 * 1024**2 / 1024)
 
         # resize back again, this time to maximum size
-        succ = resize_function(self.loop_dev, 0, None)
+        succ = resize_function(self.loop_devs[0], 0, None)
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.block_size, 1024)
         self.assertEqual(fi.block_count, self.loop_size / 1024)
@@ -383,10 +383,10 @@ class ExtResize(ExtTestCase):
         self.assertGreater(fi.free_blocks, 0.90 * self.loop_size / 1024)
 
         # get min size and resize to it
-        size = minsize_function(self.loop_dev)
+        size = minsize_function(self.loop_devs[0])
         self.assertNotEqual(size, 0)
 
-        succ = resize_function(self.loop_dev, size)
+        succ = resize_function(self.loop_devs[0], size)
         self.assertTrue(succ)
 
     def test_ext2_resize(self):
@@ -416,43 +416,43 @@ class ExtSetUUID(ExtTestCase):
     test_uuid = "4d7086c4-a4d3-432f-819e-73da03870df9"
 
     def _test_ext_set_uuid(self, mkfs_function, info_function, label_function, check_function):
-        succ = mkfs_function(self.loop_dev, None)
+        succ = mkfs_function(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
 
-        succ = label_function(self.loop_dev, self.test_uuid)
+        succ = label_function(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, self.test_uuid)
 
-        succ = label_function(self.loop_dev, "clear")
+        succ = label_function(self.loop_devs[0], "clear")
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, "")
 
-        succ = label_function(self.loop_dev, "random")
+        succ = label_function(self.loop_devs[0], "random")
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         random_uuid = fi.uuid
 
-        succ = label_function(self.loop_dev, "time")
+        succ = label_function(self.loop_devs[0], "time")
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         self.assertNotEqual(fi.uuid, random_uuid)
         time_uuid = fi.uuid
 
         # no UUID -> random
-        succ = label_function(self.loop_dev, None)
+        succ = label_function(self.loop_devs[0], None)
         self.assertTrue(succ)
-        fi = info_function(self.loop_dev)
+        fi = info_function(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         self.assertNotEqual(fi.uuid, time_uuid)

--- a/tests/fs_tests/nilfs_test.py
+++ b/tests/fs_tests/nilfs_test.py
@@ -101,18 +101,18 @@ class NILFS2TestMkfs(NILFS2TestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_nilfs2_mkfs("/non/existing/device", None)
 
-        succ = BlockDev.fs_nilfs2_mkfs(self.loop_dev)
+        succ = BlockDev.fs_nilfs2_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "nilfs2")
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
 
 class NILFS2MkfsWithLabel(NILFS2TestCase):
@@ -120,10 +120,10 @@ class NILFS2MkfsWithLabel(NILFS2TestCase):
         """Verify that it is possible to create an nilfs2 file system with label"""
 
         ea = BlockDev.ExtraArg.new("-L", "test_label")
-        succ = BlockDev.fs_nilfs2_mkfs(self.loop_dev, [ea])
+        succ = BlockDev.fs_nilfs2_mkfs(self.loop_devs[0], [ea])
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
 
@@ -132,10 +132,10 @@ class NILFS2GetInfo(NILFS2TestCase):
     def test_nilfs2_get_info(self):
         """Verify that it is possible to get info about an nilfs2 file system"""
 
-        succ = BlockDev.fs_nilfs2_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_nilfs2_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
         # should be an non-empty string
@@ -149,28 +149,28 @@ class NILFS2SetLabel(NILFS2TestCase):
     def test_nilfs2_set_label(self):
         """Verify that it is possible to set label of an nilfs2 file system"""
 
-        succ = BlockDev.fs_nilfs2_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_nilfs2_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
-        succ = BlockDev.fs_nilfs2_set_label(self.loop_dev, "test_label")
+        succ = BlockDev.fs_nilfs2_set_label(self.loop_devs[0], "test_label")
         self.assertTrue(succ)
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
 
-        succ = BlockDev.fs_nilfs2_set_label(self.loop_dev, "test_label2")
+        succ = BlockDev.fs_nilfs2_set_label(self.loop_devs[0], "test_label2")
         self.assertTrue(succ)
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label2")
 
-        succ = BlockDev.fs_nilfs2_set_label(self.loop_dev, "")
+        succ = BlockDev.fs_nilfs2_set_label(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
@@ -185,27 +185,27 @@ class NILFS2Resize(NILFS2TestCase):
     def test_nilfs2_resize(self):
         """Verify that it is possible to resize an nilfs2 file system"""
 
-        succ = BlockDev.fs_nilfs2_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_nilfs2_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
         with self.assertRaisesRegex(GLib.GError, "is not currently mounted"):
-            BlockDev.fs_nilfs2_resize(self.loop_dev, 100 * 1024**2)
+            BlockDev.fs_nilfs2_resize(self.loop_devs[0], 100 * 1024**2)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             # shrink
-            succ = BlockDev.fs_nilfs2_resize(self.loop_dev, 100 * 1024**2)
+            succ = BlockDev.fs_nilfs2_resize(self.loop_devs[0], 100 * 1024**2)
             self.assertTrue(succ)
 
             # grow
-            succ = BlockDev.fs_nilfs2_resize(self.loop_dev, 120 * 1024**2)
+            succ = BlockDev.fs_nilfs2_resize(self.loop_devs[0], 120 * 1024**2)
             self.assertTrue(succ)
 
             # shrink again
-            succ = BlockDev.fs_nilfs2_resize(self.loop_dev, 100 * 1024**2)
+            succ = BlockDev.fs_nilfs2_resize(self.loop_devs[0], 100 * 1024**2)
             self.assertTrue(succ)
 
             # resize to maximum size
-            succ = BlockDev.fs_nilfs2_resize(self.loop_dev, 0)
+            succ = BlockDev.fs_nilfs2_resize(self.loop_devs[0], 0)
             self.assertTrue(succ)
 
 
@@ -216,19 +216,19 @@ class NILFS2SetUUID(NILFS2TestCase):
     def test_nilfs2_set_uuid(self):
         """Verify that it is possible to set UUID of an nilfs2 file system"""
 
-        succ = BlockDev.fs_nilfs2_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_nilfs2_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_nilfs2_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.fs_nilfs2_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, self.test_uuid)
 
         # no uuid -> random
-        succ = BlockDev.fs_nilfs2_set_uuid(self.loop_dev, None)
+        succ = BlockDev.fs_nilfs2_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
-        fi = BlockDev.fs_nilfs2_get_info(self.loop_dev)
+        fi = BlockDev.fs_nilfs2_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         self.assertNotEqual(fi.uuid, self.test_uuid)

--- a/tests/fs_tests/ntfs_test.py
+++ b/tests/fs_tests/ntfs_test.py
@@ -109,18 +109,18 @@ class NTFSTestMkfs(NTFSTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_ntfs_mkfs("/non/existing/device", None)
 
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev)
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "ntfs")
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
 
 class NTFSMkfsWithLabel(NTFSTestCase):
@@ -128,10 +128,10 @@ class NTFSMkfsWithLabel(NTFSTestCase):
         """Verify that it is possible to create an NTFS file system with label"""
 
         ea = BlockDev.ExtraArg.new("-L", "test_label")
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, [ea])
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_devs[0], [ea])
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
 
@@ -140,10 +140,10 @@ class NTFSGetInfo(NTFSTestCase):
     def test_ntfs_get_info(self):
         """Verify that it is possible to get info about an NTFS file system"""
 
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
         # should be an non-empty string
@@ -156,58 +156,58 @@ class NTFSResize(NTFSTestCase):
     def test_ntfs_resize(self):
         """Verify that it is possible to resize an NTFS file system"""
 
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_ntfs_repair(self.loop_dev)
+        succ = BlockDev.fs_ntfs_repair(self.loop_devs[0])
         self.assertTrue(succ)
 
         # shrink
-        succ = BlockDev.fs_ntfs_resize(self.loop_dev, 80 * 1024**2)
+        succ = BlockDev.fs_ntfs_resize(self.loop_devs[0], 80 * 1024**2)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_ntfs_repair(self.loop_dev)
+        succ = BlockDev.fs_ntfs_repair(self.loop_devs[0])
         self.assertTrue(succ)
 
         # resize to maximum size
-        succ = BlockDev.fs_ntfs_resize(self.loop_dev, 0)
+        succ = BlockDev.fs_ntfs_resize(self.loop_devs[0], 0)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_ntfs_repair(self.loop_dev)
+        succ = BlockDev.fs_ntfs_repair(self.loop_devs[0])
         self.assertTrue(succ)
 
         # get min size and resize to it
-        size = BlockDev.fs_ntfs_get_min_size(self.loop_dev)
+        size = BlockDev.fs_ntfs_get_min_size(self.loop_devs[0])
         self.assertNotEqual(size, 0)
 
-        succ = BlockDev.fs_ntfs_resize(self.loop_dev, size)
+        succ = BlockDev.fs_ntfs_resize(self.loop_devs[0], size)
         self.assertTrue(succ)
 
 
 class NTFSSetLabel(NTFSTestCase):
     def test_ntfs_set_label(self):
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
-        succ = BlockDev.fs_ntfs_set_label(self.loop_dev, "TEST_LABEL")
+        succ = BlockDev.fs_ntfs_set_label(self.loop_devs[0], "TEST_LABEL")
         self.assertTrue(succ)
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL")
 
-        succ = BlockDev.fs_ntfs_set_label(self.loop_dev, "TEST_LABEL2")
+        succ = BlockDev.fs_ntfs_set_label(self.loop_devs[0], "TEST_LABEL2")
         self.assertTrue(succ)
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL2")
 
-        succ = BlockDev.fs_ntfs_set_label(self.loop_dev, "")
+        succ = BlockDev.fs_ntfs_set_label(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
@@ -224,19 +224,19 @@ class NTFSSetUUID(NTFSTestCase):
 
     def test_ntfs_set_uuid(self):
         """Verify that it is possible to set UUID of an ntfs file system"""
-        succ = BlockDev.fs_ntfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_ntfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_ntfs_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.fs_ntfs_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, self.test_uuid)
 
         # no uuid -> random
-        succ = BlockDev.fs_ntfs_set_uuid(self.loop_dev, None)
+        succ = BlockDev.fs_ntfs_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
-        fi = BlockDev.fs_ntfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_ntfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         self.assertNotEqual(fi.uuid, self.test_uuid)

--- a/tests/fs_tests/udf_test.py
+++ b/tests/fs_tests/udf_test.py
@@ -61,33 +61,33 @@ class UdfTestMkfs(UdfTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_udf_mkfs("/non/existing/device", None)
 
-        succ = BlockDev.fs_udf_mkfs(self.loop_dev)
+        succ = BlockDev.fs_udf_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "udf")
 
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.revision, "2.01")
         self.assertEqual(fi.block_size, 512)
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
         # now try with custom revision and media type
-        succ = BlockDev.fs_udf_mkfs(self.loop_dev, "bdr", "2.50", 4096)
+        succ = BlockDev.fs_udf_mkfs(self.loop_devs[0], "bdr", "2.50", 4096)
         self.assertTrue(succ)
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "udf")
 
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.revision, "2.50")
         self.assertEqual(fi.block_size, 4096)
@@ -97,10 +97,10 @@ class UdfGetInfo(UdfTestCase):
     def test_udf_get_info(self):
         """Verify that it is possible to get info about an udf file system"""
 
-        succ = BlockDev.fs_udf_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_udf_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "LinuxUDF")
         self.assertEqual(fi.vid, "LinuxUDF")
@@ -117,58 +117,58 @@ class UdfSetLabel(UdfTestCase):
     def test_udf_set_label(self):
         """Verify that it is possible to set label of an udf file system"""
 
-        succ = BlockDev.fs_udf_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_udf_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "LinuxUDF")
 
-        succ = BlockDev.fs_udf_set_label(self.loop_dev, "test_label")
+        succ = BlockDev.fs_udf_set_label(self.loop_devs[0], "test_label")
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "test_label")
         self.assertEqual(fi.vid, "test_label")
         self.assertEqual(fi.lvid, "test_label")
 
         # longer label -- vid should be truncated to 30
-        succ = BlockDev.fs_udf_set_label(self.loop_dev, "a" * 126)
+        succ = BlockDev.fs_udf_set_label(self.loop_devs[0], "a" * 126)
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "a" * 126)
         self.assertEqual(fi.vid, "a" * 30)
         self.assertEqual(fi.lvid, "a" * 126)
 
-        succ = BlockDev.fs_udf_set_label(self.loop_dev, "ä" * 126)
+        succ = BlockDev.fs_udf_set_label(self.loop_devs[0], "ä" * 126)
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "ä" * 126)
         self.assertEqual(fi.vid, "ä" * 30)
         self.assertEqual(fi.lvid, "ä" * 126)
 
         # with unicode -- vid should be truncated to 15 or 30 based on position
-        succ = BlockDev.fs_udf_set_label(self.loop_dev, "ř" * 63)
+        succ = BlockDev.fs_udf_set_label(self.loop_devs[0], "ř" * 63)
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "ř" * 63)
         self.assertEqual(fi.vid, "ř" * 15)
         self.assertEqual(fi.lvid, "ř" * 63)
 
-        succ = BlockDev.fs_udf_set_label(self.loop_dev, "ř" + "a" * 62)
+        succ = BlockDev.fs_udf_set_label(self.loop_devs[0], "ř" + "a" * 62)
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "ř" + "a" * 62)
         self.assertEqual(fi.vid, "ř" + "a" * 14)
         self.assertEqual(fi.lvid, "ř" + "a" * 62)
 
-        succ = BlockDev.fs_udf_set_label(self.loop_dev, "a" * 62 + "ř")
+        succ = BlockDev.fs_udf_set_label(self.loop_devs[0], "a" * 62 + "ř")
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "a" * 62 + "ř")
         self.assertEqual(fi.vid, "a" * 30)
@@ -202,19 +202,19 @@ class UdfSetUUID(UdfTestCase):
         if not self.udf_avail:
             self.skipTest("skipping UDF: not available")
 
-        succ = BlockDev.fs_udf_mkfs(self.loop_dev)
+        succ = BlockDev.fs_udf_mkfs(self.loop_devs[0])
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_udf_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.fs_udf_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, self.test_uuid)
 
         # no uuid -> random
-        succ = BlockDev.fs_udf_set_uuid(self.loop_dev, None)
+        succ = BlockDev.fs_udf_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
-        fi = BlockDev.fs_udf_get_info(self.loop_dev)
+        fi = BlockDev.fs_udf_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         self.assertNotEqual(fi.uuid, self.test_uuid)

--- a/tests/fs_tests/vfat_test.py
+++ b/tests/fs_tests/vfat_test.py
@@ -128,18 +128,18 @@ class VfatTestMkfs(VfatTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_vfat_mkfs("/non/existing/device", self._mkfs_options)
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "vfat")
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
 
 class VfatMkfsWithLabel(VfatTestCase):
@@ -148,12 +148,12 @@ class VfatMkfsWithLabel(VfatTestCase):
 
         ea = BlockDev.ExtraArg.new("-n", "TEST_LABEL")
         if self._mkfs_options:
-            succ = BlockDev.fs_vfat_mkfs(self.loop_dev, [ea] + self._mkfs_options)
+            succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], [ea] + self._mkfs_options)
         else:
-            succ = BlockDev.fs_vfat_mkfs(self.loop_dev, [ea])
+            succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], [ea])
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL")
 
@@ -162,13 +162,13 @@ class VfatTestCheck(VfatTestCase):
     def test_vfat_check(self):
         """Verify that it is possible to check an vfat file system"""
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_vfat_check(self.loop_dev, None)
+        succ = BlockDev.fs_vfat_check(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_vfat_check(self.loop_dev, None)
+        succ = BlockDev.fs_vfat_check(self.loop_devs[0], None)
         self.assertTrue(succ)
 
 
@@ -176,10 +176,10 @@ class VfatTestRepair(VfatTestCase):
     def test_vfat_repair(self):
         """Verify that it is possible to repair an vfat file system"""
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_vfat_repair(self.loop_dev, None)
+        succ = BlockDev.fs_vfat_repair(self.loop_devs[0], None)
         self.assertTrue(succ)
 
 
@@ -187,10 +187,10 @@ class VfatGetInfo(VfatTestCase):
     def test_vfat_get_info(self):
         """Verify that it is possible to get info about an vfat file system"""
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
         # should be an non-empty string
@@ -201,28 +201,28 @@ class VfatSetLabel(VfatTestCase):
     def test_vfat_set_label(self):
         """Verify that it is possible to set label of an vfat file system"""
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
-        succ = BlockDev.fs_vfat_set_label(self.loop_dev, "TEST_LABEL")
+        succ = BlockDev.fs_vfat_set_label(self.loop_devs[0], "TEST_LABEL")
         self.assertTrue(succ)
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL")
 
-        succ = BlockDev.fs_vfat_set_label(self.loop_dev, "TEST_LABEL2")
+        succ = BlockDev.fs_vfat_set_label(self.loop_devs[0], "TEST_LABEL2")
         self.assertTrue(succ)
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL2")
 
-        succ = BlockDev.fs_vfat_set_label(self.loop_dev, "")
+        succ = BlockDev.fs_vfat_set_label(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
@@ -240,25 +240,25 @@ class VfatSetUUID(VfatTestCase):
         if DOSFSTOOLS_VERSION <= Version("4.1"):
             self.skipTest("dosfstools >= 4.2 needed to set UUID")
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_vfat_set_uuid(self.loop_dev, "2E24EC82")
+        succ = BlockDev.fs_vfat_set_uuid(self.loop_devs[0], "2E24EC82")
         self.assertTrue(succ)
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, "2E24-EC82")
 
         # should be also support with the dash
-        succ = BlockDev.fs_vfat_set_uuid(self.loop_dev, "2E24-EC82")
+        succ = BlockDev.fs_vfat_set_uuid(self.loop_devs[0], "2E24-EC82")
         self.assertTrue(succ)
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, "2E24-EC82")
 
-        succ = BlockDev.fs_vfat_set_uuid(self.loop_dev, "")
+        succ = BlockDev.fs_vfat_set_uuid(self.loop_devs[0], "")
         self.assertTrue(succ)
-        fi = BlockDev.fs_vfat_get_info(self.loop_dev)
+        fi = BlockDev.fs_vfat_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertTrue(fi.uuid)  # new random, not empty
         self.assertNotEqual(fi.uuid, "2E24-EC82")
@@ -287,21 +287,21 @@ class VfatResize(VfatTestCase):
     def test_vfat_resize(self):
         """Verify that it is possible to resize an vfat file system"""
 
-        succ = BlockDev.fs_vfat_mkfs(self.loop_dev, self._mkfs_options)
+        succ = BlockDev.fs_vfat_mkfs(self.loop_devs[0], self._mkfs_options)
         self.assertTrue(succ)
 
         # shrink
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 130 * 1024**2)
+        succ = BlockDev.fs_vfat_resize(self.loop_devs[0], 130 * 1024**2)
         self.assertTrue(succ)
 
         # grow
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 140 * 1024**2)
+        succ = BlockDev.fs_vfat_resize(self.loop_devs[0], 140 * 1024**2)
         self.assertTrue(succ)
 
         # shrink again
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 130 * 1024**2)
+        succ = BlockDev.fs_vfat_resize(self.loop_devs[0], 130 * 1024**2)
         self.assertTrue(succ)
 
         # resize to maximum size
-        succ = BlockDev.fs_vfat_resize(self.loop_dev, 0)
+        succ = BlockDev.fs_vfat_resize(self.loop_devs[0], 0)
         self.assertTrue(succ)

--- a/tests/fs_tests/xfs_test.py
+++ b/tests/fs_tests/xfs_test.py
@@ -112,37 +112,37 @@ class XfsTestMkfs(XfsTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.fs_xfs_mkfs("/non/existing/device", None)
 
-        succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
         # just try if we can mount the file system
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             pass
 
         # check the fstype
-        fstype = BlockDev.fs_get_fstype(self.loop_dev)
+        fstype = BlockDev.fs_get_fstype(self.loop_devs[0])
         self.assertEqual(fstype, "xfs")
 
-        BlockDev.fs_wipe(self.loop_dev, True)
+        BlockDev.fs_wipe(self.loop_devs[0], True)
 
 
 class XfsTestCheck(XfsTestCase):
     def test_xfs_check(self):
         """Verify that it is possible to check an xfs file system"""
 
-        succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_xfs_check(self.loop_dev)
+        succ = BlockDev.fs_xfs_check(self.loop_devs[0])
         self.assertTrue(succ)
 
         # mounted RO, can be checked and nothing happened in/to the file system,
         # so it should be just reported as clean
-        with mounted(self.loop_dev, self.mount_dir, ro=True):
-            succ = BlockDev.fs_xfs_check(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir, ro=True):
+            succ = BlockDev.fs_xfs_check(self.loop_devs[0])
             self.assertTrue(succ)
 
-        succ = BlockDev.fs_xfs_check(self.loop_dev)
+        succ = BlockDev.fs_xfs_check(self.loop_devs[0])
         self.assertTrue(succ)
 
 
@@ -150,17 +150,17 @@ class XfsTestRepair(XfsTestCase):
     def test_xfs_repair(self):
         """Verify that it is possible to repair an xfs file system"""
 
-        succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_xfs_repair(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_repair(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        with mounted(self.loop_dev, self.mount_dir):
+        with mounted(self.loop_devs[0], self.mount_dir):
             with self.assertRaises(GLib.GError):
-                BlockDev.fs_xfs_repair(self.loop_dev, None)
+                BlockDev.fs_xfs_repair(self.loop_devs[0], None)
 
-        succ = BlockDev.fs_xfs_repair(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_repair(self.loop_devs[0], None)
         self.assertTrue(succ)
 
 
@@ -169,10 +169,10 @@ class XfsGetInfo(XfsTestCase):
     def test_xfs_get_info(self):
         """Verify that it is possible to get info about an xfs file system"""
 
-        succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertEqual(fi.block_size, 4096)
         self.assertEqual(fi.block_count, self.loop_size / 4096)
         self.assertEqual(fi.label, "")
@@ -184,32 +184,32 @@ class XfsSetLabel(XfsTestCase):
     def test_xfs_set_label(self):
         """Verify that it is possible to set label of an xfs file system"""
 
-        succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
-        succ = BlockDev.fs_xfs_set_label(self.loop_dev, "TEST_LABEL")
+        succ = BlockDev.fs_xfs_set_label(self.loop_devs[0], "TEST_LABEL")
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL")
 
-        succ = BlockDev.fs_xfs_set_label(self.loop_dev, "TEST_LABEL2")
+        succ = BlockDev.fs_xfs_set_label(self.loop_devs[0], "TEST_LABEL2")
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "TEST_LABEL2")
 
-        succ = BlockDev.fs_xfs_set_label(self.loop_dev, "")
+        succ = BlockDev.fs_xfs_set_label(self.loop_devs[0], "")
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.label, "")
 
@@ -291,36 +291,36 @@ class XfsSetUUID(XfsTestCase):
     def test_xfs_set_uuid(self):
         """Verify that it is possible to set UUID of an xfs file system"""
 
-        succ = BlockDev.fs_xfs_mkfs(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_mkfs(self.loop_devs[0], None)
         self.assertTrue(succ)
 
-        succ = BlockDev.fs_xfs_set_uuid(self.loop_dev, self.test_uuid)
+        succ = BlockDev.fs_xfs_set_uuid(self.loop_devs[0], self.test_uuid)
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertEqual(fi.uuid, self.test_uuid)
 
-        succ = BlockDev.fs_xfs_set_uuid(self.loop_dev, "nil")
+        succ = BlockDev.fs_xfs_set_uuid(self.loop_devs[0], "nil")
         self.assertTrue(succ)
 
         # can't use libblockdev because XFS without UUID can't be mounted
-        fs_type = check_output(["blkid", "-ovalue", "-sUUID", "-p", self.loop_dev]).strip()
+        fs_type = check_output(["blkid", "-ovalue", "-sUUID", "-p", self.loop_devs[0]]).strip()
         self.assertEqual(fs_type, b"")
 
-        succ = BlockDev.fs_xfs_set_uuid(self.loop_dev, "generate")
+        succ = BlockDev.fs_xfs_set_uuid(self.loop_devs[0], "generate")
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         random_uuid = fi.uuid
 
         # no uuid -> random
-        succ = BlockDev.fs_xfs_set_uuid(self.loop_dev, None)
+        succ = BlockDev.fs_xfs_set_uuid(self.loop_devs[0], None)
         self.assertTrue(succ)
-        with mounted(self.loop_dev, self.mount_dir):
-            fi = BlockDev.fs_xfs_get_info(self.loop_dev)
+        with mounted(self.loop_devs[0], self.mount_dir):
+            fi = BlockDev.fs_xfs_get_info(self.loop_devs[0])
         self.assertTrue(fi)
         self.assertNotEqual(fi.uuid, "")
         self.assertNotEqual(fi.uuid, random_uuid)

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -1,14 +1,12 @@
 import os
 import unittest
-import time
 import overrides_hack
 
 from utils import create_sparse_tempfile, TestTags, tag_test, required_plugins
 
 import gi
-gi.require_version('GLib', '2.0')
 gi.require_version('BlockDev', '3.0')
-from gi.repository import GLib, BlockDev
+from gi.repository import BlockDev
 
 
 @required_plugins(("loop",))
@@ -38,7 +36,7 @@ class LoopTestCase(unittest.TestCase):
 class LoopPluginVersionCase(LoopTestCase):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.LOOP), "libbd_loop.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.LOOP), "libbd_loop.so.3")
 
 
 class LoopTestSetupBasic(LoopTestCase):

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -28,7 +28,7 @@ class LvmDBusTestCase(_lvm_cases.LvmTestCase):
         if not BlockDev.is_initialized():
             BlockDev.init(cls.requested_plugins, None)
         else:
-                BlockDev.reinit(cls.requested_plugins, True, None)
+            BlockDev.reinit(cls.requested_plugins, True, None)
 
         try:
             cls.devices_avail = BlockDev.lvm_is_tech_avail(BlockDev.LVMTech.DEVICES, 0)
@@ -44,7 +44,7 @@ class LvmNoDevTestCase(_lvm_cases.LvmNoDevTestCase, LvmDBusTestCase):
 
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.LVM), "libbd_lvm-dbus.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.LVM), "libbd_lvm-dbus.so.3")
 
     @tag_test(TestTags.NOSTORAGE)
     def test_tech_available(self):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -37,7 +37,7 @@ class LvmNoDevTestCase(_lvm_cases.LvmNoDevTestCase, LvmTestCase):
 
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.LVM), "libbd_lvm.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.LVM), "libbd_lvm.so.3")
 
     def test_tech_available(self):
         """Verify that checking lvm tool availability by technology works as expected"""

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -42,18 +42,9 @@ class MDTest(unittest.TestCase):
 
 class MDNoDevTestCase(MDTest):
 
-    requested_plugins = BlockDev.plugin_specs_from_names(("mdraid",))
-
-    @classmethod
-    def setUpClass(cls):
-        if not BlockDev.is_initialized():
-            BlockDev.init(cls.requested_plugins, None)
-        else:
-            BlockDev.reinit(cls.requested_plugins, True, None)
-
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.MDRAID), "libbd_mdraid.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.MDRAID), "libbd_mdraid.so.3")
 
     @tag_test(TestTags.NOSTORAGE)
     def test_get_superblock_size(self):
@@ -453,7 +444,7 @@ class MDTestNameNodeBijection(MDTestCase):
         with self.assertRaisesRegex(GLib.GError, r'No name'):
             BlockDev.md_name_from_node("no_such_node")
 
-        succ = BlockDev.md_deactivate("bd_test_md");
+        succ = BlockDev.md_deactivate("bd_test_md")
         self.assertTrue(succ)
 
         succ = BlockDev.md_destroy(self.loop_devs[0])

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -214,27 +214,24 @@ class MDTestActivateDeactivate(MDTestCase):
     def test_activate_deactivate(self):
         """Verify that it is possible to activate and deactivate an MD RAID"""
 
-        with wait_for_action("resync"):
-            succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_devs[0], self.loop_devs[1]],
-                                      0, None, None)
-            self.assertTrue(succ)
+        succ = BlockDev.md_create("bd_test_md", "raid0",
+                                    [self.loop_devs[0], self.loop_devs[1]],
+                                    0, None, None)
+        self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
             BlockDev.md_deactivate("non_existing_md")
 
-        with wait_for_action("resync"):
-            succ = BlockDev.md_deactivate("bd_test_md")
-            self.assertTrue(succ)
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
             BlockDev.md_activate("bd_test_md",
                                  ["/non/existing/device", self.loop_devs[1]], None)
 
-        with wait_for_action("resync"):
-            succ = BlockDev.md_activate("bd_test_md",
-                                        [self.loop_devs[0], self.loop_devs[1]], None)
-            self.assertTrue(succ)
+        succ = BlockDev.md_activate("bd_test_md",
+                                    [self.loop_devs[0], self.loop_devs[1]], None)
+        self.assertTrue(succ)
 
         # try to activate again, should not fail, just no-op
         succ = BlockDev.md_activate("bd_test_md",
@@ -242,44 +239,42 @@ class MDTestActivateDeactivate(MDTestCase):
         self.assertTrue(succ)
 
         # try to deactivate using the node instead of name
-        with wait_for_action("resync"):
-            succ = BlockDev.md_deactivate(BlockDev.md_node_from_name("bd_test_md"))
-            self.assertTrue(succ)
+        succ = BlockDev.md_deactivate(BlockDev.md_node_from_name("bd_test_md"))
+        self.assertTrue(succ)
 
         # try to activate using full path, not just the name
         # (it should work too and blivet does this)
-        with wait_for_action("resync"):
-            succ = BlockDev.md_activate("/dev/md/bd_test_md",
-                                        [self.loop_devs[0], self.loop_devs[1]], None)
-            self.assertTrue(succ)
+        succ = BlockDev.md_activate("/dev/md/bd_test_md",
+                                    [self.loop_devs[0], self.loop_devs[1]], None)
+        self.assertTrue(succ)
 
-        with wait_for_action("resync"):
-            succ = BlockDev.md_deactivate("bd_test_md")
-            self.assertTrue(succ)
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
 
         md_info = BlockDev.md_examine(self.loop_devs[0])
         self.assertTrue(md_info)
         self.assertTrue(md_info.uuid)
 
         # try to activate with UUID and array name
-        with wait_for_action("resync"):
-            succ = BlockDev.md_activate("bd_test_md", [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+        succ = BlockDev.md_activate("bd_test_md", [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+        self.assertTrue(succ)
 
-        with wait_for_action("resync"):
-            succ = BlockDev.md_deactivate("bd_test_md")
-            self.assertTrue(succ)
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
 
         # try to activate by UUID only: should work with member devices specified
-        with wait_for_action("resync"):
-            succ = BlockDev.md_activate(None, [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+        succ = BlockDev.md_activate(None, [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+        self.assertTrue(succ)
 
-        with wait_for_action("resync"):
-            succ = BlockDev.md_deactivate("bd_test_md")
-            self.assertTrue(succ)
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
 
         # as well as without them
-        with wait_for_action("resync"):
-            succ = BlockDev.md_activate(None, None, md_info.uuid)
+        succ = BlockDev.md_activate(None, None, md_info.uuid)
+        self.assertTrue(succ)
+
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
 
 
 class MDTestNominateDenominate(MDTestCase):

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -253,18 +253,6 @@ class MDTestActivateDeactivate(MDTestCase):
                                         [self.loop_devs[0], self.loop_devs[1]], None)
             self.assertTrue(succ)
 
-
-class MDTestActivateWithUUID(MDTestCase):
-    @tag_test(TestTags.SLOW)
-    def test_activate_with_uuid(self):
-        """Verify that it is possible to activate an MD RAID with UUID"""
-
-        with wait_for_action("resync"):
-            succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_devs[0], self.loop_devs[1]],
-                                      0, None, None)
-            self.assertTrue(succ)
-
         with wait_for_action("resync"):
             succ = BlockDev.md_deactivate("bd_test_md")
             self.assertTrue(succ)
@@ -273,30 +261,15 @@ class MDTestActivateWithUUID(MDTestCase):
         self.assertTrue(md_info)
         self.assertTrue(md_info.uuid)
 
+        # try to activate with UUID and array name
         with wait_for_action("resync"):
             succ = BlockDev.md_activate("bd_test_md", [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
 
-
-class MDTestActivateByUUID(MDTestCase):
-    @tag_test(TestTags.SLOW)
-    def test_activate_by_uuid(self):
-        """Verify that it is possible to activate an MD RAID by UUID"""
-
-        with wait_for_action("resync"):
-            succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_devs[0], self.loop_devs[1]],
-                                      0, None, None)
-            self.assertTrue(succ)
-
         with wait_for_action("resync"):
             succ = BlockDev.md_deactivate("bd_test_md")
             self.assertTrue(succ)
 
-        md_info = BlockDev.md_examine(self.loop_devs[0])
-        self.assertTrue(md_info)
-        self.assertTrue(md_info.uuid)
-
-        # should work with member devices specified
+        # try to activate by UUID only: should work with member devices specified
         with wait_for_action("resync"):
             succ = BlockDev.md_activate(None, [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
 

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -100,28 +100,25 @@ class MDNoDevTestCase(MDTest):
 class MDTestCase(MDTest):
 
     _sparse_size = 10 * 1024**2
+    _num_devices = 2
+    loop_devs = []
+    dev_files = []
 
     def setUp(self):
         if os.uname()[-1] == "i686":
             self.skipTest("Skipping hanging MD RAID tests on i686")
 
         self.addCleanup(self._clean_up)
-        self.dev_file = create_sparse_tempfile("md_test", self._sparse_size)
-        self.dev_file2 = create_sparse_tempfile("md_test", self._sparse_size)
-        self.dev_file3 = create_sparse_tempfile("md_test", self._sparse_size)
 
-        try:
-            self.loop_dev = create_lio_device(self.dev_file)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
-        try:
-            self.loop_dev2 = create_lio_device(self.dev_file2)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
-        try:
-            self.loop_dev3 = create_lio_device(self.dev_file3)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
+        for i in range(self._num_devices):
+            dev_file = create_sparse_tempfile("md_test", self._sparse_size)
+            self.dev_files.append(dev_file)
+
+            try:
+                loop_dev = create_lio_device(self.dev_files[i])
+                self.loop_devs.append(loop_dev)
+            except RuntimeError as e:
+                raise RuntimeError("Failed to setup loop device for testing: %s" % e)
 
     def _clean_up(self):
         try:
@@ -132,18 +129,13 @@ class MDTestCase(MDTest):
             BlockDev.md_deactivate(BlockDev.md_node_from_name("bd_test_md"))
         except:
             pass
-        try:
-            BlockDev.md_destroy(self.loop_dev)
-        except:
-            pass
-        try:
-            BlockDev.md_destroy(self.loop_dev2)
-        except:
-            pass
-        try:
-            BlockDev.md_destroy(self.loop_dev3)
-        except:
-            pass
+
+        for i in range(self._num_devices):
+            try:
+                BlockDev.md_destroy(self.loop_devs[i])
+            except:
+                pass
+
         try:
             BlockDev.md_deactivate("bd_test_md")
         except:
@@ -153,26 +145,16 @@ class MDTestCase(MDTest):
         except:
             pass
 
-        try:
-            delete_lio_device(self.loop_dev)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file)
+        for i in range(self._num_devices):
+            try:
+                delete_lio_device(self.loop_devs[i])
+            except RuntimeError:
+                # just move on, we can do no better here
+                pass
+            os.unlink(self.dev_files[i])
 
-        try:
-            delete_lio_device(self.loop_dev2)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file2)
-
-        try:
-            delete_lio_device(self.loop_dev3)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file3)
+        self.dev_files.clear()
+        self.loop_devs.clear()
 
 
 class MDTestCreateDeactivateDestroy(MDTestCase):
@@ -182,13 +164,13 @@ class MDTestCreateDeactivateDestroy(MDTestCase):
 
         with self.assertRaises(GLib.GError):
             BlockDev.md_create("bd_test_md2", "raid1",
-                               ["/non/existing/device", self.loop_dev2],
-                               1, None, None)
+                               ["/non/existing/device", self.loop_devs[1]],
+                               0, None, None)
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, None)
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, None)
             self.assertTrue(succ)
 
         # newly created array should be 'clean'
@@ -198,12 +180,11 @@ class MDTestCreateDeactivateDestroy(MDTestCase):
         succ = BlockDev.md_deactivate("bd_test_md")
         self.assertTrue(succ)
 
-        succ = BlockDev.md_destroy(self.loop_dev)
+        succ = BlockDev.md_destroy(self.loop_devs[0])
         self.assertTrue(succ)
-        succ = BlockDev.md_destroy(self.loop_dev2)
+        succ = BlockDev.md_destroy(self.loop_devs[1])
         self.assertTrue(succ)
-        succ = BlockDev.md_destroy(self.loop_dev3)
-        self.assertTrue(succ)
+
 
 class MDTestCreateWithChunkSize(MDTestCase):
     @tag_test(TestTags.SLOW)
@@ -212,22 +193,21 @@ class MDTestCreateWithChunkSize(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid0",
-                                      [self.loop_dev, self.loop_dev2],
+                                      [self.loop_devs[0], self.loop_devs[1]],
                                       0, None, None, 512 * 1024)
             self.assertTrue(succ)
 
-        ex_data = BlockDev.md_examine(self.loop_dev)
+        ex_data = BlockDev.md_examine(self.loop_devs[0])
         self.assertEqual(ex_data.chunk_size, 512 * 1024)
 
         succ = BlockDev.md_deactivate("bd_test_md")
         self.assertTrue(succ)
 
-        succ = BlockDev.md_destroy(self.loop_dev)
+        succ = BlockDev.md_destroy(self.loop_devs[0])
         self.assertTrue(succ)
-        succ = BlockDev.md_destroy(self.loop_dev2)
+        succ = BlockDev.md_destroy(self.loop_devs[1])
         self.assertTrue(succ)
-        succ = BlockDev.md_destroy(self.loop_dev3)
-        self.assertTrue(succ)
+
 
 class MDTestActivateDeactivate(MDTestCase):
     @tag_test(TestTags.SLOW, TestTags.CORE)
@@ -236,8 +216,8 @@ class MDTestActivateDeactivate(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, None)
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, None)
             self.assertTrue(succ)
 
         with self.assertRaises(GLib.GError):
@@ -249,16 +229,16 @@ class MDTestActivateDeactivate(MDTestCase):
 
         with self.assertRaises(GLib.GError):
             BlockDev.md_activate("bd_test_md",
-                                 ["/non/existing/device", self.loop_dev2, self.loop_dev3], None)
+                                 ["/non/existing/device", self.loop_devs[1]], None)
 
         with wait_for_action("resync"):
             succ = BlockDev.md_activate("bd_test_md",
-                                        [self.loop_dev, self.loop_dev2, self.loop_dev3], None)
+                                        [self.loop_devs[0], self.loop_devs[1]], None)
             self.assertTrue(succ)
 
         # try to activate again, should not fail, just no-op
         succ = BlockDev.md_activate("bd_test_md",
-                                    [self.loop_dev, self.loop_dev2, self.loop_dev3], None)
+                                    [self.loop_devs[0], self.loop_devs[1]], None)
         self.assertTrue(succ)
 
         # try to deactivate using the node instead of name
@@ -270,8 +250,9 @@ class MDTestActivateDeactivate(MDTestCase):
         # (it should work too and blivet does this)
         with wait_for_action("resync"):
             succ = BlockDev.md_activate("/dev/md/bd_test_md",
-                                        [self.loop_dev, self.loop_dev2, self.loop_dev3], None)
+                                        [self.loop_devs[0], self.loop_devs[1]], None)
             self.assertTrue(succ)
+
 
 class MDTestActivateWithUUID(MDTestCase):
     @tag_test(TestTags.SLOW)
@@ -280,20 +261,21 @@ class MDTestActivateWithUUID(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, None)
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, None)
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
             succ = BlockDev.md_deactivate("bd_test_md")
             self.assertTrue(succ)
 
-        md_info = BlockDev.md_examine(self.loop_dev)
+        md_info = BlockDev.md_examine(self.loop_devs[0])
         self.assertTrue(md_info)
         self.assertTrue(md_info.uuid)
 
         with wait_for_action("resync"):
-            succ = BlockDev.md_activate("bd_test_md", [self.loop_dev, self.loop_dev2, self.loop_dev3], md_info.uuid)
+            succ = BlockDev.md_activate("bd_test_md", [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+
 
 class MDTestActivateByUUID(MDTestCase):
     @tag_test(TestTags.SLOW)
@@ -302,21 +284,21 @@ class MDTestActivateByUUID(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, None)
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, None)
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
             succ = BlockDev.md_deactivate("bd_test_md")
             self.assertTrue(succ)
 
-        md_info = BlockDev.md_examine(self.loop_dev)
+        md_info = BlockDev.md_examine(self.loop_devs[0])
         self.assertTrue(md_info)
         self.assertTrue(md_info.uuid)
 
         # should work with member devices specified
         with wait_for_action("resync"):
-            succ = BlockDev.md_activate(None, [self.loop_dev, self.loop_dev2, self.loop_dev3], md_info.uuid)
+            succ = BlockDev.md_activate(None, [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
 
         with wait_for_action("resync"):
             succ = BlockDev.md_deactivate("bd_test_md")
@@ -328,30 +310,32 @@ class MDTestActivateByUUID(MDTestCase):
 
 
 class MDTestNominateDenominate(MDTestCase):
+    _num_devices = 3
+
     @tag_test(TestTags.SLOW)
     def test_nominate_denominate(self):
         """Verify that it is possible to nominate and denominate an MD RAID device"""
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
+                                      [self.loop_devs[0], self.loop_devs[1], self.loop_devs[2]],
                                       1, None, None)
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
-            succ = BlockDev.md_denominate(self.loop_dev)
+            succ = BlockDev.md_denominate(self.loop_devs[0])
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
-            succ = BlockDev.md_nominate(self.loop_dev)
+            succ = BlockDev.md_nominate(self.loop_devs[0])
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
-            succ = BlockDev.md_denominate(self.loop_dev)
+            succ = BlockDev.md_denominate(self.loop_devs[0])
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
-            succ = BlockDev.md_nominate(self.loop_dev)
+            succ = BlockDev.md_nominate(self.loop_devs[0])
             self.assertTrue(succ)
 
         with wait_for_action("resync"):
@@ -360,17 +344,19 @@ class MDTestNominateDenominate(MDTestCase):
 
 
 class MDTestAddRemove(MDTestCase):
+    _num_devices = 3
+
     @tag_test(TestTags.SLOW)
     def test_add_remove(self):
         """Verify that it is possible to add a device to and remove from an MD RAID"""
 
         # the MD array doesn't exist yet
         with self.assertRaises(GLib.GError):
-            BlockDev.md_add("bd_test_md", self.loop_dev3, 0, None)
+            BlockDev.md_add("bd_test_md", self.loop_devs[2], 0, None)
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2],
+                                      [self.loop_devs[0], self.loop_devs[1]],
                                       0, None, None)
             self.assertTrue(succ)
 
@@ -378,7 +364,7 @@ class MDTestAddRemove(MDTestCase):
             BlockDev.md_add("bd_test_md", "/non/existing/device", 0, None)
 
         # add the device as a spare
-        succ = BlockDev.md_add("bd_test_md", self.loop_dev3, 0, None)
+        succ = BlockDev.md_add("bd_test_md", self.loop_devs[2], 0, None)
         self.assertTrue(succ)
 
         md_info = BlockDev.md_detail("bd_test_md")
@@ -386,11 +372,11 @@ class MDTestAddRemove(MDTestCase):
         self.assertEqual(md_info.spare_devices, 1)
 
         with self.assertRaises(GLib.GError):
-            BlockDev.md_add("bd_test_md", self.loop_dev3, 0, None)
+            BlockDev.md_add("bd_test_md", self.loop_devs[2], 0, None)
 
         # now remove the spare device (should be possible without --fail)
         with wait_for_action("resync"):
-            succ = BlockDev.md_remove("bd_test_md", self.loop_dev3, False, None)
+            succ = BlockDev.md_remove("bd_test_md", self.loop_devs[2], False, None)
             self.assertTrue(succ)
 
         md_info = BlockDev.md_detail("bd_test_md")
@@ -399,7 +385,7 @@ class MDTestAddRemove(MDTestCase):
 
         # remove one of the original devices (with --fail enabled)
         with wait_for_action("resync"):
-            succ = BlockDev.md_remove("bd_test_md", self.loop_dev2, True, None)
+            succ = BlockDev.md_remove("bd_test_md", self.loop_devs[1], True, None)
             self.assertTrue(succ)
 
         md_info = BlockDev.md_detail("bd_test_md")
@@ -410,7 +396,7 @@ class MDTestAddRemove(MDTestCase):
         # now try to add it back -- it should be re-added automatically as
         # a RAID device, not a spare device
         with wait_for_action("recovery"):
-            succ = BlockDev.md_add("bd_test_md", self.loop_dev2, 0, None)
+            succ = BlockDev.md_add("bd_test_md", self.loop_devs[1], 0, None)
             self.assertTrue(succ)
 
         md_info = BlockDev.md_detail("bd_test_md")
@@ -418,19 +404,21 @@ class MDTestAddRemove(MDTestCase):
         self.assertEqual(md_info.active_devices, 2)
         self.assertEqual(md_info.spare_devices, 0)
 
+
 class MDTestExamineDetail(MDTestCase):
-    # sleeps to let MD RAID sync things
+    _num_devices = 3
+
     @tag_test(TestTags.SLOW)
     def test_examine_detail(self):
         """Verify that it is possible to get info about an MD RAID"""
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
+                                      [self.loop_devs[0], self.loop_devs[1], self.loop_devs[2]],
                                       1, None, None)
             self.assertTrue(succ)
 
-        ex_data = BlockDev.md_examine(self.loop_dev)
+        ex_data = BlockDev.md_examine(self.loop_devs[0])
         # test that we got something
         self.assertTrue(ex_data)
 
@@ -475,6 +463,7 @@ class MDTestExamineDetail(MDTestCase):
         de_data = BlockDev.md_detail("/dev/%s" % node)
         self.assertTrue(de_data)
 
+
 class MDTestNameNodeBijection(MDTestCase):
     @tag_test(TestTags.SLOW)
     def test_name_node_bijection(self):
@@ -482,8 +471,8 @@ class MDTestNameNodeBijection(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, None)
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, None)
             self.assertTrue(succ)
 
         node = BlockDev.md_node_from_name("bd_test_md")
@@ -499,12 +488,11 @@ class MDTestNameNodeBijection(MDTestCase):
         succ = BlockDev.md_deactivate("bd_test_md");
         self.assertTrue(succ)
 
-        succ = BlockDev.md_destroy(self.loop_dev)
+        succ = BlockDev.md_destroy(self.loop_devs[0])
         self.assertTrue(succ)
-        succ = BlockDev.md_destroy(self.loop_dev2)
+        succ = BlockDev.md_destroy(self.loop_devs[1])
         self.assertTrue(succ)
-        succ = BlockDev.md_destroy(self.loop_dev3)
-        self.assertTrue(succ)
+
 
 class MDTestSetBitmapLocation(MDTestCase):
     @tag_test(TestTags.SLOW, TestTags.UNSTABLE)
@@ -513,8 +501,8 @@ class MDTestSetBitmapLocation(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, "none")
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, "none")
             self.assertTrue(succ)
 
         loc = BlockDev.md_get_bitmap_location("bd_test_md")
@@ -524,8 +512,8 @@ class MDTestSetBitmapLocation(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, "internal")
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, "internal")
             self.assertTrue(succ)
 
         loc = BlockDev.md_get_bitmap_location("bd_test_md")
@@ -576,8 +564,8 @@ class MDTestRequestSyncAction(MDTestCase):
 
         with wait_for_action("resync"):
             succ = BlockDev.md_create("bd_test_md", "raid1",
-                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
-                                      1, None, None)
+                                      [self.loop_devs[0], self.loop_devs[1]],
+                                      0, None, None)
             self.assertTrue(succ)
 
         with wait_for_action("check"):
@@ -607,7 +595,7 @@ class MDTestDDFRAID(MDTestCase):
 
     def test_examine_ddf_container(self):
         succ = BlockDev.md_create("bd_test_md", "container",
-                                  [self.loop_dev, self.loop_dev2],
+                                  [self.loop_devs[0], self.loop_devs[1]],
                                   0, "ddf", None)
         self.assertTrue(succ)
 
@@ -615,7 +603,7 @@ class MDTestDDFRAID(MDTestCase):
         ret, _out, err = run_command("mdadm --create /dev/md/bd_test_ddf --run --level=raid0 --raid-devices=2 /dev/md/bd_test_md")
         self.assertEqual(ret, 0, msg="Failed to create RAID for DDF test: %s" % err)
 
-        edata = BlockDev.md_examine(self.loop_dev)
+        edata = BlockDev.md_examine(self.loop_devs[0])
         self.assertIsNotNone(edata)
         self.assertIsNotNone(edata.uuid)
         self.assertEqual(edata.level, "container")

--- a/tests/mpath_test.py
+++ b/tests/mpath_test.py
@@ -51,7 +51,7 @@ class MpathTestCase(MpathTest):
 class MpathNoDevTestCase(MpathTest):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.MPATH), "libbd_mpath.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.MPATH), "libbd_mpath.so.3")
 
     @tag_test(TestTags.NOSTORAGE)
     def test_get_mpath_members(self):

--- a/tests/nvme_test.py
+++ b/tests/nvme_test.py
@@ -25,7 +25,7 @@ class NVMeTest(unittest.TestCase):
             raise unittest.SkipTest("nvme executable (nvme-cli package) not found in $PATH, skipping.")
         if not shutil.which("nvmetcli"):
             raise unittest.SkipTest("nvmetcli executable not found in $PATH, skipping.")
-        ret, out, err = run_command("modprobe nvme-fabrics")
+        ret, _out, _err = run_command("modprobe nvme-fabrics")
         if ret != 0:
             raise unittest.SkipTest("nvme-fabrics kernel module unavailable, skipping.")
 
@@ -44,7 +44,7 @@ class NVMeTest(unittest.TestCase):
 class NVMePluginVersionTestCase(NVMeTest):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.NVME), "libbd_nvme.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.NVME), "libbd_nvme.so.3")
 
     @tag_test(TestTags.NOSTORAGE)
     def test_availability(self):
@@ -514,13 +514,11 @@ class NVMeFabricsTestCase(NVMeTest):
             self.addCleanup(write_file, HOSTNQN_PATH, saved_hostnqn)
         except:
             self.addCleanup(self._safe_unlink, HOSTNQN_PATH)
-            pass
         try:
             saved_hostid = read_file(HOSTID_PATH)
             self.addCleanup(write_file, HOSTID_PATH, saved_hostid)
         except:
             self.addCleanup(self._safe_unlink, HOSTID_PATH)
-            pass
 
         self._safe_unlink(HOSTNQN_PATH)
         self._safe_unlink(HOSTID_PATH)

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -70,7 +70,7 @@ class PartTestCase(PartTest):
 class PartNoDevTestCase(PartTest):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.PART), "libbd_part.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.PART), "libbd_part.so.3")
 
     @tag_test(TestTags.NOSTORAGE)
     def test_part_type_str(self):
@@ -184,7 +184,7 @@ class PartCreatePartCase(PartTestCase):
 
         ps2 = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.path, ps2.path)
-        self.assertEqual(ps.type, ps2.type);
+        self.assertEqual(ps.type, ps2.type)
         self.assertEqual(ps.start, ps2.start)
         self.assertEqual(ps.size, ps2.size)
 
@@ -216,7 +216,7 @@ class PartCreatePartCase(PartTestCase):
 
         ps2 = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.path, ps2.path)
-        self.assertEqual(ps.type, ps2.type);
+        self.assertEqual(ps.type, ps2.type)
         self.assertEqual(ps.start, ps2.start)
         self.assertEqual(ps.size, ps2.size)
 
@@ -248,7 +248,7 @@ class PartCreatePartCase(PartTestCase):
 
         ps2 = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.path, ps2.path)
-        self.assertEqual(ps.type, ps2.type);
+        self.assertEqual(ps.type, ps2.type)
         self.assertEqual(ps.start, ps2.start)
         self.assertEqual(ps.size, ps2.size)
 
@@ -1018,7 +1018,7 @@ class PartCreateResizePartCase(PartTestCase):
 
         try:
             fdisk_version = self._get_fdisk_version()
-        except Exception as e:
+        except Exception:
             resize_tolerance = 0
             fdisk_version = Version("0")
 

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -18,6 +18,10 @@ class PartTestCase(unittest.TestCase):
 
     requested_plugins = BlockDev.plugin_specs_from_names(("part",))
     block_size = 512
+    _sparse_size = 100 * 1024**2
+    _num_devices = 1
+    loop_devs = []
+    dev_files = []
 
     @classmethod
     def _get_fdisk_version(cls):
@@ -36,31 +40,28 @@ class PartTestCase(unittest.TestCase):
 
     def setUp(self):
         self.addCleanup(self._clean_up)
-        self.dev_file = create_sparse_tempfile("part_test", 100 * 1024**2)
-        self.dev_file2 = create_sparse_tempfile("part_test", 100 * 1024**2)
-        try:
-            self.loop_dev = create_lio_device(self.dev_file, self.block_size)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
-        try:
-            self.loop_dev2 = create_lio_device(self.dev_file2)
-        except RuntimeError as e:
-            raise RuntimeError("Failed to setup loop device for testing: %s" % e)
+
+        for i in range(self._num_devices):
+            dev_file = create_sparse_tempfile("part_test", self._sparse_size)
+            self.dev_files.append(dev_file)
+
+            try:
+                loop_dev = create_lio_device(self.dev_files[i], self.block_size)
+                self.loop_devs.append(loop_dev)
+            except RuntimeError as e:
+                raise RuntimeError("Failed to setup loop device for testing: %s" % e)
 
     def _clean_up(self):
-        try:
-            delete_lio_device(self.loop_dev)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file)
+        for i in range(self._num_devices):
+            try:
+                delete_lio_device(self.loop_devs[i])
+            except RuntimeError:
+                # just move on, we can do no better here
+                pass
+            os.unlink(self.dev_files[i])
 
-        try:
-            delete_lio_device(self.loop_dev2)
-        except RuntimeError:
-            # just move on, we can do no better here
-            pass
-        os.unlink(self.dev_file2)
+        self.dev_files.clear()
+        self.loop_devs.clear()
 
 
 class PartCPluginVersionCase(PartTestCase):
@@ -70,6 +71,8 @@ class PartCPluginVersionCase(PartTestCase):
 
 
 class PartCreateTableCase(PartTestCase):
+    _num_devices = 2
+
     @tag_test(TestTags.CORE)
     def test_create_table(self):
         """Verify that it is possible to create a new partition table"""
@@ -84,21 +87,21 @@ class PartCreateTableCase(PartTestCase):
 
         # doesn't matter if we want to ignore any preexisting partition tables
         # or not on a clean device
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, False)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, False)
         self.assertTrue(succ)
 
-        succ = BlockDev.part_create_table (self.loop_dev2, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[1], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # should fail because of a preexisting partition table (and not ignoring it)
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, False)
+            BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, False)
 
         # should succeed if we want to ignore any preexisting partition tables
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
 
@@ -114,29 +117,29 @@ class PartGetDiskSpecCase(PartTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.part_get_disk_spec ("/non/existing/device")
 
-        ps = BlockDev.part_get_disk_spec (self.loop_dev)
+        ps = BlockDev.part_get_disk_spec (self.loop_devs[0])
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev)
+        self.assertEqual(ps.path, self.loop_devs[0])
         self.assertEqual(ps.sector_size, self.block_size)
         self.assertGreaterEqual(ps.size, 100 * 1024**2 - 512)
         self.assertEqual(ps.table_type, BlockDev.PartTableType.UNDEF)
 
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
-        ps = BlockDev.part_get_disk_spec (self.loop_dev)
+        ps = BlockDev.part_get_disk_spec (self.loop_devs[0])
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev)
+        self.assertEqual(ps.path, self.loop_devs[0])
         self.assertEqual(ps.sector_size, self.block_size)
         self.assertGreaterEqual(ps.size, 100 * 1024**2 - 512)
         self.assertEqual(ps.table_type, BlockDev.PartTableType.MSDOS)
 
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
-        ps = BlockDev.part_get_disk_spec (self.loop_dev)
+        ps = BlockDev.part_get_disk_spec (self.loop_devs[0])
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev)
+        self.assertEqual(ps.path, self.loop_devs[0])
         self.assertEqual(ps.sector_size, self.block_size)
         self.assertGreaterEqual(ps.size, 100 * 1024**2 - 512)
         self.assertEqual(ps.table_type, BlockDev.PartTableType.GPT)
@@ -152,28 +155,28 @@ class PartCreatePartCase(PartTestCase):
         """Verify that it is possible to create a partition"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 16 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 16 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 16 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * self.block_size)
         self.assertEqual(ps.size, 16 * 1024**2)
         self.assertEqual(ps.id, "0x83")  # default ID "linux filesystem"
 
-        ps2 = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps2 = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.path, ps2.path)
         self.assertEqual(ps.type, ps2.type);
         self.assertEqual(ps.start, ps2.start)
         self.assertEqual(ps.size, ps2.size)
 
-        pss = BlockDev.part_get_disk_parts (self.loop_dev)
+        pss = BlockDev.part_get_disk_parts (self.loop_devs[0])
         self.assertEqual(len(pss), 1)
         ps3 = pss[0]
         self.assertEqual(ps.path, ps3.path)
@@ -185,27 +188,27 @@ class PartCreatePartCase(PartTestCase):
         """Verify that it is possible to create a partition with minimal start and optimal alignment"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 16 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 1, 16 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 1, 16 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertLessEqual(ps.start, 2048 * self.block_size)
         self.assertEqual(ps.size, 16 * 1024**2)
 
-        ps2 = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps2 = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.path, ps2.path)
         self.assertEqual(ps.type, ps2.type);
         self.assertEqual(ps.start, ps2.start)
         self.assertEqual(ps.size, ps2.size)
 
-        pss = BlockDev.part_get_disk_parts (self.loop_dev)
+        pss = BlockDev.part_get_disk_parts (self.loop_devs[0])
         self.assertEqual(len(pss), 1)
         ps3 = pss[0]
         self.assertEqual(ps.path, ps3.path)
@@ -217,27 +220,27 @@ class PartCreatePartCase(PartTestCase):
         """Verify that it is possible to create a partition with minimal start"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 2 MiB big with none alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 1, 2 * 1024**2, BlockDev.PartAlign.NONE)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 1, 2 * 1024**2, BlockDev.PartAlign.NONE)
 
         # we should get proper data back
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, self.block_size)
         self.assertEqual(ps.size, 2 * 1024**2)
 
-        ps2 = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps2 = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.path, ps2.path)
         self.assertEqual(ps.type, ps2.type);
         self.assertEqual(ps.start, ps2.start)
         self.assertEqual(ps.size, ps2.size)
 
-        pss = BlockDev.part_get_disk_parts (self.loop_dev)
+        pss = BlockDev.part_get_disk_parts (self.loop_devs[0])
         self.assertEqual(len(pss), 1)
         ps3 = pss[0]
         self.assertEqual(ps.path, ps3.path)
@@ -254,69 +257,69 @@ class PartCreatePartFullCase(PartTestCase):
     @tag_test(TestTags.CORE)
     def test_full_device_partition(self):
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # create partition spanning whole device even disregarding the partition table (loop_dev size)
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 0, 100 * 1024**2, BlockDev.PartAlign.OPTIMAL)
-        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, 0, 100 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_devs[0], ps.path)
         self.assertTrue(succ)
 
         # same, but create a maximal partition automatically
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 0, 0, BlockDev.PartAlign.OPTIMAL)
-        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, 0, 0, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_devs[0], ps.path)
         self.assertTrue(succ)
 
         # start at byte 1 and create partition spanning whole device explicitly
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 1, 100 * 1024**2, BlockDev.PartAlign.OPTIMAL)
-        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, 1, 100 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_devs[0], ps.path)
         self.assertTrue(succ)
 
         # start at byte 1 and create a maximal partition automatically
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 1, 0, BlockDev.PartAlign.OPTIMAL)
-        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, 1, 0, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_delete_part (self.loop_devs[0], ps.path)
         self.assertTrue(succ)
 
     def test_create_part_all_primary(self):
         """Verify that partition creation works as expected with all primary parts"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps2.start + ps2.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps3.start - (ps2.start + ps2.size + 1)), ps.start)
         self.assertEqual(ps3.size, 10 * 1024**2)
 
-        ps4 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps3.start + ps3.size + 1,
+        ps4 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps4)
-        self.assertEqual(ps4.path, self.loop_dev + "4")
+        self.assertEqual(ps4.path, self.loop_devs[0] + "4")
         self.assertEqual(ps4.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -325,52 +328,52 @@ class PartCreatePartFullCase(PartTestCase):
 
         # no more primary partitions allowed in the MSDOS table
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps4.start + ps4.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps4.start + ps4.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps4.start + ps4.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps4.start + ps4.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
     def test_create_part_with_extended(self):
         """Verify that partition creation works as expected with primary and extended parts"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps2.start + ps2.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps3.start - (ps2.start + ps2.size + 1)), ps.start)
         self.assertEqual(ps3.size, 10 * 1024**2)
 
-        ps4 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps3.start + ps3.size + 1,
+        ps4 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps4)
-        self.assertEqual(ps4.path, self.loop_dev + "4")
+        self.assertEqual(ps4.path, self.loop_devs[0] + "4")
         self.assertEqual(ps4.type, BlockDev.PartType.EXTENDED)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -380,10 +383,10 @@ class PartCreatePartFullCase(PartTestCase):
 
         # no more primary partitions allowed in the MSDOS table
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps4.start + ps4.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps4.start + ps4.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps4.start + ps4.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps4.start + ps4.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
     @tag_test(TestTags.CORE)
@@ -391,32 +394,32 @@ class PartCreatePartFullCase(PartTestCase):
         """Verify that partition creation works as expected with primary, extended and logical parts"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps2.start + ps2.size + 1,
                                          30 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.EXTENDED)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -425,30 +428,30 @@ class PartCreatePartFullCase(PartTestCase):
 
         # the logical partition has number 5 even though the extended partition
         # has number 3
-        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps3.start + 1,
+        ps5 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps3.start + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps5)
-        self.assertEqual(ps5.path, self.loop_dev + "5")
+        self.assertEqual(ps5.path, self.loop_devs[0] + "5")
         self.assertEqual(ps5.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p3 which
         # should need at most 2 MiB extra space
         self.assertTrue(ps3.start < ps5.start < ps3.start + ps3.size)
         self.assertLess(abs(ps5.size - 10 * 1024**2), 2 * 1024**2)
 
-        ps6 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps5.start + ps5.size + 1,
+        ps6 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps5.start + ps5.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps6)
-        self.assertEqual(ps6.path, self.loop_dev + "6")
+        self.assertEqual(ps6.path, self.loop_devs[0] + "6")
         self.assertEqual(ps6.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p3 which
         # should need at most 2 MiB extra space
         self.assertTrue(ps3.start < ps6.start < ps3.start + ps3.size)
         self.assertEqual(ps6.size, 10 * 1024**2)
 
-        ps7 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps6.start + ps6.size + 2 * 1024**2,
+        ps7 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps6.start + ps6.size + 2 * 1024**2,
                                          5 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps7)
-        self.assertEqual(ps7.path, self.loop_dev + "7")
+        self.assertEqual(ps7.path, self.loop_devs[0] + "7")
         self.assertEqual(ps7.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p3 which
         # should need at most 2 MiB extra space
@@ -457,10 +460,10 @@ class PartCreatePartFullCase(PartTestCase):
         self.assertEqual(ps7.size, 5 * 1024**2)
 
         # here we go with the partition number 4
-        ps4 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps3.start + ps3.size + 1,
+        ps4 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps4)
-        self.assertEqual(ps4.path, self.loop_dev + "4")
+        self.assertEqual(ps4.path, self.loop_devs[0] + "4")
         self.assertEqual(ps4.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -469,40 +472,40 @@ class PartCreatePartFullCase(PartTestCase):
 
         # no more primary partitions allowed in the MSDOS table
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps3.start + ps3.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps3.start + ps3.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
     def test_create_part_with_extended_logical_gpt(self):
         """Verify that partition creation works as expected with primary, extended and logical parts on GPT"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
         self.assertEqual(ps.attrs, 0)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps2.start + ps2.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -511,11 +514,11 @@ class PartCreatePartFullCase(PartTestCase):
 
         # no extended partitions allowed in the GPT table
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps3.start + ps3.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps3.start + ps3.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         # no logical partitions allowed in the GPT table
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps3.start + ps3.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
     @tag_test(TestTags.CORE)
@@ -523,32 +526,32 @@ class PartCreatePartFullCase(PartTestCase):
         """Verify that partition creation works as expected with the NEXT (auto) type"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps2.start + ps2.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -556,36 +559,36 @@ class PartCreatePartFullCase(PartTestCase):
         self.assertEqual(ps3.size, 10 * 1024**2)
 
         # we should get a logical partition which has number 5
-        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps3.start + ps3.size + 1,
+        ps5 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
-        ps4 = BlockDev.part_get_part_spec (self.loop_dev, self.loop_dev + "4")
+        ps4 = BlockDev.part_get_part_spec (self.loop_devs[0], self.loop_devs[0] + "4")
         self.assertTrue(ps4)
-        self.assertEqual(ps4.path, self.loop_dev + "4")
+        self.assertEqual(ps4.path, self.loop_devs[0] + "4")
         self.assertEqual(ps4.type, BlockDev.PartType.EXTENDED)
         self.assertLess(abs(ps4.start - (ps3.start + ps3.size + 1)), ps.start)
         self.assertGreater(ps4.size, 65 * 1024**2)
 
         self.assertTrue(ps5)
-        self.assertEqual(ps5.path, self.loop_dev + "5")
+        self.assertEqual(ps5.path, self.loop_devs[0] + "5")
         self.assertEqual(ps5.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p4 no more
         # than 2 MiB after its start
         self.assertLessEqual(ps5.start, ps4.start + 2*1024**2)
         self.assertEqual(ps5.size, 10 * 1024**2)
 
-        ps6 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps5.start + ps5.size + 1,
+        ps6 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps5.start + ps5.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps6)
-        self.assertEqual(ps6.path, self.loop_dev + "6")
+        self.assertEqual(ps6.path, self.loop_devs[0] + "6")
         self.assertEqual(ps6.type, BlockDev.PartType.LOGICAL)
         # logical partitions start 1 MiB after each other (no idea why)
         self.assertLessEqual(abs(ps6.start - (ps5.start + ps5.size + 1)), 1024**2 + 512)
         self.assertEqual(ps6.size, 10 * 1024**2)
 
-        ps7 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps6.start + ps6.size + 1,
+        ps7 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps6.start + ps6.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps7)
-        self.assertEqual(ps7.path, self.loop_dev + "7")
+        self.assertEqual(ps7.path, self.loop_devs[0] + "7")
         self.assertEqual(ps7.type, BlockDev.PartType.LOGICAL)
         # logical partitions start 1 MiB after each other (no idea why)
         self.assertLessEqual(abs(ps7.start - (ps6.start + ps6.size + 1)), 1024**2 + 512)
@@ -594,10 +597,10 @@ class PartCreatePartFullCase(PartTestCase):
         # no more primary nor extended partitions allowed in the MSDOS table and
         # there should be no space
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps4.start + ps4.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps4.start + ps4.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         with self.assertRaises(GLib.GError):
-            BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps4.start + ps4.size + 1,
+            BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps4.start + ps4.size + 1,
                                        10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
     @tag_test(TestTags.CORE)
@@ -605,32 +608,32 @@ class PartCreatePartFullCase(PartTestCase):
         """Verify that partition creation works as expected with the NEXT (auto) type on GPT"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps2.start + ps2.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -638,28 +641,28 @@ class PartCreatePartFullCase(PartTestCase):
         self.assertEqual(ps3.size, 10 * 1024**2)
 
         # we should get just next primary partition (GPT)
-        ps4 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps3.start + ps3.size + 1,
+        ps4 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps4)
-        self.assertEqual(ps4.path, self.loop_dev + "4")
+        self.assertEqual(ps4.path, self.loop_devs[0] + "4")
         self.assertEqual(ps4.type, BlockDev.PartType.NORMAL)
         self.assertLess(abs(ps4.start - (ps3.start + ps3.size + 1)), ps.start)
         self.assertEqual(ps4.size, 10 * 1024**2)
 
         # we should get just next primary partition (GPT)
-        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps4.start + ps4.size + 1,
+        ps5 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps4.start + ps4.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps5)
-        self.assertEqual(ps5.path, self.loop_dev + "5")
+        self.assertEqual(ps5.path, self.loop_devs[0] + "5")
         self.assertEqual(ps5.type, BlockDev.PartType.NORMAL)
         self.assertLess(abs(ps5.start - (ps4.start + ps4.size + 1)), ps.start)
         self.assertEqual(ps5.size, 10 * 1024**2)
 
         # we should get just next primary partition (GPT)
-        ps6 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps5.start + ps4.size + 1,
+        ps6 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NEXT, ps5.start + ps4.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps6)
-        self.assertEqual(ps6.path, self.loop_dev + "6")
+        self.assertEqual(ps6.path, self.loop_devs[0] + "6")
         self.assertEqual(ps6.type, BlockDev.PartType.NORMAL)
         self.assertLess(abs(ps6.start - (ps5.start + ps5.size + 1)), ps.start)
         self.assertEqual(ps6.size, 10 * 1024**2)
@@ -668,7 +671,7 @@ class PartGetDiskPartsCase(PartTestCase):
     def test_get_disk_parts_empty(self):
         """Verify that getting info about partitions with no label works"""
         with self.assertRaises(GLib.GError):
-            BlockDev.part_get_disk_parts (self.loop_dev)
+            BlockDev.part_get_disk_parts (self.loop_devs[0])
 
 
 def _round_up_mib(size):
@@ -683,27 +686,27 @@ class PartGetDiskFreeRegions(PartTestCase):
         """Verify that it is possible to get info about free regions on a disk"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 1, 10 * 1024**2, BlockDev.PartAlign.NONE)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 1, 10 * 1024**2, BlockDev.PartAlign.NONE)
 
         # we should get proper data back
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        fis = BlockDev.part_get_disk_free_regions (self.loop_dev)
+        fis = BlockDev.part_get_disk_free_regions (self.loop_devs[0])
         self.assertEqual(len(fis), 1)
         fi = fis[0]
         self.assertEqual(fi.start, _round_up_mib(ps.start + ps.size))
         self.assertGreaterEqual(fi.size, 89 * 1024**2)
 
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 10 * 1024**2,
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 10 * 1024**2,
                                         10 * 1024**2, BlockDev.PartAlign.NONE)
-        fis = BlockDev.part_get_disk_free_regions (self.loop_dev)
+        fis = BlockDev.part_get_disk_free_regions (self.loop_devs[0])
         self.assertEqual(len(fis), 2)  # first part, gap, second part, free
         fi = fis[0]
         self.assertEqual(fi.start, _round_up_mib(512 + 10 * 1024**2))
@@ -712,11 +715,11 @@ class PartGetDiskFreeRegions(PartTestCase):
         self.assertEqual(fi.start, _round_up_mib(512 + 30 * 1024**2))
         self.assertGreaterEqual(fi.size, 69 * 1024**2)
 
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps.start + ps.size + 1,
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps.start + ps.size + 1,
                                         50 * 1024**2, BlockDev.PartAlign.NONE)
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps.start + 1024**2,
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps.start + 1024**2,
                                         10 * 1024**2, BlockDev.PartAlign.NONE)
-        fis = BlockDev.part_get_disk_free_regions (self.loop_dev)
+        fis = BlockDev.part_get_disk_free_regions (self.loop_devs[0])
         self.assertEqual(len(fis), 3)  # first part, gap[0], second part, extended, logical, free extended[1], free[2]
 
         fi = fis[0]
@@ -730,19 +733,19 @@ class PartGetDiskFreeRegions(PartTestCase):
         self.assertGreaterEqual(fi.size, 19 * 1024**2)
 
         # now something simple with GPT
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 1, 10 * 1024**2, BlockDev.PartAlign.NONE)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 1, 10 * 1024**2, BlockDev.PartAlign.NONE)
 
         # we should get proper data back
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        fis = BlockDev.part_get_disk_free_regions (self.loop_dev)
+        fis = BlockDev.part_get_disk_free_regions (self.loop_devs[0])
         self.assertEqual(len(fis), 1)
         fi = fis[0]
         self.assertEqual(fi.start, _round_up_mib(ps.start + ps.size))
@@ -753,72 +756,72 @@ class PartGetBestFreeRegion(PartTestCase):
         """Verify that it is possible to get info about the best free region on a disk"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
-        ps1 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 1, 10 * 1024**2, BlockDev.PartAlign.NONE)
+        ps1 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 1, 10 * 1024**2, BlockDev.PartAlign.NONE)
         self.assertTrue(ps1)
-        self.assertEqual(ps1.path, self.loop_dev + "1")
+        self.assertEqual(ps1.path, self.loop_devs[0] + "1")
         self.assertEqual(ps1.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps1.start, 512)
         self.assertEqual(ps1.size, 10 * 1024**2)
 
         # create a 20MiB gap between the partitions
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps1.start + ps1.size + 20 * 1024**2,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps1.start + ps1.size + 20 * 1024**2,
                                          10 * 1024**2, BlockDev.PartAlign.NONE)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps2.start, ps1.start + ps1.size + 20 * 1024**2)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
         # normal partition should go in between the partitions because there's enough space for it
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.NORMAL, 10 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.NORMAL, 10 * 1024**2)
         self.assertLess(ps.start, ps2.start)
 
         # extended partition should be as big as possible so it shouldn't go in between the partitions
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.EXTENDED, 10 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.EXTENDED, 10 * 1024**2)
         self.assertGreaterEqual(ps.start, ps2.start + ps2.size)
 
         # create a 10MiB gap between the partitions
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps2.start + ps2.size + 10 * 1024**2,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps2.start + ps2.size + 10 * 1024**2,
                                          45 * 1024**2, BlockDev.PartAlign.NONE)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.EXTENDED)
         self.assertEqual(ps3.start, ps2.start + ps2.size + 10 * 1024**2)
         self.assertEqual(ps3.size, 45 * 1024**2)
 
         # there should now be 5 MiB left after the third partition which is enough for a 3MiB partition
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.NORMAL, 3 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.NORMAL, 3 * 1024**2)
         self.assertGreaterEqual(ps.start, ps3.start + ps3.size)
 
         # 7MiB partition should go in between the second and third partitions because there's enough space
         # for it there
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.NORMAL, 7 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.NORMAL, 7 * 1024**2)
         self.assertGreaterEqual(ps.start, ps2.start + ps2.size)
         self.assertLess(ps.start, ps3.start)
 
         # 15MiB partition should go in between the first and second partitions because that's the only
         # space big enough for it
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.NORMAL, 15 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.NORMAL, 15 * 1024**2)
         self.assertGreaterEqual(ps.start, ps1.start + ps1.size)
         self.assertLess(ps.start, ps2.start)
 
-        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps3.start + 20 * 1024**2,
+        ps5 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps3.start + 20 * 1024**2,
                                          15 * 1024**2, BlockDev.PartAlign.NONE)
-        self.assertEqual(ps5.path, self.loop_dev + "5")
+        self.assertEqual(ps5.path, self.loop_devs[0] + "5")
         self.assertEqual(ps5.type, BlockDev.PartType.LOGICAL)
         self.assertEqual(ps5.start, ps3.start + 20 * 1024**2)
         self.assertEqual(ps5.size, 15 * 1024**2)
 
         # 5MiB logical partition should go after the fifth partition because there's enough space for it
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.LOGICAL, 5 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.LOGICAL, 5 * 1024**2)
         self.assertGreaterEqual(ps.start, ps5.start + ps5.size)
         self.assertLess(ps.start, ps3.start + ps3.size)
 
         # 15MiB logical partition should go before the fifth partition because there's enough space for it
-        ps = BlockDev.part_get_best_free_region (self.loop_dev, BlockDev.PartType.LOGICAL, 15 * 1024**2)
+        ps = BlockDev.part_get_best_free_region (self.loop_devs[0], BlockDev.PartType.LOGICAL, 15 * 1024**2)
         self.assertGreaterEqual(ps.start, ps3.start)
         self.assertLess(ps.start, ps5.start)
 
@@ -829,32 +832,32 @@ class PartGetPartByPos(PartTestCase):
         ## prepare the disk with non-trivial setup first
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps)
-        self.assertEqual(ps.path, self.loop_dev + "1")
+        self.assertEqual(ps.path, self.loop_devs[0] + "1")
         self.assertEqual(ps.type, BlockDev.PartType.NORMAL)
         self.assertEqual(ps.start, 2048 * 512)
         self.assertEqual(ps.size, 10 * 1024**2)
 
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps.start + ps.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps2)
-        self.assertEqual(ps2.path, self.loop_dev + "2")
+        self.assertEqual(ps2.path, self.loop_devs[0] + "2")
         self.assertEqual(ps2.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
         self.assertLess(abs(ps2.start - (ps.start + ps.size + 1)), ps.start)
         self.assertEqual(ps2.size, 10 * 1024**2)
 
-        ps3 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.EXTENDED, ps2.start + ps2.size + 1,
+        ps3 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.EXTENDED, ps2.start + ps2.size + 1,
                                          35 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps3)
-        self.assertEqual(ps3.path, self.loop_dev + "3")
+        self.assertEqual(ps3.path, self.loop_devs[0] + "3")
         self.assertEqual(ps3.type, BlockDev.PartType.EXTENDED)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -863,30 +866,30 @@ class PartGetPartByPos(PartTestCase):
 
         # the logical partition has number 5 even though the extended partition
         # has number 3
-        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps3.start + 1,
+        ps5 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps3.start + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps5)
-        self.assertEqual(ps5.path, self.loop_dev + "5")
+        self.assertEqual(ps5.path, self.loop_devs[0] + "5")
         self.assertEqual(ps5.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p3 which
         # should need at most 2 MiB extra space
         self.assertTrue(ps3.start < ps5.start < ps3.start + ps3.size)
         self.assertLess(abs(ps5.size - 10 * 1024**2), 2 * 1024**2)
 
-        ps6 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps5.start + ps5.size + 1,
+        ps6 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps5.start + ps5.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps6)
-        self.assertEqual(ps6.path, self.loop_dev + "6")
+        self.assertEqual(ps6.path, self.loop_devs[0] + "6")
         self.assertEqual(ps6.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p3 which
         # should need at most 2 MiB extra space
         self.assertTrue(ps3.start < ps6.start < ps3.start + ps3.size)
         self.assertEqual(ps6.size, 10 * 1024**2)
 
-        ps7 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.LOGICAL, ps6.start + ps6.size + 2 * 1024**2,
+        ps7 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.LOGICAL, ps6.start + ps6.size + 2 * 1024**2,
                                          5 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps7)
-        self.assertEqual(ps7.path, self.loop_dev + "7")
+        self.assertEqual(ps7.path, self.loop_devs[0] + "7")
         self.assertEqual(ps7.type, BlockDev.PartType.LOGICAL)
         # the start has to be somewhere in the extended partition p3 which
         # should need at most 2 MiB extra space
@@ -895,10 +898,10 @@ class PartGetPartByPos(PartTestCase):
         self.assertEqual(ps7.size, 5 * 1024**2)
 
         # here we go with the partition number 4
-        ps4 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps3.start + ps3.size + 1,
+        ps4 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(ps4)
-        self.assertEqual(ps4.path, self.loop_dev + "4")
+        self.assertEqual(ps4.path, self.loop_devs[0] + "4")
         self.assertEqual(ps4.type, BlockDev.PartType.NORMAL)
         # the start has to be at most as far from the end of the previous part
         # as is the start of the first part from the start of the disk
@@ -909,7 +912,7 @@ class PartGetPartByPos(PartTestCase):
         ## now try to get the partitions
         # XXX: Any way to get the extended partition (ps3)? Let's just skip it now.
         for part in (ps, ps2, ps5, ps6, ps7, ps4):
-            ret = BlockDev.part_get_part_by_pos(self.loop_dev, part.start + 1 * 1024**2)
+            ret = BlockDev.part_get_part_by_pos(self.loop_devs[0], part.start + 1 * 1024**2)
             self.assertIsNotNone(ret)
             self.assertEqual(ret.path, part.path)
             self.assertEqual(ret.start, part.start)
@@ -917,7 +920,7 @@ class PartGetPartByPos(PartTestCase):
             self.assertEqual(ret.type, part.type)
 
         # free space in the extended partition
-        ret = BlockDev.part_get_part_by_pos(self.loop_dev, ps3.start + 33 * 1024**2)
+        ret = BlockDev.part_get_part_by_pos(self.loop_devs[0], ps3.start + 33 * 1024**2)
         self.assertIsNotNone(ret)
         self.assertIsNone(ret.path)
         self.assertTrue(ret.type & BlockDev.PartType.FREESPACE)
@@ -928,7 +931,7 @@ class PartGetPartByPos(PartTestCase):
         self.assertLess(ret.size, 10 * 1024**2)
 
         # free space at the end of the disk
-        ret = BlockDev.part_get_part_by_pos(self.loop_dev, 90 * 1024**2)
+        ret = BlockDev.part_get_part_by_pos(self.loop_devs[0], 90 * 1024**2)
         self.assertIsNotNone(ret)
         self.assertIsNone(ret.path)
         self.assertTrue(ret.type & BlockDev.PartType.FREESPACE)
@@ -936,7 +939,7 @@ class PartGetPartByPos(PartTestCase):
         self.assertLessEqual(ret.size, (100 * 1024**2) - (ps4.start + ps4.size))
 
         # metadata at the start of the extended partition
-        ret = BlockDev.part_get_part_by_pos(self.loop_dev, ps3.start)
+        ret = BlockDev.part_get_part_by_pos(self.loop_devs[0], ps3.start)
         self.assertIsNotNone(ret)
         self.assertIsNone(ret.path)
         self.assertTrue(ret.type & BlockDev.PartType.LOGICAL)
@@ -946,7 +949,7 @@ class PartGetPartByPos(PartTestCase):
 
         # metadata after a logical partition
         for ps in (ps5, ps6, ps7):
-            ret = BlockDev.part_get_part_by_pos(self.loop_dev, ps.start + ps.size)
+            ret = BlockDev.part_get_part_by_pos(self.loop_devs[0], ps.start + ps.size)
             self.assertIsNotNone(ret)
             self.assertIsNone(ret.path)
             self.assertTrue(ret.type & BlockDev.PartType.LOGICAL)
@@ -959,42 +962,42 @@ class PartCreateResizePartCase(PartTestCase):
         """Verify that it is possible to create and resize two partitions"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         ps1_half = 20 * 1024**2
         ps1_start = 2 * 1024**2
 
         # create a maximal second partition
-        ps2 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2* ps1_half, 0, BlockDev.PartAlign.NONE)
+        ps2 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2* ps1_half, 0, BlockDev.PartAlign.NONE)
         self.assertGreaterEqual(ps2.start, 2* ps1_half)
 
         # create one maximal partition in the beginning
-        ps1 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, ps1_start, 0, BlockDev.PartAlign.NONE)
+        ps1 = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, ps1_start, 0, BlockDev.PartAlign.NONE)
         self.assertGreaterEqual(ps1.size, ps1_half)
         self.assertGreaterEqual(ps1.start, ps1_start)
         self.assertLess(ps1.size, ps1_half * 2)  # can't have full size from beginning to ps2 because of start offset
 
         # resizing should give the same result
         ps1_size = ps1.size
-        succ = BlockDev.part_resize_part (self.loop_dev, ps1.path, 0, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps1.path, 0, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps1 = BlockDev.part_get_part_spec(self.loop_dev, ps1.path)
+        ps1 = BlockDev.part_get_part_spec(self.loop_devs[0], ps1.path)
         self.assertEqual(ps1.start, ps1_start)  # offset must not be moved
         self.assertEqual(ps1.size, ps1_size)
 
-        succ = BlockDev.part_resize_part (self.loop_dev, ps1.path, ps1_half, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps1.path, ps1_half, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(succ)
-        ps1 = BlockDev.part_get_part_spec(self.loop_dev, ps1.path)
+        ps1 = BlockDev.part_get_part_spec(self.loop_devs[0], ps1.path)
         self.assertEqual(ps1.start, ps1_start)  # offset must not be moved
         self.assertGreaterEqual(ps1.size, ps1_half)  # at least requested size
         self.assertLess(ps1.size, ps1_half + 2048 * self.block_size)  # but also not too big (assuming end alignment based on sector size)
 
         ps2_size = ps2.size
         ps2_start = ps2.start
-        succ = BlockDev.part_resize_part (self.loop_dev, ps2.path, 0, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps2.path, 0, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(succ)
-        ps2 = BlockDev.part_get_part_spec(self.loop_dev, ps2.path)
+        ps2 = BlockDev.part_get_part_spec(self.loop_devs[0], ps2.path)
         self.assertEqual(ps2.start, ps2_start)  # offset must not be moved
         self.assertGreaterEqual(ps2.size, ps2_size - 2 * 1024**2)  # almost as big as before
 
@@ -1017,57 +1020,57 @@ class PartCreateResizePartCase(PartTestCase):
             resize_tolerance = 0
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # create a maximal partition
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2 * 1024**2, 0, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2 * 1024**2, 0, BlockDev.PartAlign.OPTIMAL)
         initial_start = ps.start
         initial_size = ps.size
 
         new_size = 20 * 1000**2  # resize to MB (not MiB) for a non-multiple of the blocksize
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, new_size, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, new_size, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)  # offset must not be moved
         self.assertGreaterEqual(ps.size, new_size)  # at least the requested size
         self.assertLess(ps.size, new_size + 2048 * self.block_size)  # but also not too big (assuming end alignment based on sector size)
 
         # resize to maximum
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, 0, BlockDev.PartAlign.OPTIMAL)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, 0, BlockDev.PartAlign.OPTIMAL)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)
         self.assertEqual(initial_size, ps.size)  # should grow to the same size again
 
         # resize to maximum explicitly with no alignment (we know exact size)
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, initial_size, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, initial_size, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)
         self.assertGreaterEqual(ps.size, initial_size) # at least the requested size
 
         # resize back to 20 MB (not MiB) with no alignment
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, new_size, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, new_size, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)  # offset must not be moved
         self.assertGreaterEqual(ps.size, new_size)  # at least the requested size
         self.assertLess(ps.size, new_size + 4 * 1024)  # but also not too big (assuming max. 4 KiB blocks)
 
         # resize to maximum with no alignment
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, 0, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, 0, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)
         self.assertGreaterEqual(ps.size, initial_size - resize_tolerance)
         new_size = ps.size
         unaligned_max = new_size
 
         # resize to maximum with no alignment explicitly
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, new_size, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, new_size, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)
         self.assertGreaterEqual(ps.size, new_size) # at least the requested size
 
@@ -1076,28 +1079,28 @@ class PartCreateResizePartCase(PartTestCase):
             return
 
         # resize to previous maximum with no alignment explicitly
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, initial_size, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, initial_size, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)
         self.assertGreaterEqual(ps.size, initial_size - resize_tolerance)
 
         # resize back to 20 MB (not MiB) with no alignment
         new_size = 20 * 1000**2
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, new_size, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, new_size, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)  # offset must not be moved
         self.assertGreaterEqual(ps.size, new_size)  # at least the requested size
         self.assertLess(ps.size, new_size + 4 * 1024)  # but also not too big (assuming max. 4 KiB blocks)
 
         # resize should allow up to 4 MiB over unaligned max size
         with self.assertRaisesRegex(GLib.GError, "is bigger than max size"):
-            BlockDev.part_resize_part (self.loop_dev, ps.path, unaligned_max + 4 * 1024**2 + 1, BlockDev.PartAlign.NONE)
+            BlockDev.part_resize_part (self.loop_devs[0], ps.path, unaligned_max + 4 * 1024**2 + 1, BlockDev.PartAlign.NONE)
 
-        succ = BlockDev.part_resize_part (self.loop_dev, ps.path, unaligned_max + 4 * 1024**2, BlockDev.PartAlign.NONE)
+        succ = BlockDev.part_resize_part (self.loop_devs[0], ps.path, unaligned_max + 4 * 1024**2, BlockDev.PartAlign.NONE)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec(self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec(self.loop_devs[0], ps.path)
         self.assertEqual(initial_start, ps.start)
         self.assertGreaterEqual(ps.size, unaligned_max) # at least the requested size
 
@@ -1112,18 +1115,18 @@ class PartCreateDeletePartCase(PartTestCase):
         """Verify that it is possible to create and delete a partition"""
 
         # we first need a partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
-        pss = BlockDev.part_get_disk_parts (self.loop_dev)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        pss = BlockDev.part_get_disk_parts (self.loop_devs[0])
         self.assertEqual(len(pss), 1)
 
-        succ = BlockDev.part_delete_part (self.loop_dev, ps.path)
+        succ = BlockDev.part_delete_part (self.loop_devs[0], ps.path)
         self.assertTrue(succ)
-        pss = BlockDev.part_get_disk_parts (self.loop_dev)
+        pss = BlockDev.part_get_disk_parts (self.loop_devs[0])
         self.assertEqual(len(pss), 0)
 
 
@@ -1132,41 +1135,41 @@ class PartSetNameCase(PartTestCase):
         """Verify that it is possible to set partition name"""
 
         # we first need a GPT partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
         self.assertIn(ps.name, ("", None))  # no name
 
-        succ = BlockDev.part_set_part_name (self.loop_dev, ps.path, "TEST")
+        succ = BlockDev.part_set_part_name (self.loop_devs[0], ps.path, "TEST")
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.name, "TEST")
 
-        succ = BlockDev.part_set_part_name (self.loop_dev, ps.path, "")
+        succ = BlockDev.part_set_part_name (self.loop_devs[0], ps.path, "")
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.name, "")
 
         # let's now test an MSDOS partition table (doesn't support names)
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
         self.assertIn(ps.name, ("", None))  # no name
 
         with self.assertRaises(GLib.GError):
-            BlockDev.part_set_part_name (self.loop_dev, ps.path, "")
+            BlockDev.part_set_part_name (self.loop_devs[0], ps.path, "")
 
         # we should still get proper data back though
         self.assertTrue(ps)
@@ -1181,32 +1184,32 @@ class PartSetUUIDCase(PartTestCase):
         """Verify that it is possible to set partition UUID"""
 
         # we first need a GPT partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
-        succ = BlockDev.part_set_part_uuid (self.loop_dev, ps.path, self.test_uuid)
+        succ = BlockDev.part_set_part_uuid (self.loop_devs[0], ps.path, self.test_uuid)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.uuid, self.test_uuid)
 
         # let's now test an MSDOS partition table (doesn't support UUIDs)
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should still get proper data back
         self.assertTrue(ps)
         self.assertIn(ps.uuid, ("", None))  # no name
 
         with self.assertRaises(GLib.GError):
-            BlockDev.part_set_part_name (self.loop_dev, ps.path, self.test_uuid)
+            BlockDev.part_set_part_name (self.loop_devs[0], ps.path, self.test_uuid)
 
 
 class PartSetTypeCase(PartTestCase):
@@ -1214,43 +1217,43 @@ class PartSetTypeCase(PartTestCase):
         """Verify that it is possible to set and get partition type"""
 
         # we first need a GPT partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
         self.assertTrue(ps.type_guid)  # should have some type
 
-        succ = BlockDev.part_set_part_type (self.loop_dev, ps.path, "E6D6D379-F507-44C2-A23C-238F2A3DF928")
+        succ = BlockDev.part_set_part_type (self.loop_devs[0], ps.path, "E6D6D379-F507-44C2-A23C-238F2A3DF928")
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.type_guid, "E6D6D379-F507-44C2-A23C-238F2A3DF928")
         self.assertEqual(ps.type_name, "Linux LVM")
 
-        succ = BlockDev.part_set_part_type (self.loop_dev, ps.path, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
+        succ = BlockDev.part_set_part_type (self.loop_devs[0], ps.path, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.type_guid, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
         self.assertEqual(ps.type_name, "Linux filesystem")
 
         # let's now test an MSDOS partition table (doesn't support type GUIDs)
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
         self.assertIn(ps.type_guid, ("", None))  # no type GUID
 
         with self.assertRaises(GLib.GError):
-            BlockDev.part_set_part_type (self.loop_dev, ps.path, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
+            BlockDev.part_set_part_type (self.loop_devs[0], ps.path, "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
 
         # we should still get proper data back though
         self.assertTrue(ps)
@@ -1261,25 +1264,25 @@ class PartSetIdCase(PartTestCase):
         """Verify that it is possible to set partition id (msdos partition type)"""
 
         # we first need an MBR partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # we should get proper data back
         self.assertTrue(ps)
 
-        succ = BlockDev.part_set_part_id (self.loop_dev, ps.path, "0x8e")
+        succ = BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "0x8e")
         self.assertTrue(succ)
 
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.id, "0x8e")
 
         # we can't change part id to extended partition id
         with self.assertRaises(GLib.GError):
-            BlockDev.part_set_part_id (self.loop_dev, ps.path, "0x85")
+            BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "0x85")
 
 
 class PartSetBootableFlagCase(PartTestCase):
@@ -1287,23 +1290,23 @@ class PartSetBootableFlagCase(PartTestCase):
         """Verify that it is possible to set bootable flag on MSDOS"""
 
         # we first need a MBR partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.MSDOS, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.MSDOS, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # set the flag
-        succ = BlockDev.part_set_part_bootable (self.loop_dev, ps.path, True)
+        succ = BlockDev.part_set_part_bootable (self.loop_devs[0], ps.path, True)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertTrue(ps.bootable)
 
         # unset the flag
-        succ = BlockDev.part_set_part_bootable (self.loop_dev, ps.path, False)
+        succ = BlockDev.part_set_part_bootable (self.loop_devs[0], ps.path, False)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertFalse(ps.bootable)
 
 
@@ -1314,17 +1317,17 @@ class PartSetGptFlagsCase(PartTestCase):
         esp_guid = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
 
         # we first need a GPT partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # set GUID (part type)
-        succ = BlockDev.part_set_part_type (self.loop_dev, ps.path, esp_guid)
+        succ = BlockDev.part_set_part_type (self.loop_devs[0], ps.path, esp_guid)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.type_guid, esp_guid)
         self.assertEqual(ps.type_name, "EFI System")
 
@@ -1334,21 +1337,21 @@ class PartSetGptAttrsCase(PartTestCase):
         """Verify that it is possible to set and get partition attributes"""
 
         # we first need a GPT partition table
-        succ = BlockDev.part_create_table (self.loop_dev, BlockDev.PartTableType.GPT, True)
+        succ = BlockDev.part_create_table (self.loop_devs[0], BlockDev.PartTableType.GPT, True)
         self.assertTrue(succ)
 
         # for now, let's just create a typical primary partition starting at the
         # sector 2048, 10 MiB big with optimal alignment
-        ps = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
+        ps = BlockDev.part_create_part (self.loop_devs[0], BlockDev.PartTypeReq.NORMAL, 2048*512, 10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
 
         # set some GPT attributes
         attrs = 0
         attrs |= (1 << 0)  # system partition
         attrs |= (1 << 60)  # read only
         attrs |= (1 << 62)  # hidden
-        succ = BlockDev.part_set_part_attributes (self.loop_dev, ps.path, attrs)
+        succ = BlockDev.part_set_part_attributes (self.loop_devs[0], ps.path, attrs)
         self.assertTrue(succ)
-        ps = BlockDev.part_get_part_spec (self.loop_dev, ps.path)
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.attrs, attrs)
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -194,7 +194,7 @@ def parse_args():
 def _split_test_id(test_id):
     # test.id() looks like 'crypto_test.CryptoTestResize.test_luks2_resize'
     # and we want to print 'test_luks2_resize (crypto_test.CryptoTestResize)'
-    test_desc = test.id().split(".")
+    test_desc = test_id.split(".")
     test_name = test_desc[-1]
     test_module = ".".join(test_desc[:-1])
 

--- a/tests/s390_test.py
+++ b/tests/s390_test.py
@@ -25,7 +25,7 @@ class S390TestCase(unittest.TestCase):
 
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.S390), "libbd_s390.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.S390), "libbd_s390.so.3")
 
     @tag_test(TestTags.EXTRADEPS, TestTags.NOSTORAGE)
     def test_device_input(self):

--- a/tests/smart_test.py
+++ b/tests/smart_test.py
@@ -1,12 +1,10 @@
 import unittest
 import os
-import re
 import glob
 import time
-import shutil
 import overrides_hack
 
-from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, write_file, run_command, required_plugins
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, TestTags, tag_test, write_file, run_command, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -86,7 +84,7 @@ class SMARTTest(unittest.TestCase):
 
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.SMART), "libbd_smart.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.SMART), "libbd_smart.so.3")
 
     @tag_test(TestTags.CORE)
     def test_ata_info(self):

--- a/tests/smartmontools_test.py
+++ b/tests/smartmontools_test.py
@@ -1,12 +1,11 @@
 import unittest
 import os
-import re
 import glob
 import time
 import shutil
 import overrides_hack
 
-from utils import run, create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path, TestTags, tag_test, write_file, run_command, required_plugins
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, TestTags, tag_test, write_file, run_command, required_plugins
 
 import gi
 gi.require_version('GLib', '2.0')
@@ -85,7 +84,7 @@ class SmartmontoolsTest(unittest.TestCase):
 
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.SMART), "libbd_smartmontools.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.SMART), "libbd_smartmontools.so.3")
 
     @tag_test(TestTags.CORE)
     def test_ata_info(self):

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -26,7 +26,7 @@ class SwapTest(unittest.TestCase):
 class SwapPluginVersionTestCase(SwapTest):
     @tag_test(TestTags.NOSTORAGE)
     def test_plugin_version(self):
-       self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.SWAP), "libbd_swap.so.3")
+        self.assertEqual(BlockDev.get_plugin_soname(BlockDev.Plugin.SWAP), "libbd_swap.so.3")
 
 class SwapTestCase(SwapTest):
     test_uuid = "4d7086c4-a4d3-432f-819e-73da03870df9"

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -115,21 +115,14 @@ class SwapTestCase(SwapTest):
         on = BlockDev.swap_swapstatus(self.loop_dev)
         self.assertFalse(on)
 
-    def test_mkswap_with_label(self):
+    def test_mkswap_with_label_uuid(self):
         """Verify that mkswap with label works as expected"""
 
-        succ = BlockDev.swap_mkswap(self.loop_dev, "BlockDevSwap", None)
+        succ = BlockDev.swap_mkswap(self.loop_dev, label="BlockDevSwap", uuid=self.test_uuid)
         self.assertTrue(succ)
 
         _ret, out, _err = run_command("blkid -ovalue -sLABEL -p %s" % self.loop_dev)
         self.assertEqual(out, "BlockDevSwap")
-
-    def test_mkswap_with_uuid(self):
-        """Verify that mkswap with uuid works as expected"""
-
-        succ = BlockDev.swap_mkswap(self.loop_dev, uuid=self.test_uuid)
-        self.assertTrue(succ)
-
         _ret, out, _err = run_command("blkid -ovalue -sUUID -p %s" % self.loop_dev)
         self.assertEqual(out, self.test_uuid)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -81,7 +81,7 @@ def fake_utils(path="."):
 ALL_UTILS = {"lvm", "btrfs", "mkswap", "swaplabel", "multipath", "mpathconf", "dmsetup", "mdadm",
              "mkfs.exfat", "fsck.exfat", "tune.exfat",
              "mke2fs", "e2fsck", "tune2fs", "dumpe2fs", "resize2fs",
-             "mkfs.f2fs", "fsck.f2fs", "fsck.f2fs", "dump.f2fs", "resize.f2fs",
+             "mkfs.f2fs", "fsck.f2fs", "dump.f2fs", "resize.f2fs",
              "mkfs.nilfs2", "nilfs-tune", "nilfs-resize",
              "mkntfs", "ntfsfix", "ntfsresize", "ntfslabel", "ntfsinfo",
              "mkfs.vfat", "fatlabel", "fsck.vfat", "vfat-resize",


### PR DESCRIPTION
The biggest change is using some extra pbkdf parameters when creating LUKS format to speedup the crypto tests and for other tests making sure we don't create more disks than needed.

On my machine on master the entire test suite currently takes about 2000 seconds, with these changes it's around 1400 seconds so 10 minutes less.