### PR TITLE
lvm-dbus: Do not ignore rename fails in thpool/cachepool_convert

### DIFF
--- a/src/plugins/lvm/lvm-dbus.c
+++ b/src/plugins/lvm/lvm-dbus.c
@@ -3664,7 +3664,7 @@ gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, cons
 
     ret = call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateThinPool", params, NULL, extra, TRUE, error);
     if (ret && name)
-        bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
+        ret = bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
     return ret;
 }
 
@@ -3715,7 +3715,7 @@ gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, 
     ret = call_lvm_obj_method_sync (vg_name, VG_INTF, "CreateCachePool", params, NULL, extra, TRUE, error);
 
     if (ret && name)
-        bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
+        ret = bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
 
     return ret;
 }


### PR DESCRIPTION
This makes these function behave the same way the CLI plugin does when the final rename call fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LVM thin pool and cache pool conversion operations to accurately report their final completion status. Operations now properly reflect the combined outcome of both pool creation and renaming steps, ensuring users receive reliable information about whether conversions ultimately succeed or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->