### PR TITLE
Fix gtk-doc warnings for docstrings and sections file

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -502,7 +502,6 @@ bd_swap_is_tech_avail
 bd_part_init
 bd_part_close
 BD_PART_ERROR
-BD_PART_TYPE_SPEC
 BDPartAlign
 BDPartSpec
 BDPartType
@@ -518,7 +517,6 @@ bd_part_get_disk_parts
 bd_part_get_part_spec
 bd_part_spec_copy
 bd_part_spec_free
-bd_part_spec_get_type
 bd_part_get_part_table_type_str
 bd_part_get_type_str
 bd_part_get_best_free_region
@@ -848,8 +846,6 @@ BDSmartError
 BDSmartTech
 BDSmartTechMode
 bd_smart_is_tech_avail
-BD_SMART_TYPE_ATA
-BD_SMART_TYPE_ATA_ATTRIBUTE
 BDSmartATAAttribute
 BDSmartATAAttributeUnit
 BDSmartATAAttributeFlag

--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -908,8 +908,6 @@ gboolean bd_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError 
  * bd_btrfs_change_label:
  * @mountpoint: a mountpoint of the btrfs filesystem to change label of
  * @label: new label for the filesystem
- * @extra: (nullable) (array zero-terminated=1): extra options for the volume creation (right now
- *                                                 passed to the 'btrfs' utility)
  * @error: (out) (optional): place to store error (if any)
  *
  * Returns: whether the label of the @mountpoint filesystem was successfully set

--- a/src/plugins/fs/btrfs.c
+++ b/src/plugins/fs/btrfs.c
@@ -86,6 +86,7 @@ bd_fs_btrfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **e
 
 /**
  * bd_fs_btrfs_info_copy: (skip)
+ * @data: (nullable): %BDFSBtrfsInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -105,6 +106,7 @@ BDFSBtrfsInfo* bd_fs_btrfs_info_copy (BDFSBtrfsInfo *data) {
 
 /**
  * bd_fs_btrfs_info_free: (skip)
+ * @data: (nullable): %BDFSBtrfsInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/exfat.c
+++ b/src/plugins/fs/exfat.c
@@ -98,6 +98,7 @@ bd_fs_exfat_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **e
 
 /**
  * bd_fs_exfat_info_copy: (skip)
+ * @data: (nullable): %BDFSExfatInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -118,6 +119,7 @@ BDFSExfatInfo* bd_fs_exfat_info_copy (BDFSExfatInfo *data) {
 
 /**
  * bd_fs_exfat_info_free: (skip)
+ * @data: (nullable): %BDFSExfatInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/ext.c
+++ b/src/plugins/fs/ext.c
@@ -173,6 +173,7 @@ bd_fs_ext_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **err
 
 /**
  * bd_fs_ext2_info_copy: (skip)
+ * @data: (nullable): %BDFSExt2Info to copy
  *
  * Creates a new copy of @data.
  */
