### PR TITLE
Fix calling md_activate with UUID in MDTestActivateDeactivate

### DIFF
--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -265,22 +265,25 @@ class MDTestActivateDeactivate(MDTestCase):
         self.assertTrue(md_info)
         self.assertTrue(md_info.uuid)
 
+        md_uuid = BlockDev.md_get_md_uuid(md_info.uuid)
+        self.assertIsNotNone(md_uuid)
+
         # try to activate with UUID and array name
-        succ = BlockDev.md_activate("bd_test_md", [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+        succ = BlockDev.md_activate("bd_test_md", [self.loop_devs[0], self.loop_devs[1]], md_uuid)
         self.assertTrue(succ)
 
         succ = BlockDev.md_deactivate("bd_test_md")
         self.assertTrue(succ)
 
         # try to activate by UUID only: should work with member devices specified
-        succ = BlockDev.md_activate(None, [self.loop_devs[0], self.loop_devs[1]], md_info.uuid)
+        succ = BlockDev.md_activate(None, [self.loop_devs[0], self.loop_devs[1]], md_uuid)
         self.assertTrue(succ)
 
         succ = BlockDev.md_deactivate("bd_test_md")
         self.assertTrue(succ)
 
         # as well as without them
-        succ = BlockDev.md_activate(None, None, md_info.uuid)
+        succ = BlockDev.md_activate(None, None, md_uuid)
         self.assertTrue(succ)
 
         succ = BlockDev.md_deactivate("bd_test_md")


### PR DESCRIPTION
We need to provide the UUID in the MD format, not in the rfc4122 format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized MD RAID UUID retrieval and validation in test workflows
  * Enhanced test coverage for multiple activation scenarios including UUID-based and device-based approaches
  * Strengthened consistency across MD array initialization and deactivation testing paths

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->