### PR TITLE
lvm: Add warning when user specifies invalid VDO index memory size

### DIFF
--- a/src/plugins/lvm/lvm-common.c
+++ b/src/plugins/lvm/lvm-common.c
@@ -19,6 +19,7 @@
 #include <glib.h>
 #include <math.h>
 #include <stdio.h>
+#include <blockdev/utils.h>
 #include <libdevmapper.h>
 
 #include "lvm.h"
@@ -221,6 +222,19 @@ void bd_lvm_lvdata_free (BDLVMLVdata *data) {
     g_strfreev (data->metadata_lvs);
     free_segs (data->segs);
     g_free (data);
+}
+
+/* Valid vdo_index_memory_size_mb values: 256, 512, 768, or any multiple of 1024 */
+void _lvm_check_vdo_index_memory (guint64 index_memory) {
+    guint64 index_memory_mb = index_memory / (1024 * 1024);
+
+    if (index_memory_mb != 256 && index_memory_mb != 512 && index_memory_mb != 768 &&
+        (index_memory_mb < 1024 || index_memory_mb % 1024 != 0))
+        bd_utils_log_format (BD_UTILS_LOG_WARNING,
+                             "VDO index memory size %"G_GUINT64_FORMAT" MiB is not a valid value, "
+                             "it will be rounded by LVM. "
+                             "Valid values are 256, 512, 768, or a multiple of 1024.",
+                             index_memory_mb);
 }
 
 BDLVMVDOPooldata* bd_lvm_vdopooldata_copy (BDLVMVDOPooldata *data) {

--- a/src/plugins/lvm/lvm-dbus.c
+++ b/src/plugins/lvm/lvm-dbus.c
@@ -3774,6 +3774,9 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
     extra_params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
 
+    if (index_memory != 0)
+        _lvm_check_vdo_index_memory (index_memory);
+
     /* index_memory and write_policy can be specified only using the config */
     g_mutex_lock (&global_config_lock);
     old_config = global_config_str;
@@ -3997,6 +4000,9 @@ gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, co
     g_variant_builder_add_value (&builder, g_variant_new ("{sv}", "--deduplication", g_variant_new ("s", deduplication ? "y" : "n")));
     extra_params = g_variant_builder_end (&builder);
     g_variant_builder_clear (&builder);
+
+    if (index_memory != 0)
+        _lvm_check_vdo_index_memory (index_memory);
 
     /* index_memory and write_policy can be specified only using the config */
     g_mutex_lock (&global_config_lock);

--- a/src/plugins/lvm/lvm-private.h
+++ b/src/plugins/lvm/lvm-private.h
@@ -14,4 +14,6 @@ extern gchar *global_config_str;
 
 extern gchar *global_devices_str;
 
+void _lvm_check_vdo_index_memory (guint64 index_memory);
+
 #endif /* BD_LVM_PRIVATE */

--- a/src/plugins/lvm/lvm.c
+++ b/src/plugins/lvm/lvm.c
@@ -2542,6 +2542,9 @@ gboolean bd_lvm_vdo_pool_create (const gchar *vg_name, const gchar *lv_name, con
     } else
         args[14] = vg_name;
 
+    if (index_memory != 0)
+        _lvm_check_vdo_index_memory (index_memory);
+
     /* index_memory and write_policy can be specified only using the config */
     g_mutex_lock (&global_config_lock);
     old_config = global_config_str;
@@ -2788,6 +2791,9 @@ gboolean bd_lvm_vdo_pool_convert (const gchar *vg_name, const gchar *pool_lv, co
     args[next_arg++] = size_str;
     lv_spec = g_strdup_printf ("%s/%s", vg_name, pool_lv);
     args[next_arg++] = lv_spec;
+
+    if (index_memory != 0)
+        _lvm_check_vdo_index_memory (index_memory);
 
     /* index_memory and write_policy can be specified only using the config */
     g_mutex_lock (&global_config_lock);

--- a/tests/_lvm_cases.py
+++ b/tests/_lvm_cases.py
@@ -2013,7 +2013,7 @@ class LvmTestCache(LvmPVVGLVcachePoolTestCase):
 
 class LvmVDOTest(LvmTestCase):
 
-    loop_size = 8 * 1024**3
+    loop_size = 9 * 1024**3
 
     @classmethod
     def setUpClass(cls):
@@ -2117,15 +2117,15 @@ class LvmVDOTest(LvmTestCase):
 
     @tag_test(TestTags.SLOW)
     def test_vdo_pool_create_options(self):
-        # set index size to 300 MiB, disable compression and write policy to sync
+        # set index size to 512 MiB, disable compression and write policy to sync
         policy = BlockDev.lvm_get_vdo_write_policy_from_str("sync")
-        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3,
-                                            300 * 1024**2, False, True, policy)
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 8 * 1024**3, 35 * 1024**3,
+                                            512 * 1024**2, False, True, policy)
         self.assertTrue(succ)
 
         vdo_info = BlockDev.lvm_vdo_info("testVDOVG", "vdoPool")
         self.assertIsNotNone(vdo_info)
-        self.assertEqual(vdo_info.index_memory_size, 300 * 1024**2)
+        self.assertEqual(vdo_info.index_memory_size, 512 * 1024**2)
         self.assertFalse(vdo_info.compression)
         self.assertTrue(vdo_info.deduplication)
         self.assertEqual(BlockDev.lvm_get_vdo_write_policy_str(vdo_info.write_policy), "sync")
@@ -2166,8 +2166,7 @@ class LvmVDOTest(LvmTestCase):
 
     @tag_test(TestTags.SLOW)
     def test_enable_disable_compression(self):
-        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3,
-                                            300 * 1024**2)
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3)
         self.assertTrue(succ)
 
         # enabled by default
@@ -2193,8 +2192,7 @@ class LvmVDOTest(LvmTestCase):
 
     @tag_test(TestTags.SLOW)
     def test_enable_disable_deduplication(self):
-        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3,
-                                            300 * 1024**2)
+        succ = BlockDev.lvm_vdo_pool_create("testVDOVG", "vdoLV", "vdoPool", 7 * 1024**3, 35 * 1024**3)
         self.assertTrue(succ)
 
         # enabled by default


### PR DESCRIPTION
The invalid values are silently rounded up by LVM.

This was found by our tests mostly by accident, bigger index now needs more disk space so our tests started failing on systems with the latest LVM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for VDO index-memory settings during pool creation and conversion.
  - Warns when configured memory is not 256, 512, or 768 MiB, or a multiple of 1024 MiB.
  - Prevents unsupported nonzero index-memory settings from being applied before the operation runs.

- **Tests**
  - Updated VDO coverage for current resource requirements and supported index-memory options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->