### PR TITLE
part: Check partition parsed partition type before setting it

### DIFF
--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1312,6 +1312,16 @@ class PartSetIdCase(PartTestCase):
         with self.assertRaises(GLib.GError):
             BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "0x85")
 
+        # some invalid ids
+        with self.assertRaises(GLib.GError):
+            BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "83;id")
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "0xfff")
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "999")
+
 
 class PartSetBootableFlagCase(PartTestCase):
     def test_set_part_type(self):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition-type validation to detect and reject invalid numeric IDs and unknown partition types with clearer error messages, preventing invalid changes.

* **Tests**
  * Added tests covering additional invalid partition ID inputs to ensure validation catches malformed and out-of-range values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->