@@ -194,6 +195,7 @@ BDFSExt2Info* bd_fs_ext2_info_copy (BDFSExt2Info *data) {
 
 /**
  * bd_fs_ext3_info_copy: (skip)
+ * @data: (nullable): %BDFSExt3Info to copy
  *
  * Creates a new copy of @data.
  */
@@ -203,6 +205,7 @@ BDFSExt3Info* bd_fs_ext3_info_copy (BDFSExt3Info *data) {
 
 /**
  * bd_fs_ext4_info_copy: (skip)
+ * @data: (nullable): %BDFSExt4Info to copy
  *
  * Creates a new copy of @data.
  */
@@ -212,6 +215,7 @@ BDFSExt4Info* bd_fs_ext4_info_copy (BDFSExt4Info *data) {
 
 /**
  * bd_fs_ext2_info_free: (skip)
+ * @data: (nullable): %BDFSExt2Info to free
  *
  * Frees @data.
  */
@@ -227,6 +231,7 @@ void bd_fs_ext2_info_free (BDFSExt2Info *data) {
 
 /**
  * bd_fs_ext3_info_free: (skip)
+ * @data: (nullable): %BDFSExt3Info to free
  *
  * Frees @data.
  */
@@ -236,6 +241,7 @@ void bd_fs_ext3_info_free (BDFSExt3Info *data) {
 
 /**
  * bd_fs_ext4_info_free: (skip)
+ * @data: (nullable): %BDFSExt4Info to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/f2fs.c
+++ b/src/plugins/fs/f2fs.c
@@ -145,6 +145,7 @@ bd_fs_f2fs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **er
 
 /**
  * bd_fs_f2fs_info_copy: (skip)
+ * @data: (nullable): %BDFSF2FSInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -165,6 +166,7 @@ BDFSF2FSInfo* bd_fs_f2fs_info_copy (BDFSF2FSInfo *data) {
 
 /**
  * bd_fs_f2fs_info_free: (skip)
+ * @data: (nullable): %BDFSF2FSInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/nilfs.c
+++ b/src/plugins/fs/nilfs.c
@@ -101,6 +101,7 @@ bd_fs_nilfs2_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **
 
 /**
  * bd_fs_nilfs2_info_copy: (skip)
+ * @data: (nullable): %BDFSNILFS2Info to copy
  *
  * Creates a new copy of @data.
  */
@@ -121,6 +122,7 @@ BDFSNILFS2Info* bd_fs_nilfs2_info_copy (BDFSNILFS2Info *data) {
 
 /**
  * bd_fs_nilfs2_info_free: (skip)
+ * @data: (nullable): %BDFSNILFS2Info to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/ntfs.c
+++ b/src/plugins/fs/ntfs.c
@@ -89,6 +89,7 @@ bd_fs_ntfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **er
 
 /**
  * bd_fs_ntfs_info_copy: (skip)
+ * @data: (nullable): %BDFSNtfsInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -108,6 +109,7 @@ BDFSNtfsInfo* bd_fs_ntfs_info_copy (BDFSNtfsInfo *data) {
 
 /**
  * bd_fs_ntfs_info_free: (skip)
+ * @data: (nullable): %BDFSNtfsInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/udf.c
+++ b/src/plugins/fs/udf.c
@@ -99,6 +99,7 @@ bd_fs_udf_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **err
 
 /**
  * bd_fs_udf_info_copy: (skip)
+ * @data: (nullable): %BDFSUdfInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -122,6 +123,7 @@ BDFSUdfInfo* bd_fs_udf_info_copy (BDFSUdfInfo *data) {
 
 /**
  * bd_fs_udf_info_free: (skip)
+ * @data: (nullable): %BDFSUdfInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/vfat.c
+++ b/src/plugins/fs/vfat.c
@@ -98,6 +98,7 @@ bd_fs_vfat_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **er
 
 /**
  * bd_fs_vfat_info_copy: (skip)
+ * @data: (nullable): %BDFSVfatInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -118,6 +119,7 @@ BDFSVfatInfo* bd_fs_vfat_info_copy (BDFSVfatInfo *data) {
 
 /**
  * bd_fs_vfat_info_free: (skip)
+ * @data: (nullable): %BDFSVfatInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/fs/xfs.c
+++ b/src/plugins/fs/xfs.c
@@ -95,6 +95,7 @@ bd_fs_xfs_is_tech_avail (BDFSTech tech G_GNUC_UNUSED, guint64 mode, GError **err
 
 /**
  * bd_fs_xfs_info_copy: (skip)
+ * @data: (nullable): %BDFSXfsInfo to copy
  *
  * Creates a new copy of @data.
  */
@@ -114,6 +115,7 @@ BDFSXfsInfo* bd_fs_xfs_info_copy (BDFSXfsInfo *data) {
 
 /**
  * bd_fs_xfs_info_free: (skip)
+ * @data: (nullable): %BDFSXfsInfo to free
  *
  * Frees @data.
  */

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -52,6 +52,7 @@ GQuark bd_md_error_quark (void)
 
 /**
  * bd_md_examine_data_copy: (skip)
+ * @data: (nullable): %BDMDExamineData to copy
  *
  * Creates a new copy of @data.
  */
@@ -77,6 +78,7 @@ BDMDExamineData* bd_md_examine_data_copy (BDMDExamineData *data) {
 
 /**
  * bd_md_examine_data_free: (skip)
+ * @data: (nullable): %BDMDExamineData to free
  *
  * Frees @data.
  */
@@ -95,6 +97,7 @@ void bd_md_examine_data_free (BDMDExamineData *data) {
 
 /**
  * bd_md_detail_data_copy: (skip)
+ * @data: (nullable): %BDMDDetailData to copy
  *
  * Creates a new copy of @data.
  */
@@ -125,6 +128,7 @@ BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data) {
 
 /**
  * bd_md_detail_data_free: (skip)
+ * @data: (nullable): %BDMDDetailData to free
  *
  * Frees @data.
  */
@@ -1396,7 +1400,7 @@ gchar* bd_md_name_from_node (const gchar *node, GError **error) {
 }
 
 /**
- * bd_md_get_status
+ * bd_md_get_status:
  * @raid_spec: specification of the RAID device (name, node or path) to get status
  * @error: (out) (optional): place to store error (if any)
  *

--- a/src/plugins/nvdimm.c
+++ b/src/plugins/nvdimm.c
@@ -518,10 +518,10 @@ BDNVDIMMNamespaceInfo* bd_nvdimm_namespace_info (const gchar *namespace, const B
 
 /**
  * bd_nvdimm_list_namespaces:
- * @bus_name: (nullable): return only namespaces on given bus (specified by name),
- *                          %NULL may be specified to return namespaces from all buses
- * @region_name: (nullable): return only namespaces on given region (specified by 'regionX' name),
- *                             %NULL may be specified to return namespaces from all regions
+ * @bus: (nullable): return only namespaces on given bus (specified by name),
+ *                    %NULL may be specified to return namespaces from all buses
+ * @region: (nullable): return only namespaces on given region (specified by 'regionX' name),
+ *                       %NULL may be specified to return namespaces from all regions
  * @idle: whether to list idle (not enabled) namespaces too
  * @extra: (nullable) (array zero-terminated=1): extra options (currently unused)
  * @error: (out) (optional): place to store error (if any)

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -714,8 +714,7 @@ gboolean bd_s390_zfcp_online (const gchar *devno, const gchar *wwpn, const gchar
 }
 
 /**
- * bd_s390_zfcp_scsi_offline
- *
+ * bd_s390_zfcp_scsi_offline:
  * @devno: zfcp device number
  * @wwpn: zfcp WWPN (World Wide Port Number)
  * @lun: zfcp LUN (Logical Unit Number)


### PR DESCRIPTION
- Remove stale `@extra` parameter from bd_btrfs_change_label docstring
- Fix parameter names in bd_nvdimm_list_namespaces to match public API
- Add missing colon in bd_s390_zfcp_scsi_offline and bd_md_get_status
- Add missing `@data` parameter docs to all info copy/free functions
- Remove undeclared GType symbols from libblockdev-sections.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Removed public symbols from partition and SMART modules

* **Documentation**
  * Enhanced parameter documentation across file system storage plugins with improved nullability annotations and descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->