### PR TITLE
Revert "dm: Remove root permission check in bd_dm_map_exists"

### DIFF
--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -315,6 +315,12 @@ gboolean bd_dm_map_exists (const gchar *map_name, gboolean live_only, gboolean a
     guint64 next = 0;
     gboolean ret = FALSE;
 
+    if (geteuid () != 0) {
+        g_set_error (error, BD_DM_ERROR, BD_DM_ERROR_NOT_ROOT,
+                     "Not running as root, cannot query DM maps");
+        return FALSE;
+    }
+
     task_list = dm_task_create (DM_DEVICE_LIST);
     if (!task_list) {
         g_set_error (error, BD_DM_ERROR, BD_DM_ERROR_TASK,


### PR DESCRIPTION
This reverts commit 80ba38c1fa183b1fb19dd43cd4496df1cdaa2a39.

Unfortunately blivet depends on libblockdev returning this specific error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented access control enforcement for Device Mapper functionality. The system now validates that users possess root or administrator privileges before permitting Device Mapper operations. All Device Mapper-related tasks and queries will be restricted from non-privileged users, with appropriate error messaging provided. This change improves security and prevents unauthorized access.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->