### PR TITLE
misc: Use ansible_facts instead of deprecated top-level fact variables

### DIFF
--- a/misc/libblockdev-tasks.yml
+++ b/misc/libblockdev-tasks.yml
@@ -12,15 +12,15 @@
       - libtool
       - autoconf
       - automake
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install dnf-plugins-core for dnf builddep (Fedora)
   package: name=dnf-plugins-core state=present
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install build dependencies (Fedora)
   command: "dnf -y builddep libblockdev --nogpgcheck"
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install build dependencies not covered by dnf builddep (Fedora)
   package:
@@ -33,7 +33,7 @@
       - json-glib-devel
       - libatasmart-devel
       - libyaml-devel
-  when: ansible_distribution == 'Fedora'
+  when: ansible_facts['distribution'] == 'Fedora'
 
 - name: Install test dependencies (Fedora)
   package:
@@ -67,7 +67,7 @@
       - vdo
       - volume_key
       - xfsprogs
-  when: ansible_distribution == 'Fedora' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'Fedora' and test_dependencies|bool
 
 ####### CentOS
 - name: Install basic build tools (CentOS)
@@ -79,15 +79,15 @@
       - libtool
       - autoconf
       - automake
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install dnf-plugins-core for dnf builddep (CentOS)
   package: name=dnf-plugins-core state=present
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install build dependencies (CentOS)
   command: "dnf -y builddep libblockdev --nogpgcheck"
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install build dependencies not covered by dnf builddep (CentOS)
   package:
@@ -100,7 +100,7 @@
       - json-glib-devel
       - libatasmart-devel
       - libyaml-devel
-  when: ansible_distribution == 'CentOS'
+  when: ansible_facts['distribution'] == 'CentOS'
 
 - name: Install test dependencies (CentOS)
   package:
@@ -126,19 +126,19 @@
       - vdo
       - volume_key
       - xfsprogs
-  when: ansible_distribution == 'CentOS' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and test_dependencies|bool
 
 - name: Install pylint using pip (CentOS)
   pip:
     name: ['pylint']
     extra_args: --break-system-packages
-  when: ansible_distribution == 'CentOS' and test_dependencies|bool
+  when: ansible_facts['distribution'] == 'CentOS' and test_dependencies|bool
 
 ####### Debian/Ubuntu
 - name: Update apt cache (Debian/Ubuntu)
   apt:
     update_cache: yes
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install basic build tools (Debian/Ubuntu)
   package:
@@ -146,26 +146,26 @@
     name:
       - gcc
       - make
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Add source repositories (Debian/Ubuntu)
   shell: "grep '^deb ' /etc/apt/sources.list | perl -pe 's/deb /deb-src /' >> /etc/apt/sources.list"
-  when: ansible_distribution == 'Debian' or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version < '24')
+  when: ansible_facts['distribution'] == 'Debian' or (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] < '24')
 
 - name: Add source repositories (Debian/Ubuntu)
   shell: "sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources"
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_major_version >= '24'
+  when: ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] >= '24'
 
 - name: Update apt cache (Debian/Ubuntu)
   apt:
     update_cache: yes
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install build dependencies (Debian/Ubuntu)
   apt:
     name: libblockdev
     state: build-dep
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install build dependencies not covered by apt build-dep (Debian/Ubuntu)
   package:
@@ -177,7 +177,7 @@
       - libjson-glib-dev
       - libatasmart-dev
       - libyaml-dev
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install test dependencies (Debian/Ubuntu)
   package:
@@ -206,14 +206,14 @@
       - udftools
       - volume-key
       - xfsprogs
-  when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu') and test_dependencies|bool
+  when: (ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu') and test_dependencies|bool
 
 - name: Install vdo test dependencies (Debian/Ubuntu 64bit)
   package:
     state: present
     name:
       - vdo
-  when: (ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu') and test_dependencies|bool and ansible_architecture != 'i386'
+  when: (ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu') and test_dependencies|bool and ansible_facts['architecture'] != 'i386'
 
 ####### Common actions
 


### PR DESCRIPTION
Ansible deprecated the injected top-level ansible_* fact variables (e.g. ansible_distribution) in favour of accessing them through the ansible_facts dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation across Fedora, CentOS, Debian, and Ubuntu environments.
  * Preserved appropriate repository handling for different Ubuntu versions.
  * Improved architecture detection for 64-bit VDO support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->