### PR TITLE
utils: Fail early when calling bd_utils_resolve_device with NULL

### DIFF
--- a/src/utils/dev_utils.c
+++ b/src/utils/dev_utils.c
@@ -64,6 +64,12 @@ gchar* bd_utils_resolve_device (const gchar *dev_spec, GError **error) {
     g_autofree gchar *symlink = NULL;
     GError *l_error = NULL;
 
+    if (dev_spec == NULL) {
+        g_set_error (error, BD_UTILS_DEV_UTILS_ERROR, BD_UTILS_DEV_UTILS_ERROR_FAILED,
+                     "Device specification required");
+        return NULL;
+    }
+
     if (!g_str_has_prefix (dev_spec, "/dev/"))
         path = g_strdup_printf ("/dev/%s", dev_spec);
     else


### PR DESCRIPTION
gcc static analyzer is complaining about this and the produced error in case is quite cryptic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation in device utilities to properly handle invalid inputs and improve system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->