### PR TITLE
Fix a pylint disable comment

### DIFF
--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -1263,8 +1263,7 @@ class ErrorProxy(object):
         def wrapped(*args, **kwargs):
             try:
                 ret = orig_obj(*args, **kwargs)
-            # pylint: disable=catching-non-exception
-            except tuple(tr_t[0] for tr_t in self._tr_excs) as e:
+            except tuple(tr_t[0] for tr_t in self._tr_excs) as e:  # pylint: disable=catching-non-exception
                 if hasattr(e, "msg"):
                     msg = e.msg # pylint: disable=no-member
                 elif hasattr(e, "message"):


### PR DESCRIPTION
This stopped working with pylint 4.0.7 which is probably a pylint regression, but the correct location for the comment is always on the same line where the error occurs (disable-next can be used to supress the warning on the following like) so this worked only by acciddent anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Clarified exception-handler formatting while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->