### PR TITLE
Mark _get_linux_version() as static

### DIFF
--- a/src/utils/module.c
+++ b/src/utils/module.c
@@ -274,7 +274,7 @@ static gboolean have_linux_ver = FALSE;
 
 G_LOCK_DEFINE_STATIC (detected_linux_ver);
 
-BDUtilsLinuxVersion * _get_linux_version (gboolean lock, GError **error) {
+static BDUtilsLinuxVersion * _get_linux_version (gboolean lock, GError **error) {
     struct utsname buf;
 
     if (lock)


### PR DESCRIPTION
It is an internal implementation detail and the symbol should not be exported via libblockdev-utils.