### PR TITLE
crypto: Allow using activate flags when opening a device

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -81,6 +81,8 @@ bd_crypto_keyslot_context_new_keyfile
 bd_crypto_keyslot_context_new_keyring
 bd_crypto_keyslot_context_new_volume_key
 bd_crypto_luks_open
+BDCryptoOpenFlags
+bd_crypto_luks_open_flags
 bd_crypto_luks_close
 bd_crypto_luks_add_key
 bd_crypto_luks_remove_key
@@ -119,6 +121,7 @@ bd_crypto_luks_token_info_copy
 bd_crypto_luks_token_info
 bd_crypto_keyring_add_key
 bd_crypto_tc_open
+bd_crypto_tc_open_flags
 bd_crypto_tc_close
 bd_crypto_escrow_device
 BDCryptoBITLKInfo
@@ -126,8 +129,10 @@ bd_crypto_bitlk_info
 bd_crypto_bitlk_info_copy
 bd_crypto_bitlk_info_free
 bd_crypto_bitlk_open
+bd_crypto_bitlk_open_flags
 bd_crypto_bitlk_close
 bd_crypto_fvault2_open
+bd_crypto_fvault2_open_flags
 bd_crypto_fvault2_close
 bd_crypto_opal_is_supported
 bd_crypto_opal_wipe_device

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -361,6 +361,11 @@ typedef enum {
     BD_CRYPTO_INTEGRITY_OPEN_ALLOW_DISCARDS     = 1 << 5,
 } BDCryptoIntegrityOpenFlags;
 
+typedef enum {
+    BD_CRYPTO_OPEN_ALLOW_DISCARDS  = 1 << 0,
+    BD_CRYPTO_OPEN_READONLY        = 1 << 1,
+} BDCryptoOpenFlags;
+
 #define BD_CRYPTO_TYPE_LUKS_INFO (bd_crypto_luks_info_get_type ())
 GType bd_crypto_luks_info_get_type();
 
@@ -940,6 +945,31 @@ gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint6
 gboolean bd_crypto_luks_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, gboolean read_only, GError **error);
 
 /**
+ * bd_crypto_luks_open_flags:
+ * @device: the device to open
+ * @name: name for the LUKS device
+ * @context: key slot context (passphrase/keyfile/token...) to open this LUKS @device
+ * @flags: activation flags for the LUKS device
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Supported @context types for this function: passphrase, key file, keyring
+ *
+ * Returns: whether the @device was successfully opened or not
+ *
+ * Tech category: %BD_CRYPTO_TECH_LUKS-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
+ *
+ * Example of using %bd_crypto_luks_open_flags with %BDCryptoKeyslotContext:
+ *
+ * |[<!-- language="C" -->
+ * BDCryptoKeyslotContext *context = NULL;
+ *
+ * context = bd_crypto_keyslot_context_new_passphrase ("passphrase", 10, NULL);
+ * bd_crypto_luks_open_flags ("/dev/vda1", "luks-device", context, 0, NULL);
+ * ]|
+ */
+gboolean bd_crypto_luks_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, BDCryptoOpenFlags flags, GError **error);
+
+/**
  * bd_crypto_luks_close:
  * @luks_device: LUKS device to close
  * @error: (out) (optional): place to store error (if any)
@@ -1301,6 +1331,27 @@ gboolean bd_crypto_device_seems_encrypted (const gchar *device, GError **error);
 gboolean bd_crypto_tc_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, const gchar **keyfiles, gboolean hidden, gboolean system, gboolean veracrypt, guint32 veracrypt_pim, gboolean read_only, GError **error);
 
 /**
+ * bd_crypto_tc_open_flags:
+ * @device: the device to open
+ * @name: name for the TrueCrypt/VeraCrypt device
+ * @context: (nullable): passphrase key slot context for this TrueCrypt/VeraCrypt volume
+ * @flags: activation flags for the TrueCrypt/VeraCrypt device
+ * @keyfiles: (nullable) (array zero-terminated=1): paths to the keyfiles for the TrueCrypt/VeraCrypt volume
+ * @hidden: whether a hidden volume inside the volume should be opened
+ * @system: whether to try opening as an encrypted system (with boot loader)
+ * @veracrypt: whether to try VeraCrypt modes (TrueCrypt modes are tried anyway)
+ * @veracrypt_pim: VeraCrypt PIM value (only used if @veracrypt is %TRUE)
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Supported @context types for this function: passphrase
+ *
+ * Returns: whether the @device was successfully opened or not
+ *
+ * Tech category: %BD_CRYPTO_TECH_TRUECRYPT-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
+ */
+gboolean bd_crypto_tc_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, const gchar **keyfiles, gboolean hidden, gboolean system, gboolean veracrypt, guint32 veracrypt_pim, BDCryptoOpenFlags flags, GError **error);
+
+/**
  * bd_crypto_tc_close:
  * @tc_device: TrueCrypt/VeraCrypt device to close
  * @error: (out) (optional): place to store error (if any)
@@ -1343,6 +1394,22 @@ gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, 
 gboolean bd_crypto_bitlk_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, gboolean read_only, GError **error);
 
 /**
+ * bd_crypto_bitlk_open_flags:
+ * @device: the device to open
+ * @name: name for the BITLK device
+ * @context: key slot context (passphrase/keyfile/token...) for this BITLK device
+ * @flags: activation flags for the BITLK device
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Supported @context types for this function: passphrase, key file
+ *
+ * Returns: whether the @device was successfully opened or not
+ *
+ * Tech category: %BD_CRYPTO_TECH_BITLK-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
+ */
+gboolean bd_crypto_bitlk_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, BDCryptoOpenFlags flags, GError **error);
+
+/**
  * bd_crypto_bitlk_close:
  * @bitlk_device: BITLK device to close
  * @error: (out) (optional): place to store error (if any)
@@ -1368,6 +1435,22 @@ gboolean bd_crypto_bitlk_close (const gchar *bitlk_device, GError **error);
  * Tech category: %BD_CRYPTO_TECH_FVAULT2-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
  */
 gboolean bd_crypto_fvault2_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, gboolean read_only, GError **error);
