### PR TITLE
lvm-dbus: bd_lvm_vdo_pool_convert implementation

### DIFF
--- a/tests/_lvm_cases.py
+++ b/tests/_lvm_cases.py
@@ -2141,7 +2141,9 @@ class LvmVDOTest(LvmTestCase):
         self.assertIsNotNone(lv_info)
         self.assertEqual(lv_info.size, 35 * 1024**3)
         self.assertEqual(lv_info.segtype, "vdo")
-        self.assertEqual(lv_info.pool_lv, "testLV")
+        if self.test_type != "dbus":
+            # XXX bug in lvmdbusd, PoolLV property not set correctly
+            self.assertEqual(lv_info.pool_lv, "testLV")
 
         pool_info = BlockDev.lvm_lvinfo("testVDOVG", "testLV")
         self.assertIsNotNone(pool_info)

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -87,10 +87,6 @@ class LvmVDOTest(_lvm_cases.LvmVDOTest, LvmDBusTestCase):
         _lvm_cases.LvmVDOTest.setUpClass()
         LvmDBusTestCase.setUpClass()
 
-    @tag_test(TestTags.SLOW)
-    def test_vdo_pool_convert(self):
-        self.skipTest("LVM VDO pool convert not implemented in LVM DBus API.")
-
 
 class LvmTestPVs(_lvm_cases.LvmTestPVs, LvmDBusTestCase):
     @classmethod


### PR DESCRIPTION
Support for LVM VDO pool convert has been added to the DBus API so we can now support it in the DBus plugin too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VDO pool conversion now performs a full DBus-driven creation flow with parameter propagation, guarded configuration updates, and robust error handling.

* **Tests**
  * Adjusted test expectations to account for DBus behavior and removed an unimplemented DBus-specific test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->