### PR TITLE
part: Fix partition ID validation

### DIFF
--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -1725,13 +1725,13 @@ static gboolean set_part_type (struct fdisk_context *cxt, gint part_num, const g
     const gchar *label_name = NULL;
     gchar *endptr = NULL;
     gint status = 0;
-    gint part_id_int = 0;
+    gint64 part_id_int = 0;
 
     /* check if part type/id is valid for MBR */
     if (table_type == BD_PART_TABLE_MSDOS) {
-        part_id_int = g_ascii_strtoull (type_str, &endptr, 0);
+        part_id_int = g_ascii_strtoll (type_str, &endptr, 0);
 
-        if (part_id_int == 0 || endptr == NULL || *endptr != '\0') {
+        if (part_id_int <= 0 || part_id_int > 0xFF || endptr == NULL || *endptr != '\0') {
             g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_INVAL,
                          "Invalid partition id given: '%s'.", type_str);
             return FALSE;
@@ -1771,18 +1771,6 @@ static gboolean set_part_type (struct fdisk_context *cxt, gint part_num, const g
                      "Failed to parse partition type.");
         fdisk_unref_partition (pa);
         return FALSE;
-    }
-
-    if (table_type == BD_PART_TABLE_MSDOS) {
-        /* for GPT types unknown by libfdisk might still be valid */
-        status = fdisk_parttype_is_unknown (ptype);
-        if (status != 0) {
-            g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_INVAL,
-                        "Invalid partition type given: '%s'.", type_str);
-            fdisk_unref_parttype (ptype);
-            fdisk_unref_partition (pa);
-            return FALSE;
-        }
     }
 
     status = fdisk_set_partition_type (cxt, part_num, ptype);

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1308,6 +1308,13 @@ class PartSetIdCase(PartTestCase):
         ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
         self.assertEqual(ps.id, "0x8e")
 
+        # 0xc8 -- unknown to libfdisk, but still valid
+        succ = BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "0xc8")
+        self.assertTrue(succ)
+
+        ps = BlockDev.part_get_part_spec (self.loop_devs[0], ps.path)
+        self.assertEqual(ps.id, "0xc8")
+
         # we can't change part id to extended partition id
         with self.assertRaises(GLib.GError):
             BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "0x85")
@@ -1321,6 +1328,9 @@ class PartSetIdCase(PartTestCase):
 
         with self.assertRaises(GLib.GError):
             BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "999")
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.part_set_part_id (self.loop_devs[0], ps.path, "-1")
 
 
 class PartSetBootableFlagCase(PartTestCase):


### PR DESCRIPTION
Follow up for a42600f. We want to be able to set all valid IDs even those unknown to libfdisk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened partition ID validation: now accepts additional valid IDs (e.g., 0xc8) and rejects negative/out-of-range values.
  * Fixed an issue that could incorrectly reject certain partition types for MSDOS/MBR layouts, reducing false errors when applying types.

* **Tests**
  * Updated test suite to cover the new partition ID rules and the negative-ID error case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->