### PR TITLE
fs: Never show progress bar for ntfsresize

### DIFF
--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -461,7 +461,7 @@ BDFSNtfsInfo* bd_fs_ntfs_get_info (const gchar *device, GError **error) {
  * Tech category: %BD_FS_TECH_NTFS-%BD_FS_TECH_MODE_RESIZE
  */
 guint64 bd_fs_ntfs_get_min_size (const gchar *device, GError **error) {
-    const gchar *args[4] = {"ntfsresize", "--info", device, NULL};
+    const gchar *args[5] = {"ntfsresize", "--no-progress-bar", "--info", device, NULL};
     gboolean success = FALSE;
     gchar *output = NULL;
     gchar **lines = NULL;


### PR DESCRIPTION
It shows progress even when only getting the min size info and it needlessly pollutes the log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed progress output when checking the minimum resize size for NTFS volumes, resulting in cleaner, less noisy output during this query.
  * Prevents incidental progress bar display in logs or terminals while gathering information only, improving clarity for users monitoring operations without performing an actual resize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->