### PR TITLE
ci: Do not install DNF5 Python bindings on CentOS/RHEL 10

### DIFF
--- a/plans/tests-rhel.fmf
+++ b/plans/tests-rhel.fmf
@@ -10,7 +10,7 @@ prepare:
   - name: copr
     how: shell
     script:
-      - sudo dnf install -y python3-libdnf5 'dnf-command(copr)'
+      - sudo dnf install -y python3-libdnf 'dnf-command(copr)'
       - sudo dnf copr enable -y @storage/udisks-daily centos-stream-10-x86_64
       # TF prioritizes Fedora tag repo over all others, in particular our daily COPR
       - for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do sed -i '/priority/d' "$f" ;done


### PR DESCRIPTION
Related: #1141