### PR TITLE
loop: Remove the loop device when setting sector size fails

### DIFF
--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -372,6 +372,9 @@ gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean 
     if (status != 0) {
         g_set_error (&l_error, BD_LOOP_ERROR, BD_LOOP_ERROR_FAIL,
                      "Failed to set status for the %s device: %m", loop_device);
+        if (ioctl (loop_fd, LOOP_CLR_FD) < 0)
+            bd_utils_log_format (BD_UTILS_LOG_WARNING,
+                                 "Failed to clear the %s device: %m", loop_device);
         g_free (loop_device);
         close (loop_fd);
         bd_utils_report_finished (progress_id, l_error->message);
@@ -391,6 +394,9 @@ gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean 
         if (status != 0) {
             g_set_error (&l_error, BD_LOOP_ERROR, BD_LOOP_ERROR_FAIL,
                          "Failed to set sector size for the %s device: %m", loop_device);
+            if (ioctl (loop_fd, LOOP_CLR_FD) < 0)
+                bd_utils_log_format (BD_UTILS_LOG_WARNING,
+                                     "Failed to clear the %s device: %m", loop_device);
             g_free (loop_device);
             close (loop_fd);
             bd_utils_report_finished (progress_id, l_error->message);

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 import overrides_hack
 
@@ -141,6 +142,17 @@ class LoopTestSetupSectorSize(LoopTestCase):
         # logical_block_size should be 4096
         with open("/sys/block/%s/queue/logical_block_size" % self.loop, "r") as f:
             self.assertEqual(f.read().strip(), "4096")
+
+        succ = BlockDev.loop_teardown(self.loop)
+        self.assertTrue(succ)
+
+        # invalid sector size -- setup should fail, make sure we also removed the loop device after
+        with self.assertRaisesRegex(GLib.GError, "Failed to set sector size"):
+            BlockDev.loop_setup(self.dev_file, sector_size=7)
+
+        time.sleep(2)
+        loop_name = BlockDev.loop_get_loop_name(self.dev_file)
+        self.assertIsNone(loop_name)
 
 
 class LoopTestSetupPartprobe(LoopTestCase):


### PR DESCRIPTION
Fixes: #1170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during loop device setup: failed sector-size or setup attempts now ensure the device is cleaned up and log warnings if cleanup itself fails.

* **Tests**
  * Added coverage for invalid sector-size scenarios, confirming proper error reporting and that no loop device remains associated after failed setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->