### PR TITLE
ci: Add a GH action to check for exported private symbols

### DIFF
--- a/.github/workflows/symbols.yml
+++ b/.github/workflows/symbols.yml
@@ -1,0 +1,37 @@
+name: Check for exported private symbols
+
+on:
+  pull_request:
+    branches:
+     - master
+
+jobs:
+  build:
+    name: symbols
+    runs-on: ubuntu-24.04
+    env:
+      CI_CONTAINER: libblockdev-ci-symbols
+    steps:
+      - name: Checkout libblockdev repository
+        uses: actions/checkout@v5
+
+      - name: Install podman
+        run: |
+          sudo apt -qq update
+          sudo apt -y -qq install podman
+
+      - name: Build the container
+        run: |
+          podman build --no-cache -t ${{ env.CI_CONTAINER }} -f misc/ci.Dockerfile .
+
+      - name: Start the container
+        run: |
+          podman run -d -t --name ${{ env.CI_CONTAINER }} --privileged --volume "$(pwd):/app" --workdir "/app" ${{ env.CI_CONTAINER }}
+
+      - name: Install test dependencies in the container
+        run: |
+          podman exec -it ${{ env.CI_CONTAINER }} bash -c "ansible-playbook -i "localhost," -c local misc/install-test-dependencies.yml -e 'test_dependencies=false'"
+
+      - name: Run check script in the container
+        run: |
+          podman exec -it ${{ env.CI_CONTAINER }} bash -c "/ci/check_new_symbols -p libblockdev"


### PR DESCRIPTION
With this we'll hopefully avoid issues like #1135 in the future.