### PR TITLE
Preserve XFS quota options in temporary mounts 

### DIFF
--- a/src/plugins/fs/mount.c
+++ b/src/plugins/fs/mount.c
@@ -29,6 +29,8 @@
 #include <errno.h>
 #include <string.h>
 
+#include <blockdev/utils.h>
+
 #include "fs.h"
 #include "mount.h"
 
@@ -172,6 +174,8 @@ static gboolean do_unmount (MountArgs *args, GError **error) {
             return FALSE;
         }
     }
+
+    bd_utils_log_format (BD_UTILS_LOG_INFO, "Unmounting %s", args->spec);
 
     ret = mnt_context_umount (cxt);
 #ifdef LIBMOUNT_NEW_ERR_API
@@ -423,6 +427,12 @@ static gboolean do_mount (MountArgs *args, GError **error) {
     if (args->options && (mnt_optstr_get_option (args->options, "rw", NULL, NULL) == 0))
         mnt_context_enable_rwonly_mount (cxt, TRUE);
 #endif
+
+    bd_utils_log_format (BD_UTILS_LOG_INFO, "Mounting %s (fstype %s) to %s with options: %s",
+                         args->device ? args->device : "unspecified device",
+                         args->fstype ? args->fstype : "auto",
+                         args->mountpoint ? args->mountpoint : "unspecified mountpoint",
+                         args->options ? args->options : "none");
 
     ret = mnt_context_mount (cxt);
 

--- a/tests/fs_tests/fs_test.py
+++ b/tests/fs_tests/fs_test.py
@@ -13,8 +13,8 @@ from gi.repository import BlockDev
 
 
 @contextmanager
-def mounted(device, where, ro=False):
-    utils.mount(device, where, ro)
+def mounted(device, where, ro=False, options=None):
+    utils.mount(device, where, ro, options)
 
     try:
         yield

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -277,12 +277,12 @@ def clean_scsi_debug(scsi_debug_dev):
 def _wait_for_nvme_controllers_ready(subnqn, timeout=3):
     """
     Wait for NVMe controllers with matching subsystem NQN to be in live state
-    
+
     :param str subnqn: subsystem nqn to match controllers against
     :param int timeout: timeout in seconds (default: 3)
     """
     start_time = time.time()
-    
+
     while time.time() - start_time < timeout:
         try:
             for ctrl_path in glob.glob("/sys/class/nvme/nvme*/"):
@@ -297,12 +297,12 @@ def _wait_for_nvme_controllers_ready(subnqn, timeout=3):
                         return
                 except:
                     continue
-                
+
         except:
             pass
-        
+
         time.sleep(1)
-    
+
     os.system("udevadm settle")
 
 def find_nvme_ctrl_devs_for_subnqn(subnqn, wait_for_ready=True):
@@ -756,11 +756,18 @@ def run(cmd_string):
     return subprocess.call(cmd_string, close_fds=True, shell=True)
 
 
-def mount(device, where, ro=False):
+def mount(device, where, ro=False, options=None):
     if not os.path.isdir(where):
         os.makedirs(where)
+
     if ro:
-        os.system("mount -oro %s %s" % (device, where))
+        if options:
+            options += ",ro"
+        else:
+            options = "ro"
+
+    if options:
+        os.system("mount -o %s %s %s" % (options, device, where))
     else:
         os.system("mount %s %s" % (device, where))
 


### PR DESCRIPTION
Originally reported against LVM and their fsresize helper script: https://github.com/lvmteam/lvm2/issues/182