+
+/**
+ * bd_crypto_fvault2_open_flags:
+ * @device: the device to open
+ * @name: name for the FVAULT2 device
+ * @context: key slot context (passphrase/keyfile/token...) for this FVAULT2 volume
+ * @flags: activation flags for the FVAULT2 device
+ * @error: (out) (optional): place to store error (if any)
+ *
+ * Supported @context types for this function: passphrase, key file
+ *
+ * Returns: whether the @device was successfully opened or not
+ *
+ * Tech category: %BD_CRYPTO_TECH_FVAULT2-%BD_CRYPTO_TECH_MODE_OPEN_CLOSE
+ */
+gboolean bd_crypto_fvault2_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, BDCryptoOpenFlags flags, GError **error);
 
 /**
  * bd_crypto_fvault2_close:

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -172,6 +172,11 @@ typedef enum {
     BD_CRYPTO_LUKS_ACTIVATE_HIGH_PRIORITY           = 1 << 6,
 } BDCryptoLUKSPersistentFlags;
 
+typedef enum {
+    BD_CRYPTO_OPEN_ALLOW_DISCARDS  = 1 << 0,
+    BD_CRYPTO_OPEN_READONLY        = 1 << 1,
+} BDCryptoOpenFlags;
+
 /**
  * BDCryptoLUKSInfo:
  * @version: LUKS version
@@ -290,6 +295,7 @@ const gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error);
 
 gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint64 key_size, BDCryptoKeyslotContext *context, guint64 min_entropy, BDCryptoLUKSVersion luks_version, BDCryptoLUKSExtra *extra,GError **error);
 gboolean bd_crypto_luks_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, gboolean read_only, GError **error);
+gboolean bd_crypto_luks_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, BDCryptoOpenFlags flags, GError **error);
 gboolean bd_crypto_luks_close (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_add_key (const gchar *device, BDCryptoKeyslotContext *context, BDCryptoKeyslotContext *ncontext, GError **error);
 gboolean bd_crypto_luks_remove_key (const gchar *device, BDCryptoKeyslotContext *context, GError **error);
@@ -319,12 +325,15 @@ gboolean bd_crypto_keyring_add_key (const gchar *key_desc, const guint8 *key_dat
 
 gboolean bd_crypto_device_seems_encrypted (const gchar *device, GError **error);
 gboolean bd_crypto_tc_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, const gchar **keyfiles, gboolean hidden, gboolean system, gboolean veracrypt, guint32 veracrypt_pim, gboolean read_only, GError **error);
+gboolean bd_crypto_tc_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, const gchar **keyfiles, gboolean hidden, gboolean system, gboolean veracrypt, guint32 veracrypt_pim, BDCryptoOpenFlags flags, GError **error);
 gboolean bd_crypto_tc_close (const gchar *tc_device, GError **error);
 
 gboolean bd_crypto_bitlk_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, gboolean read_only, GError **error);
+gboolean bd_crypto_bitlk_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, BDCryptoOpenFlags flags, GError **error);
 gboolean bd_crypto_bitlk_close (const gchar *bitlk_device, GError **error);
 
 gboolean bd_crypto_fvault2_open (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, gboolean read_only, GError **error);
+gboolean bd_crypto_fvault2_open_flags (const gchar *device, const gchar *name, BDCryptoKeyslotContext *context, BDCryptoOpenFlags flags, GError **error);
 gboolean bd_crypto_fvault2_close (const gchar *fvault2_device, GError **error);
 
 gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, const gchar *cert_data, const gchar *directory, const gchar *backup_passphrase, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -336,6 +336,14 @@ def crypto_tc_open(device, name, passphrase, read_only=False, keyfiles=None, hid
     return _crypto_tc_open(device, name, passphrase, keyfiles, hidden, system, veracrypt, veracrypt_pim, read_only)
 __all__.append("crypto_tc_open")
 
+_crypto_tc_open_flags = BlockDev.crypto_tc_open_flags
+@override(BlockDev.crypto_tc_open_flags)
+def crypto_tc_open_flags(device, name, passphrase, flags=0, keyfiles=None, hidden=False, system=False, veracrypt=False, veracrypt_pim=0):
+    if isinstance(passphrase, str):
+        passphrase = passphrase.encode("utf-8")
+    return _crypto_tc_open_flags(device, name, passphrase, keyfiles, hidden, system, veracrypt, veracrypt_pim, flags)
+__all__.append("crypto_tc_open_flags")
+
 _crypto_bitlk_open = BlockDev.crypto_bitlk_open
 @override(BlockDev.crypto_bitlk_open)
 def crypto_bitlk_open(device, name, passphrase, read_only=False):


### PR DESCRIPTION
This currently allows setting the device as read only and enabling discard for all types of devices supported by cryptsetup.

Fixes: #1138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flag-based open options for encrypted volumes, enabling read-only mounts and optional discard support across LUKS, TrueCrypt/VeraCrypt, BitLocker and FileVault2 while preserving backward-compatible wrappers.
* **Python API**
  * Exposed a new Python wrapper to call the flag-enabled open operations from bindings.
* **Tests**
  * Added tests validating flag-based opens, including discard activation and read-only verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->