### PR TITLE
crypto: Fix reading keyfile in bd_crypto_luks_change_key

### DIFF
--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -1734,7 +1734,7 @@ gboolean bd_crypto_luks_change_key (const gchar *device, BDCryptoKeyslotContext 
     }
 
     if (ncontext->type == BD_CRYPTO_KEYSLOT_CONTEXT_TYPE_KEYFILE) {
-        ret = crypt_keyfile_device_read (cd, ncontext->u.keyfile.keyfile, &key_buf, &buf_len,
+        ret = crypt_keyfile_device_read (cd, ncontext->u.keyfile.keyfile, &nkey_buf, &nbuf_len,
                                          ncontext->u.keyfile.keyfile_offset, ncontext->u.keyfile.key_size, 0);
         if (ret != 0) {
             g_set_error (&l_error, BD_CRYPTO_ERROR, BD_CRYPTO_ERROR_KEYFILE_FAILED,

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -631,6 +631,33 @@ class CryptoTestChangeKey(CryptoTestCase):
         succ = BlockDev.crypto_luks_change_key(self.loop_devs[0], ctx, nctx)
         self.assertTrue(succ)
 
+        # old passphrase should no longer work
+        with self.assertRaises(GLib.GError):
+            BlockDev.crypto_luks_remove_key(self.loop_devs[0], ctx)
+
+        # new passphrase should work
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", nctx)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
+        self.assertTrue(succ)
+
+        # try with keyfile as well
+        kctx = BlockDev.CryptoKeyslotContext(keyfile=self.keyfile)
+        succ = BlockDev.crypto_luks_change_key(self.loop_devs[0], nctx, kctx)
+        self.assertTrue(succ)
+
+        # old passphrase should no longer work
+        with self.assertRaises(GLib.GError):
+            BlockDev.crypto_luks_remove_key(self.loop_devs[0], nctx)
+
+        # keyfile should work
+        succ = BlockDev.crypto_luks_open(self.loop_devs[0], "libblockdevTestLUKS", kctx)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_luks_close("libblockdevTestLUKS")
+        self.assertTrue(succ)
+
     @tag_test(TestTags.SLOW)
     def test_luks_change_key(self):
         self._change_key(self._luks_format)


### PR DESCRIPTION
Copy-paste bug, we need to make sure save the new passphrase into the correct buffer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory-management issue during LUKS key change operations when using keyfile-based keys, preventing incorrect buffer handling on error.

* **Tests**
  * Expanded tests for LUKS key change flows to cover passphrase-to-keyfile transitions, validation that previous keys are rejected, and open/close operations with the new keyfile context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->