### PR TITLE
nvme: Fix typo in BD_NVME_SANITIZE_STATUS_IN_PROG*R*ESS

### DIFF
--- a/src/lib/plugin_apis/nvme.api
+++ b/src/lib/plugin_apis/nvme.api
@@ -886,7 +886,8 @@ typedef enum {
 /**
  * BDNVMESanitizeStatus:
  * @BD_NVME_SANITIZE_STATUS_NEVER_SANITIZED: The NVM subsystem has never been sanitized.
- * @BD_NVME_SANITIZE_STATUS_IN_PROGESS: A sanitize operation is currently in progress.
+ * @BD_NVME_SANITIZE_STATUS_IN_PROGRESS: A sanitize operation is currently in progress.
+ * @BD_NVME_SANITIZE_STATUS_IN_PROGESS: Deprecated alias for %BD_NVME_SANITIZE_STATUS_IN_PROGRESS
  * @BD_NVME_SANITIZE_STATUS_SUCCESS: The most recent sanitize operation completed successfully including any additional media modification.
  * @BD_NVME_SANITIZE_STATUS_SUCCESS_NO_DEALLOC: The most recent sanitize operation for which No-Deallocate After Sanitize was requested has completed successfully with deallocation of all user data.
  * @BD_NVME_SANITIZE_STATUS_FAILED: The most recent sanitize operation failed.
@@ -894,7 +895,8 @@ typedef enum {
 /* BpG-skip-end */
 typedef enum {
     BD_NVME_SANITIZE_STATUS_NEVER_SANITIZED = 0,
-    BD_NVME_SANITIZE_STATUS_IN_PROGESS = 1,
+    BD_NVME_SANITIZE_STATUS_IN_PROGRESS = 1,
+    BD_NVME_SANITIZE_STATUS_IN_PROGESS = BD_NVME_SANITIZE_STATUS_IN_PROGRESS,
     BD_NVME_SANITIZE_STATUS_SUCCESS = 2,
     BD_NVME_SANITIZE_STATUS_SUCCESS_NO_DEALLOC = 3,
     BD_NVME_SANITIZE_STATUS_FAILED = 4,

--- a/src/plugins/nvme/nvme-info.c
+++ b/src/plugins/nvme/nvme-info.c
@@ -1147,7 +1147,7 @@ BDNVMESanitizeLog * bd_nvme_get_sanitize_log (const gchar *device, GError **erro
             log->sanitize_status = BD_NVME_SANITIZE_STATUS_SUCCESS;
             break;
         case NVME_SANITIZE_SSTAT_STATUS_IN_PROGESS:
-            log->sanitize_status = BD_NVME_SANITIZE_STATUS_IN_PROGESS;
+            log->sanitize_status = BD_NVME_SANITIZE_STATUS_IN_PROGRESS;
             break;
         case NVME_SANITIZE_SSTAT_STATUS_COMPLETED_FAILED:
             log->sanitize_status = BD_NVME_SANITIZE_STATUS_FAILED;

--- a/src/plugins/nvme/nvme.h
+++ b/src/plugins/nvme/nvme.h
@@ -468,14 +468,16 @@ typedef enum {
 /**
  * BDNVMESanitizeStatus:
  * @BD_NVME_SANITIZE_STATUS_NEVER_SANITIZED: The NVM subsystem has never been sanitized.
- * @BD_NVME_SANITIZE_STATUS_IN_PROGESS: A sanitize operation is currently in progress.
+ * @BD_NVME_SANITIZE_STATUS_IN_PROGRESS: A sanitize operation is currently in progress.
+ * @BD_NVME_SANITIZE_STATUS_IN_PROGESS: Deprecated alias for %BD_NVME_SANITIZE_STATUS_IN_PROGRESS
  * @BD_NVME_SANITIZE_STATUS_SUCCESS: The most recent sanitize operation completed successfully including any additional media modification.
  * @BD_NVME_SANITIZE_STATUS_SUCCESS_NO_DEALLOC: The most recent sanitize operation for which No-Deallocate After Sanitize was requested has completed successfully with deallocation of all user data.
  * @BD_NVME_SANITIZE_STATUS_FAILED: The most recent sanitize operation failed.
  */
 typedef enum {
     BD_NVME_SANITIZE_STATUS_NEVER_SANITIZED = 0,
-    BD_NVME_SANITIZE_STATUS_IN_PROGESS = 1,
+    BD_NVME_SANITIZE_STATUS_IN_PROGRESS = 1,
+    BD_NVME_SANITIZE_STATUS_IN_PROGESS = BD_NVME_SANITIZE_STATUS_IN_PROGRESS,
     BD_NVME_SANITIZE_STATUS_SUCCESS = 2,
     BD_NVME_SANITIZE_STATUS_SUCCESS_NO_DEALLOC = 3,
     BD_NVME_SANITIZE_STATUS_FAILED = 4,


### PR DESCRIPTION
Unfortunately we need to keep the "progess" member as well now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a misspelling so the NVMe sanitize-status now properly shows "in-progress".
  * Preserved backward compatibility by keeping the previous identifier as a deprecated alias, ensuring existing integrations continue working with no observable behavior change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->