### PR TITLE
crypto: Add a function to check for label and subsystem validity

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -92,6 +92,7 @@ bd_crypto_luks_kill_slot
 bd_crypto_luks_header_backup
 bd_crypto_luks_header_restore
 bd_crypto_luks_set_label
+bd_crypto_luks_check_label
 bd_crypto_luks_set_uuid
 bd_crypto_luks_convert
 BDCryptoLUKSPersistentFlags

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -1095,6 +1095,19 @@ gboolean bd_crypto_luks_header_restore (const gchar *device, const gchar *backup
 gboolean bd_crypto_luks_set_label (const gchar *device, const gchar *label, const gchar *subsystem, GError **error);
 
 /**
+ * bd_crypto_luks_check_label:
+ * @label: (nullable): label to check
+ * @subsystem: (nullable): subsystem to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label and @subsystem are valid for LUKS2 or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_crypto_luks_check_label (const gchar *label, const gchar *subsystem, GError **error);
+
+/**
  * bd_crypto_luks_set_uuid:
  * @device: device to set UUID on
  * @uuid: (nullable): UUID to set or %NULL to generate a new one

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -2160,6 +2160,33 @@ gboolean bd_crypto_luks_header_restore (const gchar *device, const gchar *backup
 }
 
 /**
+ * bd_crypto_luks_check_label:
+ * @label: (nullable): label to check
+ * @subsystem: (nullable): subsystem to check
+ * @error: (out) (optional): place to store error
+ *
+ * Returns: whether @label and @subsystem are valid for LUKS2 or not
+ *          (reason is provided in @error)
+ *
+ * Tech category: always available
+ */
+gboolean bd_crypto_luks_check_label (const gchar *label, const gchar *subsystem, GError **error) {
+    if (label && strlen (label) > 47) {
+        g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_INVALID_PARAMS,
+                     "Label for LUKS must be at most 47 characters long");
+        return FALSE;
+    }
+
+    if (subsystem && strlen (subsystem) > 47) {
+        g_set_error (error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_INVALID_PARAMS,
+                     "Subsystem for LUKS must be at most 47 characters long");
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
  * bd_crypto_luks_set_label:
  * @device: device to set label on
  * @label: (nullable): label to set

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -301,6 +301,7 @@ gboolean bd_crypto_luks_kill_slot (const gchar *device, gint slot, GError **erro
 gboolean bd_crypto_luks_header_backup (const gchar *device, const gchar *backup_file, GError **error);
 gboolean bd_crypto_luks_header_restore (const gchar *device, const gchar *backup_file, GError **error);
 gboolean bd_crypto_luks_set_label (const gchar *device, const gchar *label, const gchar *subsystem, GError **error);
+gboolean bd_crypto_luks_check_label (const gchar *label, const gchar *subsystem, GError **error);
 gboolean bd_crypto_luks_set_uuid (const gchar *device, const gchar *uuid, GError **error);
 gboolean bd_crypto_luks_convert (const gchar *device, BDCryptoLUKSVersion target_version, GError **error);
 gboolean bd_crypto_luks_set_persistent_flags (const gchar *device, BDCryptoLUKSPersistentFlags flags, GError **error);

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -1084,6 +1084,14 @@ class CryptoTestSetLabelUuid(CryptoTestCase):
     test_uuid = "4d7086c4-a4d3-432f-819e-73da03870df9"
 
     def _test_set_label(self):
+        succ = BlockDev.crypto_luks_check_label(self.label, self.subsystem)
+        self.assertTrue(succ)
+
+        with self.assertRaisesRegex(GLib.GError, "Label for LUKS must be at most 47 characters long"):
+            BlockDev.crypto_luks_check_label(label="a" * 48)
+        with self.assertRaisesRegex(GLib.GError, "Subsystem for LUKS must be at most 47 characters long"):
+            BlockDev.crypto_luks_check_label(subsystem="a" * 48)
+
         succ = BlockDev.crypto_luks_set_label(self.loop_devs[0], self.label, self.subsystem)
         self.assertTrue(succ)
 


### PR DESCRIPTION
cryptsetup recently started imposing some limits on label and subsystem lenght so we should add a function for the users to be able to check if their label and subsystem are valid. This is similar to existing FS plugin functions.

See also: https://gitlab.com/cryptsetup/cryptsetup/-/merge_requests/841