### PR TITLE
lvm-dbus: Fix calling lvcreate with empty list of PVs

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1992,7 +1992,7 @@ gboolean bd_lvm_lvcreate (const gchar *vg_name, const gchar *lv_name, guint64 si
     GVariant *extra_params = NULL;
 
     /* build the array of PVs (object paths) */
-    if (pv_list) {
+    if (pv_list && *pv_list) {
         g_variant_builder_init (&builder, G_VARIANT_TYPE_ARRAY);
         for (pv=pv_list; *pv; pv++) {
             path = get_object_path (*pv, error);

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -675,6 +675,13 @@ class LvmTestLVcreateRemove(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvremove("testVG", "testLV", True, None)
         self.assertTrue(succ)
 
+        # no PVs specified
+        succ = BlockDev.lvm_lvcreate("testVG", "testLV", 512 * 1024**2, None, [], None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_lvremove("testVG", "testLV", True, None)
+        self.assertTrue(succ)
+
         # not enough space (only one PV)
         with six.assertRaisesRegex(self, GLib.GError, "Insufficient free space"):
             succ = BlockDev.lvm_lvcreate("testVG", "testLV", 1048 * 1024**2, None, [self.loop_dev], None)


### PR DESCRIPTION
GLib really dislikes us calling 'g_variant_builder_end' on the empty array in this case.

Backport of #1125