### PR TITLE
crypto: Show better error when crypt_activate returns ETXTBSY

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -1358,6 +1358,9 @@ gboolean bd_crypto_luks_open_flags (const gchar *device, const gchar *name, BDCr
         if (ret == -EPERM)
           g_set_error (&l_error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
                        "Failed to activate device: Incorrect passphrase.");
+        else if (ret == -ETXTBSY)
+          g_set_error (&l_error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
+                       "Failed to activate device: Unknown or unsupported LUKS2 requirements detected.");
         else
           g_set_error (&l_error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_DEVICE,
                        "Failed to activate device: %s", strerror_l (-ret, c_locale));


### PR DESCRIPTION
This error code is used when the LUKS2 device requires some features not supported by the used version of cryptsetup, e.g. when trying to open a device created with a newer version. The "Text file busy" error message return by strerror is not very usefull in this case.

Fixes: #1148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for LUKS device activation with better diagnostic messages when unsupported LUKS2 requirements are detected during device activation attempts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->