### PR TITLE
tests: Add a separate simpler MD activation test case

### DIFF
--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -202,6 +202,25 @@ class MDTestCreateWithChunkSize(MDTestCase):
 
 class MDTestActivateDeactivate(MDTestCase):
     @tag_test(TestTags.SLOW, TestTags.CORE)
+    def test_activate_deactivate_core(self):
+        """Verify that it is possible to activate and deactivate an MD RAID"""
+
+        succ = BlockDev.md_create("bd_test_md", "raid0",
+                                    [self.loop_devs[0], self.loop_devs[1]],
+                                    0, None, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
+
+        succ = BlockDev.md_activate("bd_test_md",
+                                    [self.loop_devs[0], self.loop_devs[1]], None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.md_deactivate("bd_test_md")
+        self.assertTrue(succ)
+
+    @tag_test(TestTags.SLOW, TestTags.CORE, TestTags.UNSTABLE)
     def test_activate_deactivate(self):
         """Verify that it is possible to activate and deactivate an MD RAID"""
 

--- a/tests/skip.yml
+++ b/tests/skip.yml
@@ -76,3 +76,9 @@
     - distro: "centos"
       version: ["9", "10"]
       reason: "Race condition in denominate with latest mdadm v4.4"
+
+- test: mdraid_test.MDTestActivateDeactivate
+  skip_on:
+    - distro: "centos"
+      version: "9"
+      reason: "Race condition in activate-deactivate test with latest kernel. RHEL-126233"


### PR DESCRIPTION
MD (de)activation is currently very race-y in both RHEL 9 and 10 and then tests fails often especially when starting and stopping the array multiple times. This introduces a new simple test case that should cover most of the use cases without failing all the time keeping the "full" test case, but marking it as unstable until these issues are resolved in mdadm.